### PR TITLE
feat: 食事履歴一覧での写真カルーセル表示 (User Story 3)

### DIFF
--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -105,10 +105,11 @@ export class MealService {
       filtered = filtered.slice(0, options.limit);
     }
 
-    // Get photo counts and first photo keys for all filtered meals
+    // Get photo counts, first photo keys, and photos array for all filtered meals
     const mealIds = filtered.map((m) => m.id);
     const photoCounts = new Map<string, number>();
     const firstPhotoKeys = new Map<string, string>();
+    const photosArrays = new Map<string, Array<{ id: string; photoKey: string; photoUrl: string }>>();
 
     if (mealIds.length > 0) {
       // Query all photos
@@ -128,15 +129,23 @@ export class MealService {
         }
       }
 
-      // Count photos and get first photo key per meal
+      // Count photos, get first photo key, and create photos array per meal
       for (const [mealId, photos] of photosByMeal.entries()) {
         photoCounts.set(mealId, photos.length);
-        // Sort by displayOrder and get first photo
+        // Sort by displayOrder
         const sortedPhotos = photos.sort((a, b) => a.displayOrder - b.displayOrder);
         const firstPhoto = sortedPhotos[0];
         if (firstPhoto) {
           firstPhotoKeys.set(mealId, firstPhoto.photoKey);
         }
+
+        // Create photos array with URLs
+        const photosWithUrls = sortedPhotos.map((photo) => ({
+          id: photo.id,
+          photoKey: photo.photoKey,
+          photoUrl: `/api/meals/photos/${encodeURIComponent(photo.photoKey)}`,
+        }));
+        photosArrays.set(mealId, photosWithUrls);
       }
     }
 
@@ -145,6 +154,7 @@ export class MealService {
       ...record,
       photoCount: photoCounts.get(record.id) || 0,
       firstPhotoKey: firstPhotoKeys.get(record.id) || null,
+      photos: photosArrays.get(record.id) || [],
     }));
   }
 

--- a/packages/frontend/src/components/meal/MealList.tsx
+++ b/packages/frontend/src/components/meal/MealList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { MealRecord } from '@lifestyle-app/shared';
 import { MEAL_TYPE_LABELS } from '@lifestyle-app/shared';
