### PR TITLE
feat: ログアウト機能改善 & セッション切れ自動リダイレクト

### DIFF
--- a/packages/frontend/src/lib/client.ts
+++ b/packages/frontend/src/lib/client.ts
@@ -2,6 +2,7 @@ import { hc } from 'hono/client';
 import type { AppType } from '@lifestyle-app/backend';
 import { generateRequestId } from './requestId';
 import { setCurrentRequestId } from './errorLogger';
+import { useAuthStore } from '../stores/authStore';
 
 // In production (empty VITE_API_URL), use same origin
 // In development, use localhost:8787
@@ -18,6 +19,9 @@ function getApiBaseUrl(): string {
 }
 
 const API_BASE_URL = getApiBaseUrl();
+
+// Paths that should not trigger auto-logout on 401
+const AUTH_PATHS = ['/api/auth/login', '/api/auth/register', '/api/auth/me'];
 
 // Hono RPC client with full type safety
 export const client = hc<AppType>(API_BASE_URL, {
@@ -40,6 +44,17 @@ export const client = hc<AppType>(API_BASE_URL, {
         headers,
       });
       console.log('[RPC] Response:', response.status, response.statusText);
+
+      // Auto-logout on 401 (session expired)
+      if (response.status === 401) {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+        const isAuthPath = AUTH_PATHS.some(path => url.includes(path));
+        if (!isAuthPath && useAuthStore.getState().isAuthenticated) {
+          useAuthStore.getState().logout();
+          window.location.href = '/login';
+        }
+      }
+
       return response;
     } catch (error) {
       console.error('[RPC] Fetch error:', error);

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -318,6 +318,18 @@ export function Settings() {
         )}
       </div>
 
+      {/* Logout */}
+      <button
+        onClick={() => {
+          api.auth.logout.$post().catch(() => {});
+          logout();
+          navigate('/login');
+        }}
+        className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+      >
+        ログアウト
+      </button>
+
       {/* Delete Account Section */}
       <div className="card border border-red-100 bg-red-50/50 p-5">
         <h2 className="mb-2 text-sm font-semibold text-red-900">アカウント削除</h2>


### PR DESCRIPTION
## Summary
- 設定ページにログアウトボタンを追加（スマホではヘッダーのログアウトボタンが `hidden sm:block` で非表示だった）
- APIクライアントで401レスポンスを検知し、セッション切れ時に自動でログイン画面にリダイレクト
- 認証系API（login/register/me）は除外して無限ループを防止

## Test plan
- [ ] スマホ表示で設定ページからログアウトできること
- [ ] セッション切れ後のAPI呼び出しでログイン画面にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)