### PR TITLE
feat: 前回と同じボタンで全セットをコピー

### DIFF
--- a/packages/backend/src/routes/exercises.ts
+++ b/packages/backend/src/routes/exercises.ts
@@ -76,6 +76,16 @@ export const exercises = new Hono<{ Bindings: Bindings; Variables: Variables }>(
 
     return c.json({ exercise });
   })
+  .get('/last-session/:exerciseType', async (c) => {
+    const exerciseType = decodeURIComponent(c.req.param('exerciseType'));
+    const db = c.get('db');
+    const user = c.get('user');
+
+    const exerciseService = new ExerciseService(db);
+    const exercises = await exerciseService.getLastSessionByType(user.id, exerciseType);
+
+    return c.json({ exercises });
+  })
   .get('/types', async (c) => {
     const db = c.get('db');
     const user = c.get('user');

--- a/packages/frontend/src/components/exercise/LastRecordBadge.tsx
+++ b/packages/frontend/src/components/exercise/LastRecordBadge.tsx
@@ -2,11 +2,12 @@ import type { ExerciseRecord } from '@lifestyle-app/shared';
 
 interface LastRecordBadgeProps {
   record: ExerciseRecord | null;
+  sessionCount?: number;
   onCopy: () => void;
   isLoading?: boolean;
 }
 
-export function LastRecordBadge({ record, onCopy, isLoading }: LastRecordBadgeProps) {
+export function LastRecordBadge({ record, sessionCount = 1, onCopy, isLoading }: LastRecordBadgeProps) {
   if (isLoading) {
     return (
       <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -37,7 +38,7 @@ export function LastRecordBadge({ record, onCopy, isLoading }: LastRecordBadgePr
     <div className="flex items-center gap-3 rounded-lg bg-gray-50 px-3 py-2">
       <div className="flex-1">
         <span className="text-sm text-gray-600">
-          前回: {formatExercise(record)}
+          前回: {sessionCount > 1 ? `${sessionCount}セット` : formatExercise(record)}
         </span>
         <span className="ml-2 text-xs text-gray-400">
           ({formatDate(record.recordedAt)})

--- a/packages/frontend/src/hooks/useExercises.ts
+++ b/packages/frontend/src/hooks/useExercises.ts
@@ -113,6 +113,16 @@ export function useExercises(options?: UseExercisesOptions) {
     return data.exercise;
   };
 
+  const fetchLastSession = async (exerciseType: string): Promise<ExerciseRecord[]> => {
+    const encodedType = encodeURIComponent(exerciseType);
+    const res = await api.exercises['last-session'][':exerciseType'].$get({ param: { exerciseType: encodedType } });
+    if (!res.ok) {
+      return [];
+    }
+    const data = await res.json();
+    return data.exercises as ExerciseRecord[];
+  };
+
   return {
     exercises: exercisesQuery.data ?? [],
     weeklySummary: weeklySummaryQuery.data,
@@ -129,6 +139,7 @@ export function useExercises(options?: UseExercisesOptions) {
     updateError: updateMutation.error,
     deleteError: deleteMutation.error,
     fetchLastRecord,
+    fetchLastSession,
   };
 }
 

--- a/packages/frontend/src/pages/Exercise.tsx
+++ b/packages/frontend/src/pages/Exercise.tsx
@@ -25,6 +25,7 @@ export function Exercise() {
     isDeleting,
     createError,
     fetchLastRecord,
+    fetchLastSession,
   } = useExercises();
 
   if (isLoading) {
@@ -71,6 +72,7 @@ export function Exercise() {
           isLoading={isCreating}
           error={createError}
           onFetchLastRecord={fetchLastRecord}
+          onFetchLastSession={fetchLastSession}
           customTypes={exerciseTypes}
         />
       </div>


### PR DESCRIPTION
## Summary
- 「前回と同じ」ボタンを押すと、前回の最後の1セットだけでなく全セットがコピーされるように修正
- バックエンドに新規APIエンドポイント `/last-session/:exerciseType` を追加
- フロントエンドで全セット情報を取得・表示するよう更新

## Changes
- **バックエンド**: `getLastSessionByType` メソッドを追加（同じ日の全セットを取得）
- **バックエンド**: `/last-session/:exerciseType` APIエンドポイントを追加
- **フロント**: `fetchLastSession` 関数を `useExercises` フックに追加
- **StrengthInput**: `handleCopyLastRecord` を全セットコピーに対応
- **LastRecordBadge**: セット数を表示（例: 「前回: 3セット」）

## Test plan
- [ ] 種目を選択して「前回と同じ」ボタンを押す
- [ ] 前回のセット数分のセットがすべてコピーされることを確認
- [ ] 回数・重量が各セットごとに正しくコピーされることを確認
- [ ] 前回記録がない場合の動作確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)