-import { getPhotoUrl } from '../../lib/api';
+import { PhotoCarousel } from './PhotoCarousel';
 
 interface MealListProps {
   meals: MealRecord[];
@@ -63,7 +63,7 @@ export function MealList({
   );
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" style={{ touchAction: 'pan-y' }}>
       {Object.entries(groupedMeals).map(([date, dateMeals]) => (
         <div key={date}>
           <h3 className="mb-3 text-sm font-medium text-gray-500">{date}</h3>
@@ -93,29 +93,14 @@ export function MealList({
                     </div>
                   </div>
                 ) : (
-                  <div className="flex gap-3">
-                    {/* Photo thumbnail - clickable to detail */}
-                    {meal.firstPhotoKey && (
-                      <Link to={`/meals/${meal.id}`} className="flex-shrink-0 relative">
-                        <img
-                          src={getPhotoUrl(meal.firstPhotoKey) || undefined}
-                          alt={meal.content}
-                          className="h-16 w-16 rounded-lg object-cover hover:opacity-80 transition-opacity"
-                        />
-                        {/* Photo count badge */}
-                        {meal.photoCount !== undefined && meal.photoCount > 1 && (
-                          <div className="absolute -bottom-1 -right-1 flex items-center justify-center rounded-full bg-blue-500 px-1.5 py-0.5 text-xs text-white shadow-sm">
-                            <span>📷 {meal.photoCount}</span>
-                          </div>
-                        )}
-                        {meal.photoCount === 1 && (
-                          <div className="absolute -bottom-1 -right-1 flex items-center justify-center rounded-full bg-blue-500 px-1.5 py-0.5 text-xs text-white shadow-sm">
-                            <span>📷</span>
-                          </div>
-                        )}
+                  <div className="flex flex-col gap-3">
+                    {/* Photo carousel */}
+                    {meal.photos && meal.photos.length > 0 && (
+                      <Link to={`/meals/${meal.id}`}>
+                        <PhotoCarousel photos={meal.photos} />
                       </Link>
                     )}
-                    <div className="flex flex-1 items-start justify-between">
+                    <div className="flex items-start justify-between">
                       <Link to={`/meals/${meal.id}`} className="flex-1 hover:opacity-80 transition-opacity">
                         <div className="flex flex-wrap items-center gap-2">
                           <span

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -74,6 +74,7 @@ export interface MealRecord {
   // Extended fields for photo information from meal_photos table
   photoCount?: number;
   firstPhotoKey?: string | null;
+  photos?: Array<{ id: string; photoKey: string; photoUrl: string }>;
 }
 
 export interface ExerciseRecord {

--- a/specs/016-multiple-meal-photos/tasks.md
+++ b/specs/016-multiple-meal-photos/tasks.md
@@ -94,20 +94,20 @@ Web app monorepo structure:
 
 ### Tests for User Story 2 (TDD - Write FIRST, ensure FAIL)
 
-- [ ] T031 [P] [US2] Integration test for POST /api/meal-chat/:mealId/add-photo in packages/backend/tests/integration/meal-chat-photos.test.ts
-- [ ] T032 [P] [US2] E2E test for chat photo upload flow in packages/frontend/tests/e2e/meal-chat-photo.spec.ts
+- [X] T031 [P] [US2] Integration test for POST /api/meal-chat/:mealId/add-photo in packages/backend/tests/integration/meal-chat-photos.test.ts
+- [X] T032 [P] [US2] E2E test for chat photo upload flow in packages/frontend/tests/e2e/meal-chat-photo.spec.ts
 
 ### Implementation for User Story 2
 
-- [ ] T033 [US2] Add POST /api/meal-chat/:mealId/add-photo endpoint in packages/backend/src/routes/meal-chat.ts
-- [ ] T034 [US2] Add photo upload handling with chat message creation in packages/backend/src/routes/meal-chat.ts
-- [ ] T035 [US2] Trigger AI analysis in background when photo added via chat in packages/backend/src/routes/meal-chat.ts
-- [ ] T036 [US2] Send AI acknowledgment message ("Analyzing photo...") in packages/backend/src/routes/meal-chat.ts
-- [ ] T037 [P] [US2] Add "Add Photo" button to MealChat component in packages/frontend/src/components/meal/MealChat.tsx
-- [ ] T038 [US2] Implement photo upload with progress indicator in chat UI in packages/frontend/src/components/meal/MealChat.tsx
-- [ ] T039 [US2] Display AI response with updated nutrition after analysis in packages/frontend/src/components/meal/MealChat.tsx
-- [ ] T040 [US2] Handle background upload (allow typing while uploading) in packages/frontend/src/components/meal/MealChat.tsx
-- [ ] T041 [US2] Show photo thumbnails in chat message thread in packages/frontend/src/components/meal/MealChat.tsx
+- [X] T033 [US2] Add POST /api/meal-chat/:mealId/add-photo endpoint in packages/backend/src/routes/meal-chat.ts
+- [X] T034 [US2] Add photo upload handling with chat message creation in packages/backend/src/routes/meal-chat.ts
+- [X] T035 [US2] Trigger AI analysis in background when photo added via chat in packages/backend/src/routes/meal-chat.ts
+- [X] T036 [US2] Send AI acknowledgment message ("Analyzing photo...") in packages/backend/src/routes/meal-chat.ts
+- [X] T037 [P] [US2] Add "Add Photo" button to MealChat component in packages/frontend/src/components/meal/MealChat.tsx
+- [X] T038 [US2] Implement photo upload with progress indicator in chat UI in packages/frontend/src/components/meal/MealChat.tsx
+- [X] T039 [US2] Display AI response with updated nutrition after analysis in packages/frontend/src/components/meal/MealChat.tsx
+- [X] T040 [US2] Handle background upload (allow typing while uploading) in packages/frontend/src/components/meal/MealChat.tsx
+- [X] T041 [US2] Show photo thumbnails in chat message thread in packages/frontend/src/components/meal/MealChat.tsx
 
 **Checkpoint**: At this point, User Stories 1 AND 2 should both work independently - chat photo upload flows seamlessly
 
@@ -121,20 +121,20 @@ Web app monorepo structure:
 
 ### Tests for User Story 3 (TDD - Write FIRST, ensure FAIL)
 
-- [ ] T042 [P] [US3] Unit test for PhotoCarousel component in packages/frontend/src/components/meal/PhotoCarousel.test.tsx
-- [ ] T043 [P] [US3] E2E test for carousel swipe interaction in packages/frontend/tests/e2e/meal-history-carousel.spec.ts
-- [ ] T044 [P] [US3] E2E test for vertical scroll not triggering carousel in packages/frontend/tests/e2e/meal-history-carousel.spec.ts
+- [X] T042 [P] [US3] Unit test for PhotoCarousel component in packages/frontend/src/components/meal/PhotoCarousel.test.tsx
+- [X] T043 [P] [US3] E2E test for carousel swipe interaction in packages/frontend/tests/e2e/meal-history-carousel.spec.ts
+- [X] T044 [P] [US3] E2E test for vertical scroll not triggering carousel in packages/frontend/tests/e2e/meal-history-carousel.spec.ts
 
 ### Implementation for User Story 3
 
-- [ ] T045 [P] [US3] Create PhotoCarousel component with scroll-snap CSS in packages/frontend/src/components/meal/PhotoCarousel.tsx
-- [ ] T046 [US3] Add scroll position tracking and indicator dots to PhotoCarousel in packages/frontend/src/components/meal/PhotoCarousel.tsx
-- [ ] T047 [US3] Add touch-action: pan-x to carousel container in packages/frontend/src/components/meal/PhotoCarousel.tsx
-- [ ] T048 [US3] Handle single-photo case (no carousel) in PhotoCarousel in packages/frontend/src/components/meal/PhotoCarousel.tsx
-- [ ] T049 [US3] Integrate PhotoCarousel into MealList component in packages/frontend/src/components/meal/MealList.tsx
-- [ ] T050 [US3] Ensure parent scroll container has touch-action: pan-y in packages/frontend/src/components/meal/MealList.tsx
-- [ ] T051 [US3] Add lazy loading for carousel images in packages/frontend/src/components/meal/PhotoCarousel.tsx
-- [ ] T052 [US3] Add loading placeholders for photos in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T045 [P] [US3] Create PhotoCarousel component with scroll-snap CSS in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T046 [US3] Add scroll position tracking and indicator dots to PhotoCarousel in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T047 [US3] Add touch-action: pan-x to carousel container in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T048 [US3] Handle single-photo case (no carousel) in PhotoCarousel in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T049 [US3] Integrate PhotoCarousel into MealList component in packages/frontend/src/components/meal/MealList.tsx
+- [X] T050 [US3] Ensure parent scroll container has touch-action: pan-y in packages/frontend/src/components/meal/MealList.tsx
+- [X] T051 [US3] Add lazy loading for carousel images in packages/frontend/src/components/meal/PhotoCarousel.tsx
+- [X] T052 [US3] Add loading placeholders for photos in packages/frontend/src/components/meal/PhotoCarousel.tsx
 
 **Checkpoint**: All three user stories should now be independently functional - history list has smooth carousels
 


### PR DESCRIPTION
## 概要

User Story 3 (食事履歴一覧での写真カルーセル表示) を完了しました。

## 変更内容

### T049-T052: 食事履歴一覧での写真カルーセル表示

**実装タスク:**
- ✅ T049: MealList に PhotoCarousel を統合
- ✅ T050: 親スクロールコンテナに touch-action: pan-y を設定
- ✅ T051: カルーセル画像の遅延読み込み (loading="lazy")
- ✅ T052: ローディングプレースホルダーを追加

### バックエンド変更

**packages/backend/src/services/meal.ts**
- `findByUserId()` が `photos` 配列を返すように拡張
- 各食事に対して写真情報 (id, photoKey, photoUrl) を含むレスポンスを返す

```typescript
photos: [{
  id: string,
  photoKey: string,
  photoUrl: string
}]
```

### 型定義変更

**packages/shared/src/types/index.ts**
- `MealRecord` インターフェースに `photos` プロパティを追加

### フロントエンド変更

**packages/frontend/src/components/meal/MealList.tsx**
- PhotoCarousel コンポーネントを統合
- 従来のサムネイル表示から写真カルーセルに置き換え
- 親コンテナに `touch-action: pan-y` を設定（縦スクロールと横スワイプの競合を防止）

**packages/frontend/src/components/meal/PhotoCarousel.tsx**
- 画像読み込み状態の管理を追加 (`loadedImages` state)
- ローディングプレースホルダーを実装
  - 画像読み込み中: グレー背景 + 画像アイコン + パルスアニメーション
  - `onLoad` イベントで読み込み完了を検知
- AI 分析中のオーバーレイ UI を改善

## 技術仕様

- **ネイティブ CSS スクロールスナップ**: 外部ライブラリ不要
- **遅延読み込み**: `loading="lazy"` 属性
- **タッチ操作の競合解消**: `touch-action: pan-x` (カルーセル) vs `pan-y` (親スクロール)
- **ローディング状態**: 画像読み込み完了まで placeholder 表示

## テスト

```
✅ TypeScript型チェック - 成功
✅ ESLint - 成功  
✅ テスト - 314 passed, 1 skipped
```

## 動作確認項目

- [ ] 食事履歴一覧で複数写真がある食事がカルーセル表示される
- [ ] 写真を横スワイプして切り替えられる
- [ ] インジケーター（ドット）が正しく表示される
- [ ] 縦スクロールと横スワイプが干渉しない
- [ ] 画像読み込み中にプレースホルダーが表示される
- [ ] 写真が1枚の場合はカルーセルUIなし（通常表示）

## 関連 Issue

Closes #27 (User Story 3)

## スクリーンショット

プレビュー環境で確認をお願いします。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
