### PR TITLE
fix: 食事記録UIの3つのバグを修正

### DIFF
--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -245,6 +245,8 @@ mealAnalysis.post(
 // Schema for create-empty endpoint
 const createEmptySchema = z.object({
   recordedAt: z.string().regex(/^.+([+-]\d{2}:\d{2}|Z)$/).optional(),
+  mealType: z.enum(['breakfast', 'lunch', 'dinner', 'snack']).optional(),
+  content: z.string().optional(),
 });
 
 // POST /api/meals/create-empty - Create empty meal for manual input
@@ -261,8 +263,8 @@ mealAnalysis.post('/create-empty', zValidator('json', createEmptySchema), async 
   await db.insert(mealRecords).values({
     id: mealId,
     userId,
-    mealType: 'lunch', // Default, will be set when saving
-    content: '',
+    mealType: data.mealType || 'lunch',
+    content: data.content || '',
     calories: 0,
     totalProtein: 0,
     totalFat: 0,

--- a/packages/frontend/src/components/meal/SmartMealInput.tsx
+++ b/packages/frontend/src/components/meal/SmartMealInput.tsx
@@ -190,10 +190,24 @@ export function SmartMealInput({ onSave, onRefresh }: SmartMealInputProps) {
   }, []);
 
   // Fallback to manual input (T017)
-  const handleManualFallback = useCallback(() => {
+  const handleManualFallback = useCallback(async () => {
     setError(null);
-    setInputState('idle');
-  }, []);
+    setInputState('analyzing');
+
+    try {
+      const { mealId: newMealId } = await mealAnalysisApi.createEmptyMeal({
+        content: text.trim() || undefined,
+        recordedAt: toLocalISOString(new Date()),
+      });
+      setMealId(newMealId);
+      setFoodItems([]);
+      setTotals({ calories: 0, protein: 0, fat: 0, carbs: 0 });
+      setInputState('result');
+    } catch {
+      setError('手動入力の作成に失敗しました');
+      setInputState('error');
+    }
+  }, [text]);
 
   // Handle date/time change (011-meal-datetime)
   const handleDateTimeChange = useCallback((newDateTime: string) => {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -192,8 +192,8 @@ export const mealAnalysisApi = {
   },
 
   // Create empty meal for manual input
-  async createEmptyMeal(): Promise<{ mealId: string }> {
-    return api.post('/api/meals/create-empty');
+  async createEmptyMeal(options?: { mealType?: string; content?: string; recordedAt?: string }): Promise<{ mealId: string }> {
+    return api.post('/api/meals/create-empty', options || {});
   },
 
   // Get food items for a meal

--- a/packages/frontend/src/pages/MealDetail.tsx
+++ b/packages/frontend/src/pages/MealDetail.tsx
@@ -66,23 +66,21 @@ export default function MealDetailPage() {
           setPhotos([]);
         }
 
-        // Load food items if this is an AI-analyzed meal
-        if (mealResponse.meal.analysisSource === 'ai') {
-          try {
-            const { foodItems: items } = await mealAnalysisApi.getFoodItems(mealId);
-            setFoodItems(items);
-          } catch {
-            // Food items might not exist for older records
-            setFoodItems([]);
-          }
+        // Load food items
+        try {
+          const { foodItems: items } = await mealAnalysisApi.getFoodItems(mealId);
+          setFoodItems(items);
+        } catch {
+          // Food items might not exist for older records
+          setFoodItems([]);
+        }
 
-          // Load chat history
-          try {
-            const { messages } = await mealAnalysisApi.getChatHistory(mealId);
-            setChatHistory(messages);
-          } catch {
-            setChatHistory([]);
-          }
+        // Load chat history
+        try {
+          const { messages } = await mealAnalysisApi.getChatHistory(mealId);
+          setChatHistory(messages);
+        } catch {
+          setChatHistory([]);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'データの読み込みに失敗しました');
@@ -109,9 +107,11 @@ export default function MealDetailPage() {
         setPhotos([]);
       }
 
-      if (mealResponse.meal.analysisSource === 'ai') {
+      try {
         const { foodItems: items } = await mealAnalysisApi.getFoodItems(mealId);
         setFoodItems(items);
+      } catch {
+        setFoodItems([]);
       }
     } catch (err) {
       console.error('Failed to reload meal data:', err);


### PR DESCRIPTION
## Summary

Closes #79

食事記録UIの動作確認で発見された3つのバグを修正:

- **mealTypeのハードコード**: `create-empty` エンドポイントが `mealType` パラメータを無視して常に `lunch` を設定していた → スキーマを拡張してリクエスト値を使用するように修正
- **「手動で入力する」ボタン**: エラー状態をリセットするだけで手動入力フォームが表示されなかった → `createEmptyMeal` APIを呼び出して `result` ステートに遷移するように修正
- **編集モードの食材非表示**: `analysisSource === 'ai'` の条件ガードにより手動入力の食事で食材がフェッチされなかった → 条件を削除して全食事で食材をフェッチ

## Test plan

- [ ] テキスト入力 → サーバーエラー → 「手動で入力する」クリック → 手動入力フォームが表示されること
- [ ] 手動入力で食事を作成し、食事タイプが正しく反映されること（朝食/昼食/夕食/間食）
- [ ] 食事詳細ページで食材一覧が表示されること（AI分析・手動入力両方）
- [ ] 編集モードで「識別された食材」セクションに食材が表示されること
- [ ] 既存のAI分析フローに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)