### PR TITLE
feat: Passkey (WebAuthn) 認証を並走導入 (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,10 @@ jobs:
             --var AI_PROVIDER:google \
             --var AI_MODEL:gemini-3-flash-preview \
             --var FROM_EMAIL:onboarding@resend.dev \
-            --var FRONTEND_URL:https://lifestyle-tracker-pr-${{ github.event.pull_request.number }}.abe00makoto.workers.dev
+            --var FRONTEND_URL:https://lifestyle-tracker-pr-${{ github.event.pull_request.number }}.abe00makoto.workers.dev \
+            --var RP_ID:lifestyle-tracker-pr-${{ github.event.pull_request.number }}.abe00makoto.workers.dev \
+            --var RP_NAME:"Lifestyle Tracker (PR Preview)" \
+            --var RP_ORIGIN:https://lifestyle-tracker-pr-${{ github.event.pull_request.number }}.abe00makoto.workers.dev
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/backend/migrations/0030_passkey_webauthn.sql
+++ b/packages/backend/migrations/0030_passkey_webauthn.sql
@@ -1,0 +1,34 @@
+-- Migration: WebAuthn / Passkey support
+-- Phase 1: introduces passkey_credentials and webauthn_challenges tables.
+-- users.password_hash remains NOT NULL during the parallel period; Phase 2
+-- will introduce a separate migration to make it nullable once all users
+-- have registered at least one passkey.
+
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  credential_id TEXT NOT NULL UNIQUE,
+  public_key TEXT NOT NULL,
+  counter INTEGER NOT NULL DEFAULT 0,
+  device_type TEXT NOT NULL,
+  backed_up INTEGER NOT NULL DEFAULT 0,
+  transports TEXT,
+  name TEXT,
+  last_used_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_user_id ON passkey_credentials(user_id);
+
+CREATE TABLE IF NOT EXISTS webauthn_challenges (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  challenge TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_challenge_expires ON webauthn_challenges(expires_at);

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
     "@ai-sdk/google": "^3.0.2",
     "@hono/zod-validator": "^0.2.0",
     "@lifestyle-app/shared": "workspace:*",
+    "@simplewebauthn/server": "^13.3.0",
     "ai": "^6.0.5",
     "bcryptjs": "^2.4.3",
     "drizzle-orm": "^0.30.0",

--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -10,6 +10,7 @@ import { drizzle } from 'drizzle-orm/d1';
 import { eq, and, lt } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import * as emailSchema from '../db/schema/email';
+import * as webauthnSchema from '../db/schema/webauthn';
 
 const UNVERIFIED_ACCOUNT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const TOKEN_CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -19,13 +20,14 @@ interface CleanupResult {
   deletedPasswordResetTokens: number;
   deletedEmailVerificationTokens: number;
   deletedEmailChangeRequests: number;
+  deletedExpiredChallenges: number;
 }
 
 /**
  * Execute all scheduled cleanup tasks
  */
 export async function executeScheduledCleanup(db: D1Database): Promise<CleanupResult> {
-  const orm = drizzle(db, { schema: { ...schema, ...emailSchema } });
+  const orm = drizzle(db, { schema: { ...schema, ...emailSchema, ...webauthnSchema } });
   const now = Date.now();
   const unverifiedCutoff = now - UNVERIFIED_ACCOUNT_RETENTION_MS;
   const tokenCutoff = now - TOKEN_CLEANUP_AGE_MS;
@@ -140,11 +142,30 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     console.error('[Cleanup] Error deleting email change requests:', error);
   }
 
+  // 5. Delete expired WebAuthn challenges (5-minute TTL, so anything past now is dead)
+  let deletedExpiredChallenges = 0;
+  try {
+    const nowIso = new Date(now).toISOString();
+    const result = await orm
+      .delete(webauthnSchema.webauthnChallenges)
+      .where(lt(webauthnSchema.webauthnChallenges.expiresAt, nowIso))
+      .run();
+    deletedExpiredChallenges = result.meta?.changes ?? 0;
+    if (deletedExpiredChallenges > 0) {
+      console.log(`[Cleanup] Deleted ${deletedExpiredChallenges} expired WebAuthn challenges`);
+    } else {
+      console.log('[Cleanup] No expired WebAuthn challenges to delete');
+    }
+  } catch (error) {
+    console.error('[Cleanup] Error deleting expired WebAuthn challenges:', error);
+  }
+
   const result = {
     deletedUsers,
     deletedPasswordResetTokens,
     deletedEmailVerificationTokens,
     deletedEmailChangeRequests,
+    deletedExpiredChallenges,
   };
 
   console.log('[Cleanup] Cleanup tasks completed:', result);

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -179,3 +179,6 @@ export type NewAIUsageRecord = typeof aiUsageRecords.$inferInsert;
 
 // Email-related tables
 export * from './schema/email';
+
+// WebAuthn / Passkey tables
+export * from './schema/webauthn';

--- a/packages/backend/src/db/schema/webauthn.ts
+++ b/packages/backend/src/db/schema/webauthn.ts
@@ -1,0 +1,44 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { users } from '../schema';
+
+export const passkeyCredentials = sqliteTable(
+  'passkey_credentials',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    credentialId: text('credential_id').notNull().unique(),
+    publicKey: text('public_key').notNull(),
+    counter: integer('counter').notNull().default(0),
+    deviceType: text('device_type').notNull(),
+    backedUp: integer('backed_up').notNull().default(0),
+    transports: text('transports'),
+    name: text('name'),
+    lastUsedAt: text('last_used_at'),
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_passkey_user_id').on(table.userId),
+  })
+);
+
+export const webauthnChallenges = sqliteTable(
+  'webauthn_challenges',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
+    challenge: text('challenge').notNull().unique(),
+    type: text('type', { enum: ['registration', 'authentication'] }).notNull(),
+    expiresAt: text('expires_at').notNull(),
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => ({
+    expiresAtIdx: index('idx_webauthn_challenge_expires').on(table.expiresAt),
+  })
+);
+
+export type PasskeyCredential = typeof passkeyCredentials.$inferSelect;
+export type NewPasskeyCredential = typeof passkeyCredentials.$inferInsert;
+export type WebAuthnChallenge = typeof webauthnChallenges.$inferSelect;
+export type NewWebAuthnChallenge = typeof webauthnChallenges.$inferInsert;

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -87,6 +87,7 @@ app.use(
   cors({
     origin: [
       'http://localhost:5173',
+      'http://localhost:5174',
       'http://localhost:3000',
       'https://lifestyle-tracker.abe00makoto.workers.dev',
       'https://lifestyle-tracker-preview.abe00makoto.workers.dev',

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -16,6 +16,7 @@ import {
 } from '../services/auth/password-reset.service';
 import { sendVerificationEmail } from '../services/email/email-verification.service';
 import { getClientIP } from '../services/rate-limit/email-rate-limit';
+import { webauthn } from './auth/webauthn';
 
 type Bindings = {
   DB: D1Database;
@@ -23,6 +24,9 @@ type Bindings = {
   RESEND_API_KEY: string;
   FROM_EMAIL: string;
   FRONTEND_URL: string;
+  RP_ID: string;
+  RP_NAME: string;
+  RP_ORIGIN: string;
 };
 
 type Variables = {
@@ -32,6 +36,7 @@ type Variables = {
 
 // Chain format for RPC type inference
 export const auth = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .route('/webauthn', webauthn)
   .post('/register', zValidator('json', registerSchema), async (c) => {
     const input = c.req.valid('json');
     const db = c.get('db');

--- a/packages/backend/src/routes/auth/webauthn.ts
+++ b/packages/backend/src/routes/auth/webauthn.ts
@@ -1,0 +1,248 @@
+import { Hono } from 'hono';
+import { setCookie } from 'hono/cookie';
+import { zValidator } from '@hono/zod-validator';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  AuthenticatorTransportFuture,
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+import {
+  passkeyRegisterVerifySchema,
+  passkeyAuthVerifySchema,
+} from '@lifestyle-app/shared';
+import { authMiddleware, createSessionToken } from '../../middleware/auth';
+import { AppError } from '../../middleware/error';
+import type { Database } from '../../db';
+import {
+  saveChallenge,
+  getAndDeleteChallenge,
+  saveCredential,
+  getCredentialsByUserId,
+  getCredentialByCredentialId,
+  updateCredentialCounter,
+  deleteCredential,
+  base64urlToUint8Array,
+  uint8ArrayToBase64url,
+} from '../../services/webauthn.service';
+import { AuthService } from '../../services/auth';
+
+type Bindings = {
+  DB: D1Database;
+  ENVIRONMENT: string;
+  RP_ID: string;
+  RP_NAME: string;
+  RP_ORIGIN: string;
+};
+
+type Variables = {
+  db: Database;
+  user: { id: string; email: string };
+};
+
+// Authenticated sub-chain (uses authMiddleware)
+const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .use(authMiddleware)
+  .post('/register/options', async (c) => {
+    const user = c.get('user');
+    const db = c.get('db');
+
+    const existing = await getCredentialsByUserId(db, user.id);
+
+    const options = await generateRegistrationOptions({
+      rpName: c.env.RP_NAME,
+      rpID: c.env.RP_ID,
+      userName: user.email,
+      userID: new TextEncoder().encode(user.id),
+      attestationType: 'none',
+      excludeCredentials: existing.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports
+          ? (JSON.parse(cred.transports) as AuthenticatorTransportFuture[])
+          : undefined,
+      })),
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+    });
+
+    await saveChallenge(db, {
+      userId: user.id,
+      challenge: options.challenge,
+      type: 'registration',
+    });
+
+    return c.json(options);
+  })
+  .post(
+    '/register/verify',
+    zValidator('json', passkeyRegisterVerifySchema),
+    async (c) => {
+      const { response, name } = c.req.valid('json');
+      const user = c.get('user');
+      const db = c.get('db');
+
+      const verification = await verifyRegistrationResponse({
+        response: response as unknown as RegistrationResponseJSON,
+        expectedChallenge: async (challenge) => {
+          const record = await getAndDeleteChallenge(db, challenge);
+          return record !== null && record.userId === user.id && record.type === 'registration';
+        },
+        expectedOrigin: c.env.RP_ORIGIN,
+        expectedRPID: c.env.RP_ID,
+      });
+
+      if (!verification.verified || !verification.registrationInfo) {
+        throw new AppError('パスキーの検証に失敗しました', 400, 'WEBAUTHN_VERIFICATION_FAILED');
+      }
+
+      const { credential, credentialDeviceType, credentialBackedUp } =
+        verification.registrationInfo;
+
+      const transports =
+        (response as unknown as RegistrationResponseJSON).response?.transports ?? undefined;
+
+      const saved = await saveCredential(db, user.id, {
+        credentialId: credential.id,
+        publicKey: uint8ArrayToBase64url(credential.publicKey),
+        counter: credential.counter,
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+        transports,
+        name,
+      });
+
+      return c.json({
+        verified: true,
+        credentialId: saved.credentialId,
+        name: saved.name,
+      });
+    },
+  )
+  .get('/credentials', async (c) => {
+    const user = c.get('user');
+    const db = c.get('db');
+    const credentials = await getCredentialsByUserId(db, user.id);
+    return c.json({
+      credentials: credentials.map((cred) => ({
+        id: cred.id,
+        credentialId: cred.credentialId,
+        name: cred.name,
+        deviceType: cred.deviceType,
+        backedUp: cred.backedUp === 1,
+        lastUsedAt: cred.lastUsedAt,
+        createdAt: cred.createdAt,
+      })),
+    });
+  })
+  .delete('/credentials/:credentialId', async (c) => {
+    const user = c.get('user');
+    const db = c.get('db');
+    const credentialId = c.req.param('credentialId');
+
+    const all = await getCredentialsByUserId(db, user.id);
+    const target = all.find((cred) => cred.credentialId === credentialId);
+    if (!target) {
+      throw new AppError('パスキーが見つかりません', 404, 'CREDENTIAL_NOT_FOUND');
+    }
+
+    // Phase 2 guard: if user has no password and this is their last credential,
+    // refuse deletion to avoid account lockout. In Phase 1 password is always set,
+    // so this branch is a no-op but keeps the guard logic stable.
+    const userRecord = await new AuthService(db).getUserById(user.id);
+    const hasPassword = Boolean((userRecord as { passwordHash?: string | null }).passwordHash);
+    if (!hasPassword && all.length <= 1) {
+      throw new AppError(
+        '最後のパスキーは削除できません',
+        400,
+        'LAST_CREDENTIAL',
+      );
+    }
+
+    await deleteCredential(db, credentialId, user.id);
+    return c.json({ success: true });
+  });
+
+// Public routes
+export const webauthn = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .route('/', authedRoutes)
+  .post('/authenticate/options', async (c) => {
+    const db = c.get('db');
+
+    const options = await generateAuthenticationOptions({
+      rpID: c.env.RP_ID,
+      allowCredentials: [],
+      userVerification: 'preferred',
+    });
+
+    await saveChallenge(db, {
+      userId: null,
+      challenge: options.challenge,
+      type: 'authentication',
+    });
+
+    return c.json(options);
+  })
+  .post(
+    '/authenticate/verify',
+    zValidator('json', passkeyAuthVerifySchema),
+    async (c) => {
+      const { response } = c.req.valid('json');
+      const db = c.get('db');
+
+      const authResponse = response as unknown as AuthenticationResponseJSON;
+      const credentialRow = await getCredentialByCredentialId(db, authResponse.id);
+      if (!credentialRow) {
+        throw new AppError('認証情報が見つかりません', 401, 'CREDENTIAL_NOT_FOUND');
+      }
+
+      const verification = await verifyAuthenticationResponse({
+        response: authResponse,
+        expectedChallenge: async (challenge) => {
+          const record = await getAndDeleteChallenge(db, challenge);
+          return record !== null && record.type === 'authentication';
+        },
+        expectedOrigin: c.env.RP_ORIGIN,
+        expectedRPID: c.env.RP_ID,
+        credential: {
+          id: credentialRow.credentialId,
+          publicKey: base64urlToUint8Array(credentialRow.publicKey) as Uint8Array<ArrayBuffer>,
+          counter: credentialRow.counter,
+          transports: credentialRow.transports
+            ? (JSON.parse(credentialRow.transports) as AuthenticatorTransportFuture[])
+            : undefined,
+        },
+      });
+
+      if (!verification.verified) {
+        throw new AppError('パスキー認証に失敗しました', 401, 'WEBAUTHN_AUTH_FAILED');
+      }
+
+      await updateCredentialCounter(
+        db,
+        credentialRow.credentialId,
+        verification.authenticationInfo.newCounter,
+      );
+
+      const authService = new AuthService(db);
+      const user = await authService.getUserById(credentialRow.userId);
+
+      const token = createSessionToken(user.id);
+      const isProduction = c.env.ENVIRONMENT === 'production';
+      setCookie(c, 'session', token, {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'Lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 7,
+      });
+
+      return c.json({ user });
+    },
+  );

--- a/packages/backend/src/routes/auth/webauthn.ts
+++ b/packages/backend/src/routes/auth/webauthn.ts
@@ -45,10 +45,10 @@ type Variables = {
   user: { id: string; email: string };
 };
 
-// Authenticated sub-chain (uses authMiddleware)
-const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
-  .use(authMiddleware)
-  .post('/register/options', async (c) => {
+// Public + authenticated routes. authMiddleware is attached per-route to avoid
+// leaking into sibling routes via Hono's middleware chain semantics.
+export const webauthn = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .post('/register/options', authMiddleware, async (c) => {
     const user = c.get('user');
     const db = c.get('db');
 
@@ -82,6 +82,7 @@ const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
   })
   .post(
     '/register/verify',
+    authMiddleware,
     zValidator('json', passkeyRegisterVerifySchema),
     async (c) => {
       const { response, name } = c.req.valid('json');
@@ -125,7 +126,7 @@ const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       });
     },
   )
-  .get('/credentials', async (c) => {
+  .get('/credentials', authMiddleware, async (c) => {
     const user = c.get('user');
     const db = c.get('db');
     const credentials = await getCredentialsByUserId(db, user.id);
@@ -141,7 +142,7 @@ const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       })),
     });
   })
-  .delete('/credentials/:credentialId', async (c) => {
+  .delete('/credentials/:credentialId', authMiddleware, async (c) => {
     const user = c.get('user');
     const db = c.get('db');
     const credentialId = c.req.param('credentialId');
@@ -167,11 +168,7 @@ const authedRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
     await deleteCredential(db, credentialId, user.id);
     return c.json({ success: true });
-  });
-
-// Public routes
-export const webauthn = new Hono<{ Bindings: Bindings; Variables: Variables }>()
-  .route('/', authedRoutes)
+  })
   .post('/authenticate/options', async (c) => {
     const db = c.get('db');
 

--- a/packages/backend/src/services/webauthn.service.ts
+++ b/packages/backend/src/services/webauthn.service.ts
@@ -1,0 +1,159 @@
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { Database } from '../db';
+import { passkeyCredentials, webauthnChallenges } from '../db/schema/webauthn';
+import type { PasskeyCredential, WebAuthnChallenge } from '../db/schema/webauthn';
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+export async function saveChallenge(
+  db: Database,
+  params: {
+    userId: string | null;
+    challenge: string;
+    type: 'registration' | 'authentication';
+  },
+): Promise<void> {
+  const now = new Date();
+  await db.insert(webauthnChallenges).values({
+    id: uuidv4(),
+    userId: params.userId,
+    challenge: params.challenge,
+    type: params.type,
+    expiresAt: new Date(now.getTime() + CHALLENGE_TTL_MS).toISOString(),
+    createdAt: now.toISOString(),
+  });
+}
+
+export async function getAndDeleteChallenge(
+  db: Database,
+  challenge: string,
+): Promise<WebAuthnChallenge | null> {
+  const row = await db
+    .select()
+    .from(webauthnChallenges)
+    .where(eq(webauthnChallenges.challenge, challenge))
+    .get();
+
+  if (!row) return null;
+
+  await db
+    .delete(webauthnChallenges)
+    .where(eq(webauthnChallenges.challenge, challenge))
+    .run();
+
+  if (new Date(row.expiresAt).getTime() < Date.now()) {
+    return null;
+  }
+
+  return row;
+}
+
+export async function saveCredential(
+  db: Database,
+  userId: string,
+  cred: {
+    credentialId: string;
+    publicKey: string;
+    counter: number;
+    deviceType: string;
+    backedUp: boolean;
+    transports?: string[];
+    name?: string;
+  },
+): Promise<PasskeyCredential> {
+  const id = uuidv4();
+  const createdAt = new Date().toISOString();
+  await db.insert(passkeyCredentials).values({
+    id,
+    userId,
+    credentialId: cred.credentialId,
+    publicKey: cred.publicKey,
+    counter: cred.counter,
+    deviceType: cred.deviceType,
+    backedUp: cred.backedUp ? 1 : 0,
+    transports: cred.transports ? JSON.stringify(cred.transports) : null,
+    name: cred.name ?? null,
+    lastUsedAt: null,
+    createdAt,
+  });
+
+  const inserted = await db
+    .select()
+    .from(passkeyCredentials)
+    .where(eq(passkeyCredentials.id, id))
+    .get();
+  if (!inserted) throw new Error('Failed to insert credential');
+  return inserted;
+}
+
+export async function getCredentialsByUserId(
+  db: Database,
+  userId: string,
+): Promise<PasskeyCredential[]> {
+  return db
+    .select()
+    .from(passkeyCredentials)
+    .where(eq(passkeyCredentials.userId, userId))
+    .all();
+}
+
+export async function getCredentialByCredentialId(
+  db: Database,
+  credentialId: string,
+): Promise<PasskeyCredential | null> {
+  const row = await db
+    .select()
+    .from(passkeyCredentials)
+    .where(eq(passkeyCredentials.credentialId, credentialId))
+    .get();
+  return row ?? null;
+}
+
+export async function updateCredentialCounter(
+  db: Database,
+  credentialId: string,
+  newCounter: number,
+): Promise<void> {
+  await db
+    .update(passkeyCredentials)
+    .set({ counter: newCounter, lastUsedAt: new Date().toISOString() })
+    .where(eq(passkeyCredentials.credentialId, credentialId))
+    .run();
+}
+
+export async function deleteCredential(
+  db: Database,
+  credentialId: string,
+  userId: string,
+): Promise<boolean> {
+  const result = await db
+    .delete(passkeyCredentials)
+    .where(
+      and(
+        eq(passkeyCredentials.credentialId, credentialId),
+        eq(passkeyCredentials.userId, userId),
+      ),
+    )
+    .run();
+  return (result.meta?.changes ?? 0) > 0;
+}
+
+export function base64urlToUint8Array(b64url: string): Uint8Array {
+  const base64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function uint8ArrayToBase64url(arr: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < arr.length; i += 1) {
+    binary += String.fromCharCode(arr[i]!);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -8,6 +8,9 @@ ip = "0.0.0.0"
 
 [dev.vars]
 ENVIRONMENT = "development"
+RP_ID = "localhost"
+RP_NAME = "Lifestyle Tracker (Dev)"
+RP_ORIGIN = "http://localhost:5174"
 
 [assets]
 directory = "./public"
@@ -22,6 +25,10 @@ AI_MODEL = "gemini-3-flash-preview"
 # RESEND_API_KEY should be set via wrangler secrets (see .github/workflows/ci.yml)
 FROM_EMAIL = "noreply@yasedas.com"
 FRONTEND_URL = "https://lifestyle-tracker.abe00makoto.workers.dev"
+# WebAuthn / Passkey configuration
+RP_ID = "lifestyle-tracker.abe00makoto.workers.dev"
+RP_NAME = "Lifestyle Tracker"
+RP_ORIGIN = "https://lifestyle-tracker.abe00makoto.workers.dev"
 
 [[d1_databases]]
 binding = "DB"
@@ -48,6 +55,10 @@ AI_MODEL = "gemini-3-flash-preview"
 # Email delivery configuration
 FROM_EMAIL = "onboarding@resend.dev"
 FRONTEND_URL = "https://lifestyle-tracker-preview.abe00makoto.workers.dev"
+# WebAuthn / Passkey configuration
+RP_ID = "lifestyle-tracker-preview.abe00makoto.workers.dev"
+RP_NAME = "Lifestyle Tracker"
+RP_ORIGIN = "https://lifestyle-tracker-preview.abe00makoto.workers.dev"
 
 [[env.preview.d1_databases]]
 binding = "DB"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.3.0",
     "@lifestyle-app/shared": "workspace:*",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/react-query": "^5.17.0",
     "chart.js": "^4.4.0",
     "date-fns-tz": "^3.2.0",

--- a/packages/frontend/src/components/auth/PasskeyManagement.tsx
+++ b/packages/frontend/src/components/auth/PasskeyManagement.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import { api } from '../../lib/client';
+import { usePasskeyRegistration } from '../../hooks/usePasskeyRegistration';
+
+interface Credential {
+  id: string;
+  credentialId: string;
+  name: string | null;
+  deviceType: string;
+  backedUp: boolean;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+export function PasskeyManagement() {
+  const queryClient = useQueryClient();
+  const [newName, setNewName] = useState('');
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const isSupported = browserSupportsWebAuthn();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['passkey', 'credentials'],
+    queryFn: async () => {
+      const res = await api.auth.webauthn.credentials.$get();
+      if (!res.ok) throw new Error('Failed to fetch credentials');
+      return res.json() as Promise<{ credentials: Credential[] }>;
+    },
+    enabled: isSupported,
+  });
+
+  const { registerAsync, isPending: isRegistering } = usePasskeyRegistration();
+
+  const deleteMutation = useMutation({
+    mutationFn: async (credentialId: string) => {
+      const res = await api.auth.webauthn.credentials[':credentialId'].$delete({
+        param: { credentialId },
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? '削除に失敗しました');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['passkey', 'credentials'] });
+      setDeleteTargetId(null);
+    },
+  });
+
+  if (!isSupported) {
+    return (
+      <div className="card p-5">
+        <h2 className="mb-3 text-sm font-semibold text-gray-900">パスキー管理</h2>
+        <p className="text-xs text-gray-500">
+          このブラウザはパスキー(WebAuthn)に対応していません。
+        </p>
+      </div>
+    );
+  }
+
+  const credentials = data?.credentials ?? [];
+
+  const handleAdd = async () => {
+    setFeedback(null);
+    try {
+      await registerAsync(newName.trim() || undefined);
+      setNewName('');
+      setFeedback('パスキーを登録しました');
+      setTimeout(() => setFeedback(null), 3000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'パスキー登録に失敗しました';
+      // ユーザーキャンセル(NotAllowedError)は黙る
+      if (err instanceof Error && err.name === 'NotAllowedError') return;
+      setFeedback(message);
+      setTimeout(() => setFeedback(null), 5000);
+    }
+  };
+
+  return (
+    <div className="card p-5">
+      <h2 className="mb-3 text-sm font-semibold text-gray-900">パスキー管理</h2>
+
+      {isLoading ? (
+        <p className="text-xs text-gray-400">読み込み中...</p>
+      ) : credentials.length === 0 ? (
+        <p className="mb-4 text-xs text-gray-500">
+          パスキーを登録すると、次回からパスワード不要でログインできます。
+        </p>
+      ) : (
+        <ul className="mb-4 space-y-2">
+          {credentials.map((cred) => (
+            <li
+              key={cred.id}
+              className="flex items-center justify-between rounded-lg border border-gray-100 bg-gray-50 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-gray-900">
+                  {cred.name || '名称未設定'}
+                </p>
+                <p className="text-[10px] text-gray-400">
+                  {cred.deviceType === 'multiDevice' ? '同期済み' : 'このデバイスのみ'}
+                  {cred.lastUsedAt
+                    ? ` ・ 最終使用 ${new Date(cred.lastUsedAt).toLocaleDateString('ja-JP')}`
+                    : ' ・ 未使用'}
+                </p>
+              </div>
+              <button
+                onClick={() => setDeleteTargetId(cred.credentialId)}
+                className="ml-2 shrink-0 rounded-md border border-red-200 bg-white px-2 py-1 text-xs text-red-600 hover:bg-red-50 transition-colors"
+              >
+                削除
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-gray-600">
+          新しいパスキー
+        </label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="例: iPhone 15"
+            maxLength={50}
+            className="flex-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+          />
+          <button
+            onClick={handleAdd}
+            disabled={isRegistering}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {isRegistering ? '登録中...' : 'パスキーを追加'}
+          </button>
+        </div>
+        {feedback && (
+          <p className="text-xs text-gray-500">{feedback}</p>
+        )}
+      </div>
+
+      {deleteTargetId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-sm card p-6">
+            <h3 className="text-base font-semibold text-gray-900">
+              このパスキーを削除しますか?
+            </h3>
+            <p className="mt-2 text-sm text-gray-500">
+              削除すると、このデバイスからパスキーでログインできなくなります。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setDeleteTargetId(null)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => deleteTargetId && deleteMutation.mutate(deleteTargetId)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {deleteMutation.isPending ? '削除中...' : '削除する'}
+              </button>
+            </div>
+            {deleteMutation.isError && (
+              <p className="mt-2 text-xs text-red-500">
+                {(deleteMutation.error as Error).message}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/usePasskeyAuth.ts
+++ b/packages/frontend/src/hooks/usePasskeyAuth.ts
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import type { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser';
+import { api } from '../lib/client';
+import { useAuthStore } from '../stores/authStore';
+
+export function usePasskeyAuth(redirectTo = '/') {
+  const { setUser } = useAuthStore();
+  const navigate = useNavigate();
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const authenticate = async () => {
+    setIsPending(true);
+    setError(null);
+    try {
+      const optRes = await api.auth.webauthn.authenticate.options.$post();
+      if (!optRes.ok) {
+        throw new Error('パスキー認証の準備に失敗しました');
+      }
+      const options = (await optRes.json()) as PublicKeyCredentialRequestOptionsJSON;
+
+      const response = await startAuthentication({ optionsJSON: options });
+
+      const verRes = await api.auth.webauthn.authenticate.verify.$post({
+        json: { response: response as unknown as Record<string, unknown> },
+      });
+      if (!verRes.ok) {
+        const err = (await verRes.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? 'パスキー認証に失敗しました');
+      }
+      const data = (await verRes.json()) as { user: Parameters<typeof setUser>[0] };
+      setUser(data.user);
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      if (err instanceof Error) {
+        // ユーザーキャンセル(NotAllowedError) はエラー表示しない
+        if (err.name === 'NotAllowedError') {
+          setError(null);
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError('パスキー認証に失敗しました');
+      }
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return {
+    authenticate,
+    isPending,
+    error,
+    isSupported: browserSupportsWebAuthn(),
+  };
+}

--- a/packages/frontend/src/hooks/usePasskeyRegistration.ts
+++ b/packages/frontend/src/hooks/usePasskeyRegistration.ts
@@ -1,0 +1,40 @@
+import { startRegistration, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import type { PublicKeyCredentialCreationOptionsJSON } from '@simplewebauthn/browser';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/client';
+
+export function usePasskeyRegistration() {
+  const queryClient = useQueryClient();
+
+  const registerMutation = useMutation({
+    mutationFn: async (name?: string) => {
+      const optRes = await api.auth.webauthn.register.options.$post();
+      if (!optRes.ok) {
+        throw new Error('パスキー登録の準備に失敗しました');
+      }
+      const options = (await optRes.json()) as PublicKeyCredentialCreationOptionsJSON;
+
+      const response = await startRegistration({ optionsJSON: options });
+
+      const verRes = await api.auth.webauthn.register.verify.$post({
+        json: { response: response as unknown as Record<string, unknown>, name },
+      });
+      if (!verRes.ok) {
+        const err = (await verRes.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? 'パスキー登録に失敗しました');
+      }
+      return verRes.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['passkey', 'credentials'] });
+    },
+  });
+
+  return {
+    register: registerMutation.mutate,
+    registerAsync: registerMutation.mutateAsync,
+    isPending: registerMutation.isPending,
+    error: registerMutation.error,
+    isSupported: browserSupportsWebAuthn(),
+  };
+}

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { loginSchema, type LoginInput } from '@lifestyle-app/shared';
 import { api } from '../lib/client';
 import { useAuthStore } from '../stores/authStore';
 import { ForgotPasswordLink } from '../components/auth/ForgotPasswordLink';
+import { usePasskeyAuth } from '../hooks/usePasskeyAuth';
 
 export function Login() {
   const navigate = useNavigate();
@@ -16,6 +17,13 @@ export function Login() {
 
   const from = (location.state as { from?: Location })?.from?.pathname || '/';
   const successMessage = (location.state as { message?: string })?.message;
+
+  const {
+    authenticate: authenticateWithPasskey,
+    isPending: isPasskeyPending,
+    error: passkeyError,
+    isSupported: isPasskeySupported,
+  } = usePasskeyAuth(from);
 
   const {
     register,
@@ -137,6 +145,30 @@ export function Login() {
           >
             {isSubmitting ? 'ログイン中...' : 'ログイン'}
           </button>
+
+          {isPasskeySupported && (
+            <>
+              <div className="relative flex items-center">
+                <div className="flex-grow border-t border-gray-200" />
+                <span className="mx-3 flex-shrink text-xs text-gray-400">または</span>
+                <div className="flex-grow border-t border-gray-200" />
+              </div>
+              <button
+                type="button"
+                onClick={authenticateWithPasskey}
+                disabled={isPasskeyPending}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 transition-colors"
+              >
+                <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clipRule="evenodd" />
+                </svg>
+                {isPasskeyPending ? '認証中...' : 'パスキーでログイン'}
+              </button>
+              {passkeyError && (
+                <p className="text-center text-xs text-red-500">{passkeyError}</p>
+              )}
+            </>
+          )}
 
           <ForgotPasswordLink />
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/client';
 import { useAuthStore } from '../stores/authStore';
+import { PasskeyManagement } from '../components/auth/PasskeyManagement';
 
 export function Settings() {
   const navigate = useNavigate();
@@ -184,6 +185,9 @@ export function Settings() {
           </div>
         </div>
       </div>
+
+      {/* Passkey Management */}
+      <PasskeyManagement />
 
       {/* Goals Section */}
       <div className="card p-5">

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -229,3 +229,6 @@ export * from './exercise';
 // Email and token schemas
 export * from './email';
 export * from './token';
+
+// WebAuthn / Passkey schemas
+export * from './webauthn';

--- a/packages/shared/src/schemas/webauthn.ts
+++ b/packages/shared/src/schemas/webauthn.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+// RegistrationResponseJSON / AuthenticationResponseJSON are validated
+// structurally by @simplewebauthn/server. We only validate the wrapper.
+export const passkeyRegisterVerifySchema = z.object({
+  response: z.record(z.unknown()),
+  name: z.string().max(50).optional(),
+});
+
+export const passkeyAuthVerifySchema = z.object({
+  response: z.record(z.unknown()),
+});
+
+export type PasskeyRegisterVerifyInput = z.infer<typeof passkeyRegisterVerifySchema>;
+export type PasskeyAuthVerifyInput = z.infer<typeof passkeyAuthVerifySchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@lifestyle-app/shared':
         specifier: workspace:*
         version: link:../shared
+      '@simplewebauthn/server':
+        specifier: ^13.3.0
+        version: 13.3.0
       ai:
         specifier: ^6.0.5
         version: 6.0.5(zod@3.25.76)
@@ -111,6 +114,9 @@ importers:
       '@lifestyle-app/shared':
         specifier: workspace:*
         version: link:../shared
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@tanstack/react-query':
         specifier: ^5.17.0
         version: 5.90.15(react@18.3.1)
@@ -2330,6 +2336,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /@hexagon/base64@1.1.28:
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+    dev: false
+
   /@hono/zod-validator@0.2.2(hono@4.11.3)(zod@3.25.76):
     resolution: {integrity: sha512-dSDxaPV70Py8wuIU2QNpoVEIOSzSXZ/6/B/h4xA7eOMz7+AarKTSGV8E6QwrdcCbBLkpqfJ4Q2TmBO0eP1tCBQ==}
     peerDependencies:
@@ -2634,6 +2644,10 @@ packages:
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
     dev: false
 
+  /@levischuck/tiny-cbor@0.2.11:
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+    dev: false
+
   /@napi-rs/wasm-runtime@1.1.1:
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
     requiresBuild: true
@@ -2831,6 +2845,133 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@peculiar/asn1-android@2.7.0:
+    resolution: {integrity: sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-cms@2.7.0:
+    resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-csr@2.7.0:
+    resolution: {integrity: sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-ecc@2.7.0:
+    resolution: {integrity: sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pfx@2.7.0:
+    resolution: {integrity: sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==}
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pkcs8@2.7.0:
+    resolution: {integrity: sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pkcs9@2.7.0:
+    resolution: {integrity: sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==}
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pfx': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-rsa@2.7.0:
+    resolution: {integrity: sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-schema@2.7.0:
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-x509-attr@2.7.0:
+    resolution: {integrity: sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-x509@2.7.0:
+    resolution: {integrity: sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/utils@2.0.3:
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/x509@1.14.3:
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-csr': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-pkcs9': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+    dev: false
 
   /@playwright/test@1.57.0:
     resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
@@ -3132,6 +3273,24 @@ packages:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+    dev: false
+
+  /@simplewebauthn/browser@13.3.0:
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
+    dev: false
+
+  /@simplewebauthn/server@13.3.0:
+    resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/x509': 1.14.3
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -3674,6 +3833,15 @@ packages:
     dependencies:
       printable-characters: 1.0.42
     dev: true
+
+  /asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+    dev: false
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -5110,6 +5278,7 @@ packages:
   /glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
     dependencies:
       foreground-child: 3.3.1
@@ -6418,6 +6587,17 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -6518,6 +6698,10 @@ packages:
     dependencies:
       picomatch: 2.3.1
     dev: true
+
+  /reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+    dev: false
 
   /reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -7261,11 +7445,20 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
+
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
     requiresBuild: true
-    dev: true
-    optional: true
+
+  /tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      tslib: 1.14.1
+    dev: false
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -27,7 +27,7 @@ test.describe('Authentication', () => {
 
   test('should show validation errors on login with empty fields', async ({ page }) => {
     await page.goto('/login');
-    await page.getByRole('button', { name: 'ログイン' }).click();
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
     // Form validation should prevent submission
     await expect(page).toHaveURL('/login');
   });

--- a/tests/e2e/email-verification.spec.ts
+++ b/tests/e2e/email-verification.spec.ts
@@ -156,7 +156,7 @@ test.describe('Email Verification Flow', () => {
     await page.waitForLoadState('networkidle');
     await page.getByLabel(/メールアドレス/).fill(uniqueEmail);
     await page.getByLabel(/パスワード/).fill(testPassword);
-    await page.getByRole('button', { name: /ログイン/ }).click();
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
 
     // Wait for response
     await page.waitForTimeout(1000);
@@ -180,7 +180,7 @@ test.describe('Email Verification Flow', () => {
     await page.waitForLoadState('networkidle');
     await page.getByLabel(/メールアドレス/).fill('test@example.com');
     await page.getByLabel(/パスワード/).fill('test1234');
-    await page.getByRole('button', { name: /ログイン/ }).click();
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
 
     // Wait for login to complete
     await page.waitForURL('/', { timeout: 10000 }).catch(() => {});
@@ -229,7 +229,7 @@ test.describe('Email Verification Flow', () => {
     await page.goto('/login');
     await page.getByLabel(/メールアドレス/).fill(uniqueEmail);
     await page.getByLabel(/パスワード/).fill(testPassword);
-    await page.getByRole('button', { name: /ログイン/ }).click();
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
 
     // 5. Should be logged in without verification banner
     await expect(page).toHaveURL('/dashboard');

--- a/tests/helpers/e2e.ts
+++ b/tests/helpers/e2e.ts
@@ -42,7 +42,7 @@ export async function loginAsTestUser(
   // Click login button and wait for navigation
   await Promise.all([
     page.waitForURL('/', { timeout: 15000 }),
-    page.getByRole('button', { name: /ログイン/i }).click(),
+    page.getByRole('button', { name: 'ログイン', exact: true }).click(),
   ]);
 
   // Wait for auth state to be updated

--- a/tests/integration/routes/auth/webauthn.test.ts
+++ b/tests/integration/routes/auth/webauthn.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration tests for WebAuthn / Passkey endpoints
+ *
+ * Tests:
+ * - POST /api/auth/webauthn/register/options (auth required)
+ * - POST /api/auth/webauthn/register/verify (auth required)
+ * - POST /api/auth/webauthn/authenticate/options (public)
+ * - POST /api/auth/webauthn/authenticate/verify (public)
+ * - GET  /api/auth/webauthn/credentials (auth required)
+ * - DELETE /api/auth/webauthn/credentials/:credentialId (auth required)
+ *
+ * Note: Full ceremony tests require a real authenticator/browser environment.
+ * These tests cover only the simple cases that don't require ceremony state.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+const API_BASE = 'http://localhost:8787';
+
+describe('WebAuthn / Passkey API Integration Tests', () => {
+  describe('POST /api/auth/webauthn/authenticate/options', () => {
+    it('returns 200 with valid PublicKeyCredentialRequestOptions shape', async () => {
+      const res = await fetch(`${API_BASE}/api/auth/webauthn/authenticate/options`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(typeof body['challenge']).toBe('string');
+      expect((body['challenge'] as string).length).toBeGreaterThan(0);
+      expect(typeof body['rpId']).toBe('string');
+      expect(Array.isArray(body['allowCredentials'])).toBe(true);
+    });
+  });
+
+  describe('GET /api/auth/webauthn/credentials', () => {
+    it('returns 401 without a valid session cookie', async () => {
+      const res = await fetch(`${API_BASE}/api/auth/webauthn/credentials`);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/webauthn/register/options', () => {
+    it('returns 401 without a valid session cookie', async () => {
+      const res = await fetch(`${API_BASE}/api/auth/webauthn/register/options`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/webauthn/register/verify', () => {
+    it('returns 401 without a valid session cookie', async () => {
+      const res = await fetch(`${API_BASE}/api/auth/webauthn/register/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response: {} }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/webauthn/authenticate/verify', () => {
+    it('rejects with 401 when the credential does not exist', async () => {
+      const res = await fetch(`${API_BASE}/api/auth/webauthn/authenticate/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          response: {
+            id: 'non-existent-credential-id',
+            rawId: 'non-existent-credential-id',
+            response: {},
+            type: 'public-key',
+            clientExtensionResults: {},
+          },
+        }),
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe('CREDENTIAL_NOT_FOUND');
+    });
+  });
+});

--- a/tests/unit/webauthn.service.test.ts
+++ b/tests/unit/webauthn.service.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  base64urlToUint8Array,
+  uint8ArrayToBase64url,
+} from '../../packages/backend/src/services/webauthn.service';
+
+describe('webauthn.service utilities', () => {
+  describe('base64url round-trip', () => {
+    it('roundtrips empty array', () => {
+      const empty = new Uint8Array([]);
+      expect(base64urlToUint8Array(uint8ArrayToBase64url(empty))).toEqual(empty);
+    });
+
+    it('roundtrips arbitrary bytes including 0xff/0x00 boundary values', () => {
+      const bytes = new Uint8Array([0, 1, 2, 254, 255, 127, 128]);
+      const encoded = uint8ArrayToBase64url(bytes);
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+      expect(encoded).not.toContain('=');
+      expect(base64urlToUint8Array(encoded)).toEqual(bytes);
+    });
+
+    it('handles values that require padding (length not multiple of 3)', () => {
+      const lengths = [1, 2, 4, 5, 7, 8];
+      for (const n of lengths) {
+        const bytes = new Uint8Array(n).map((_, i) => (i * 37) & 0xff);
+        expect(base64urlToUint8Array(uint8ArrayToBase64url(bytes))).toEqual(bytes);
+      }
+    });
+  });
+
+  describe('base64urlToUint8Array', () => {
+    it('decodes a base64url string with no padding', () => {
+      // "Man" -> base64 "TWFu" -> base64url "TWFu"
+      const decoded = base64urlToUint8Array('TWFu');
+      expect(Array.from(decoded)).toEqual([0x4d, 0x61, 0x6e]);
+    });
+
+    it('decodes a string using url-safe characters (- and _)', () => {
+      // Bytes 0xfb, 0xff produce base64 "+/8=" -> base64url "-_8"
+      const decoded = base64urlToUint8Array('-_8');
+      expect(Array.from(decoded)).toEqual([0xfb, 0xff]);
+    });
+  });
+});


### PR DESCRIPTION
## 背景

メール送信の用途を整理すると、現状は3つの認証フロー(新規登録時のメール認証 / パスワードリセット / メールアドレス変更)でのみ使用していた。Cloudflare Email Service への切り替えを検討したが、DNS 設定が回避できず Resend と比べて移行メリットが乏しい。

**そもそも認証経路を Passkey に切り替えれば、メール送信そのものが不要になる**ため、段階移行を開始。

## Phase 1 (本 PR)

- パスワード認証と Passkey 認証を**並走**
- 既存ユーザーはパスワードログイン後、設定画面で Passkey を追加 → 次回からパスキー利用
- リカバリ戦略は**複数端末登録依存**(PC+スマホ両方に登録、片方紛失時は他方から再追加)
- メール送信コードはそのまま残す(Phase 2 で一括削除)

## Phase 2 (将来 PR)

全ユーザーが Passkey 登録完了後、以下を一括削除:
- `services/email/`, `services/auth/password-reset.service.ts`
- email 関連ルートとテーブル
- `resend` 依存と `RESEND_API_KEY` secret
- `users.password_hash` を nullable 化

## 変更内容

### Backend
- `migrations/0030_passkey_webauthn.sql` — `passkey_credentials`, `webauthn_challenges` テーブル
- `services/webauthn.service.ts` — DB 操作 + base64url ユーティリティ
- `routes/auth/webauthn.ts` — 6 エンドポイント:
  - `POST /api/auth/webauthn/register/options` (認証要)
  - `POST /api/auth/webauthn/register/verify` (認証要)
  - `POST /api/auth/webauthn/authenticate/options` (公開)
  - `POST /api/auth/webauthn/authenticate/verify` (公開、セッション cookie 発行)
  - `GET /api/auth/webauthn/credentials` (認証要)
  - `DELETE /api/auth/webauthn/credentials/:credentialId` (認証要)
- `wrangler.toml` — 環境別 `RP_ID` / `RP_NAME` / `RP_ORIGIN`
- `cron/cleanup.ts` — 期限切れ challenge 掃除を追加

### Frontend
- `hooks/usePasskeyRegistration.ts` / `usePasskeyAuth.ts` — セレモニーフック
- `components/auth/PasskeyManagement.tsx` — 設定画面のパスキー管理カード
- `pages/Login.tsx` — 「パスキーでログイン」ボタン
- `pages/Settings.tsx` — `PasskeyManagement` を組み込み

### Shared
- `schemas/webauthn.ts` — Zod 検証スキーマ

### Tests
- `tests/unit/webauthn.service.test.ts` — base64url ユーティリティ
- `tests/integration/routes/auth/webauthn.test.ts` — 401 動作と options 形式

## 主要な設計判断

- **Challenge ストレージ**: D1 (KV ではなく)。検証時に即削除して replay 防止
- **usernameless 認証**: `allowCredentials: []` で discoverable credential フロー
- **`expectedChallenge` コールバック**: simplewebauthn の callback 形式で chal-userId 照合を1回で実施
- **削除ガード**: パスワード無し かつ 最後の1個のパスキーは削除拒否(Phase 1 は no-op、Phase 2 で発動)
- **CORS**: localhost:5174 を allow origins に追加(frontend dev port)

## Preview 環境のテスト手順

1. PR Preview は自動マイグレーションされないので手動適用:
   \`\`\`bash
   pnpm --filter @lifestyle-app/backend exec wrangler d1 migrations apply DB --env preview --remote
   \`\`\`
2. パスワードでログイン
3. 設定 → パスキー管理 → 名前入力 → 「パスキーを追加」
4. ブラウザの認証ダイアログで生体認証 / PIN
5. ログアウト → ログイン画面で「パスキーでログイン」
6. 別ブラウザ/端末でも追加できることを確認

## 検証済み

- [x] `pnpm typecheck` (全パッケージ)
- [x] `pnpm lint` (新規 0 errors)
- [x] `pnpm find-deadcode` (0 unused exports)
- [x] `pnpm test:unit` (213 passed / 5 new webauthn tests)
- [x] ローカル D1 migration 適用成功

## 残りの確認 (preview 環境)

- [ ] Passkey 登録セレモニー
- [ ] Passkey 認証セレモニー
- [ ] 複数端末登録 + 片方削除
- [ ] 並走: パスワードログインも引き続き動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)