### PR TITLE
fix: handle empty optional number fields in forms

### DIFF
--- a/packages/frontend/src/components/meal/MealInput.tsx
+++ b/packages/frontend/src/components/meal/MealInput.tsx
@@ -98,7 +98,9 @@ export function MealInput({ onSubmit, isLoading, error }: MealInputProps) {
             カロリー (kcal、任意)
           </label>
           <input
-            {...register('calories', { valueAsNumber: true })}
+            {...register('calories', {
+              setValueAs: (v) => (v === '' ? undefined : parseInt(v, 10)),
+            })}
             type="number"
             id="calories"
             min="0"

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -92,7 +92,9 @@ export function Register() {
                 目標体重（kg、任意）
               </label>
               <input
-                {...register('goalWeight', { valueAsNumber: true })}
+                {...register('goalWeight', {
+                  setValueAs: (v) => (v === '' ? undefined : parseFloat(v)),
+                })}
                 type="number"
                 id="goalWeight"
                 step="0.1"


### PR DESCRIPTION
## Summary
- Fix validation error "Expected number, received nan" when optional number fields are left empty
- Changed `valueAsNumber: true` to `setValueAs` with proper empty string → undefined handling

## Files Changed
- `packages/frontend/src/pages/Register.tsx` - goalWeight field
- `packages/frontend/src/components/meal/MealInput.tsx` - calories field

## Test plan
- [x] E2Eテストで発見したバグ
- [ ] 登録フォームで目標体重を空のまま送信 → エラーなし
- [ ] 食事記録でカロリーを空のまま送信 → エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)