### PR TITLE
fix: improve E2E test reliability

### DIFF
--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -3,21 +3,24 @@ import { test, expect } from '@playwright/test';
 test.describe('Authentication', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
+    // Wait for React to hydrate
+    await page.waitForLoadState('networkidle');
   });
 
   test('should display login and register links when not authenticated', async ({ page }) => {
-    await expect(page.getByRole('link', { name: 'ログイン' })).toBeVisible();
-    await expect(page.getByRole('link', { name: '登録' })).toBeVisible();
+    // Use navigation links in header (more specific selector)
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'ログイン' })).toBeVisible();
+    await expect(page.getByRole('navigation').getByRole('link', { name: '登録' })).toBeVisible();
   });
 
   test('should navigate to login page', async ({ page }) => {
-    await page.getByRole('link', { name: 'ログイン' }).click();
+    await page.getByRole('navigation').getByRole('link', { name: 'ログイン' }).click();
     await expect(page).toHaveURL('/login');
     await expect(page.getByRole('heading', { name: 'ログイン' })).toBeVisible();
   });
 
   test('should navigate to register page', async ({ page }) => {
-    await page.getByRole('link', { name: '登録' }).click();
+    await page.getByRole('navigation').getByRole('link', { name: '登録' }).click();
     await expect(page).toHaveURL('/register');
     await expect(page.getByRole('heading', { name: 'アカウント登録' })).toBeVisible();
   });
@@ -31,10 +34,12 @@ test.describe('Authentication', () => {
 
   test('should show validation errors on register with invalid email', async ({ page }) => {
     await page.goto('/register');
+    await page.waitForLoadState('networkidle');
     await page.getByLabel('メールアドレス').fill('invalid-email');
     await page.getByLabel('パスワード').fill('password123');
     await page.getByRole('button', { name: '登録する' }).click();
-    await expect(page.getByText('有効なメールアドレス')).toBeVisible();
+    // Client-side validation should show error immediately
+    await expect(page.getByText('有効なメールアドレス')).toBeVisible({ timeout: 5000 });
   });
 
   test('should show validation errors on register with short password', async ({ page }) => {
@@ -52,7 +57,9 @@ test.describe('Authentication', () => {
 
   test('should have link to login from register page', async ({ page }) => {
     await page.goto('/register');
-    await expect(page.getByRole('link', { name: 'ログイン' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    // The form has a link to login page
+    await expect(page.locator('form').getByRole('link', { name: 'ログイン' })).toBeVisible();
   });
 
   test('should redirect to login when accessing protected route', async ({ page }) => {


### PR DESCRIPTION
## Summary

Improves E2E test reliability by addressing timing and selector issues.

### Changes

1. **Add `waitForLoadState('networkidle')`** in beforeEach
   - Ensures React has fully hydrated before assertions
   - Prevents tests from running against partially loaded pages

2. **Use more specific selectors**
   - `page.getByRole('navigation').getByRole('link', ...)` for header links
   - `page.locator('form').getByRole('link', ...)` for form links
   - Avoids strict mode violations when multiple elements match

3. **Add explicit timeout for validation**
   - `toBeVisible({ timeout: 5000 })` for form validation errors
   - Gives time for client-side validation to complete

### Root cause analysis

Tests were failing because:
- React hydration wasn't complete when assertions ran (~300ms failures)
- Multiple "ログイン" links on some pages caused ambiguity
- Form validation timing was inconsistent

## Test plan

- [ ] CI passes
- [ ] E2E tests show improved pass rate after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)