### PR TITLE
fix: 別端末で画像が表示されない問題を修正

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -85,7 +85,12 @@ app.use('*', requestContext()); // Request ID tracking - MUST be after logger
 app.use(
   '*',
   cors({
-    origin: ['http://localhost:5173', 'http://localhost:3000'],
+    origin: [
+      'http://localhost:5173',
+      'http://localhost:3000',
+      'https://lifestyle-tracker.abe00makoto.workers.dev',
+      'https://lifestyle-tracker-preview.abe00makoto.workers.dev',
+    ],
     credentials: true,
   })
 );

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -144,12 +144,32 @@ export class MealService {
     }
 
     // Add photo information to records
-    return filtered.map((record) => ({
-      ...record,
-      photoCount: photoCounts.get(record.id) || 0,
-      firstPhotoKey: firstPhotoKeys.get(record.id) || null,
-      photos: photosArrays.get(record.id) || [],
-    }));
+    return filtered.map((record) => {
+      const photos = photosArrays.get(record.id) || [];
+
+      // Fallback: If no meal_photos but legacy photo_key exists, use it
+      if (photos.length === 0 && record.photoKey) {
+        return {
+          ...record,
+          photoCount: 1,
+          firstPhotoKey: record.photoKey,
+          photos: [
+            {
+              id: `legacy-${record.id}`,
+              photoKey: record.photoKey,
+              photoUrl: `/api/meals/photos/${encodeURIComponent(record.photoKey)}`,
+            },
+          ],
+        };
+      }
+
+      return {
+        ...record,
+        photoCount: photoCounts.get(record.id) || 0,
+        firstPhotoKey: firstPhotoKeys.get(record.id) || null,
+        photos,
+      };
+    });
   }
 
   async getCalorieSummary(


### PR DESCRIPTION
## Summary
- 別の端末でアプリを使用すると食事の画像が表示されない問題を修正
- CORS設定に本番ドメインを追加
- meal_photos テーブルと meal_records.photo_key の同期問題を解決

## 原因
1. CORS設定に本番ドメインが含まれていなかった
2. 食事保存時に `meal_photos` テーブルが更新されず、`temp/` パスのまま残っていた
3. R2の一時ファイルは削除されるため、404エラーが発生

## 修正内容
- `index.ts`: CORS許可リストに本番・プレビュードメインを追加
- `meal.ts`: `meal_photos` が空の場合、レガシー `photo_key` をフォールバックで使用
- `meal-analysis.ts`: 食事保存・写真アップロード時に `meal_photos` テーブルも更新

## Test plan
- [ ] タブレットで新規食事登録後、画像が表示されることを確認
- [ ] 既存の食事も画像が表示されることを確認（レガシーフォールバック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)