### PR TITLE
fix: ダッシュボードのドットグリッドでタイムゾーン対応

### DIFF
--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -31,6 +31,7 @@ const goalsQuerySchema = z.object({
 
 const activityQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(1000).optional().default(800),
+  timezone: z.string().optional(),
 });
 
 // Chain format for RPC type inference
@@ -89,11 +90,11 @@ export const dashboard = new Hono<{ Bindings: Bindings; Variables: Variables }>(
   })
   .get('/activity', zValidator('query', activityQuerySchema), async (c) => {
     const user = c.get('user');
-    const { days } = c.req.valid('query');
+    const { days, timezone } = c.req.valid('query');
     const db = c.get('db');
     const service = new DashboardService(db);
 
-    const activity = await service.getDailyActivity(user.id, days);
+    const activity = await service.getDailyActivity(user.id, days, timezone);
 
     return c.json(activity);
   });

--- a/packages/frontend/src/hooks/useActivityDots.ts
+++ b/packages/frontend/src/hooks/useActivityDots.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/client';
 
+const getUserTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export interface DailyActivity {
   date: string;
   hasMeal: boolean;
@@ -19,11 +21,13 @@ export interface DailyActivityResponse {
 }
 
 export function useActivityDots(days: number = 800) {
+  const timezone = getUserTimezone();
+
   return useQuery({
-    queryKey: ['dashboard', 'activity', days],
+    queryKey: ['dashboard', 'activity', days, timezone],
     queryFn: async (): Promise<DailyActivityResponse> => {
       const res = await api.dashboard.activity.$get({
-        query: { days: String(days) },
+        query: { days: String(days), timezone },
       });
       if (!res.ok) {
         const error = await res.json().catch(() => ({ message: 'Failed to fetch activity' }));


### PR DESCRIPTION
## Summary
- ダッシュボードの活動ドットグリッドで、朝に記録した体重が前日として表示される問題を修正
- フロントエンドからクライアントのタイムゾーンをAPIに送信
- バックエンドで`date-fns-tz`を使用してローカル日付に変換

## 背景
UTC基準で日付を処理していたため、日本時間の朝8時前（UTC前日）に記録した体重が前日の日付にマッピングされていた。

## 変更内容
| ファイル | 変更 |
|---------|------|
| `useActivityDots.ts` | `timezone`パラメータをAPIに送信 |
| `dashboard.ts` (route) | `timezone`クエリパラメータを受け取る |
| `dashboard.ts` (service) | `toZonedTime`で日付をローカルTZ変換 |

## Test plan
- [ ] プレビュー環境でダッシュボードを開く
- [ ] 朝に記録した体重データが正しい日付に表示されることを確認
- [ ] ドットグリッドのツールチップで体重・カロリー・運動が表示されることを確認

## Future improvement
記録時にタイムゾーンを保存する方式への変更は、影響範囲が大きいため別issueで対応予定。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)