### PR TITLE
fix: 今日のカロリー集計でタイムゾーンを考慮 (#18)

### DIFF
--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -151,14 +151,24 @@ export class MealService {
     await this.db.delete(schema.mealRecords).where(eq(schema.mealRecords.id, id));
   }
 
-  async getTodaysSummary(userId: string) {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const startDate = today.toISOString();
+  async getTodaysSummary(userId: string, timezoneOffset?: number) {
+    // timezoneOffset: minutes offset from UTC (e.g., -540 for JST)
+    // If not provided, defaults to UTC
+    const offset = timezoneOffset ?? 0;
 
-    const tomorrow = new Date(today);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const endDate = tomorrow.toISOString();
+    // Get current time in user's timezone
+    const now = new Date();
+    const userNow = new Date(now.getTime() - offset * 60 * 1000);
+
+    // Calculate start of today in user's timezone, then convert back to UTC
+    const userToday = new Date(userNow);
+    userToday.setUTCHours(0, 0, 0, 0);
+    const startDate = new Date(userToday.getTime() + offset * 60 * 1000).toISOString();
+
+    // Calculate start of tomorrow in user's timezone, then convert back to UTC
+    const userTomorrow = new Date(userToday);
+    userTomorrow.setUTCDate(userTomorrow.getUTCDate() + 1);
+    const endDate = new Date(userTomorrow.getTime() + offset * 60 * 1000).toISOString();
 
     return this.getCalorieSummary(userId, { startDate, endDate });
   }

--- a/packages/frontend/src/hooks/useMeals.ts
+++ b/packages/frontend/src/hooks/useMeals.ts
@@ -36,7 +36,11 @@ export function useMeals(options?: UseMealsOptions) {
   const todaySummaryQuery = useQuery({
     queryKey: ['meals', 'today-summary'],
     queryFn: async () => {
-      const res = await api.meals.today.$get();
+      // Pass timezone offset so server can calculate "today" correctly
+      const timezoneOffset = new Date().getTimezoneOffset();
+      const res = await api.meals.today.$get({
+        query: { timezoneOffset: String(timezoneOffset) },
+      });
       if (!res.ok) {
         const error = await res.json().catch(() => ({ message: 'Failed to fetch today summary' }));
         throw new Error((error as { message?: string }).message || 'Failed to fetch today summary');


### PR DESCRIPTION
## Summary

- `/api/meals/today` エンドポイントに `timezoneOffset` クエリパラメータを追加
- フロントエンドで `getTimezoneOffset()` を使ってタイムゾーンオフセットを送信
- サーバー側でユーザーのローカル日付を正しく計算

## 問題

バックエンドの `getTodaysSummary()` がサーバーのUTC時刻を基準に「今日」を計算していたため、JST（日本時間）など他のタイムゾーンのユーザーで昨日のカロリーが今日の分と混ざっていた。

例: 日本時間2025-01-05 08:00の朝食 → UTCでは2025-01-04T23:00:00Z
サーバーがUTC基準で「今日」を計算すると、この朝食は除外されてしまう。

## 解決方法

1. フロントエンドで `new Date().getTimezoneOffset()` を取得（分単位のオフセット）
2. `/api/meals/today?timezoneOffset=-540` のようにサーバーに送信
3. サーバー側でオフセットを使ってユーザーのローカル日付の00:00〜24:00をUTCに変換

## Test plan

- [x] 型チェック通過
- [x] 既存テスト全て通過（297 tests）
- [ ] プレビュー環境で動作確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)