### PR TITLE
fix: セッションCookieをHMAC-SHA256署名方式に変更しなりすましを防止 (#95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,12 @@ jobs:
           cd packages/backend
           echo "${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}" | pnpm exec wrangler secret put GOOGLE_GENERATIVE_AI_API_KEY --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
           echo "${{ secrets.RESEND_API_KEY }}" | pnpm exec wrangler secret put RESEND_API_KEY --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
-          echo "${{ secrets.SESSION_SECRET }}" | pnpm exec wrangler secret put SESSION_SECRET --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
+          # Optional: when the SESSION_SECRET repo secret is unset, the preview
+          # worker falls back to the dev key (non-production), so skip rather than
+          # push an empty secret.
+          if [ -n "${{ secrets.SESSION_SECRET }}" ]; then
+            echo "${{ secrets.SESSION_SECRET }}" | pnpm exec wrangler secret put SESSION_SECRET --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
+          fi
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,7 @@ jobs:
           cd packages/backend
           echo "${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}" | pnpm exec wrangler secret put GOOGLE_GENERATIVE_AI_API_KEY --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
           echo "${{ secrets.RESEND_API_KEY }}" | pnpm exec wrangler secret put RESEND_API_KEY --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
+          echo "${{ secrets.SESSION_SECRET }}" | pnpm exec wrangler secret put SESSION_SECRET --name lifestyle-tracker-pr-${{ github.event.pull_request.number }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/backend/.dev.vars.example
+++ b/packages/backend/.dev.vars.example
@@ -1,3 +1,8 @@
+# Marks this as a local dev run (cookies served over http, insecure session
+# fallback key allowed). Without this, wrangler dev inherits ENVIRONMENT from
+# [vars] (= "production"), which makes auth fail closed locally.
+ENVIRONMENT=development
+
 # AI Configuration
 # Get your API key from https://makersuite.google.com/app/apikey
 GOOGLE_GENERATIVE_AI_API_KEY=your-google-ai-api-key-here
@@ -5,3 +10,9 @@ GOOGLE_GENERATIVE_AI_API_KEY=your-google-ai-api-key-here
 # AI Provider settings
 AI_PROVIDER=google
 AI_MODEL=gemini-3-flash
+
+# Session signing key (HMAC-SHA256 for the `session` cookie). Optional locally:
+# non-production runs fall back to a shared insecure dev key. Set a real
+# high-entropy value here to mirror production. Production/preview MUST set this
+# as a real Workers Secret via `wrangler secret put SESSION_SECRET`.
+# SESSION_SECRET=replace-with-a-high-entropy-string

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -22,6 +22,7 @@ import { executeScheduledCleanup } from './cron/cleanup';
 type Bindings = {
   DB: D1Database;
   ENVIRONMENT: string;
+  SESSION_SECRET?: string;
   PHOTOS: R2Bucket;
   ASSETS: Fetcher;
   GOOGLE_GENERATIVE_AI_API_KEY?: string;

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -16,6 +16,148 @@ declare module 'hono' {
   }
 }
 
+interface SessionPayload {
+  userId: string;
+  exp: number;
+}
+
+/**
+ * Fallback signing key for dev / test / preview only. Production refuses to use
+ * it — a real high-entropy `SESSION_SECRET` Workers Secret must be configured
+ * there (see SETUP_SECRETS.md). This keeps local dev and CI working out of the
+ * box while guaranteeing production tokens are signed with a non-public key.
+ */
+const DEV_SESSION_SECRET = 'dev-only-insecure-session-secret-do-not-use-in-prod';
+
+/**
+ * Resolve the session signing secret from the Worker env. In production a real
+ * secret is mandatory (throws if missing, so auth fails closed rather than
+ * silently using a guessable key); elsewhere it falls back to a dev constant.
+ */
+export function resolveSessionSecret(env: {
+  SESSION_SECRET?: string;
+  ENVIRONMENT?: string;
+}): string {
+  if (env.SESSION_SECRET) {
+    return env.SESSION_SECRET;
+  }
+  if (env.ENVIRONMENT === 'production') {
+    throw new Error('SESSION_SECRET must be configured in production');
+  }
+  return DEV_SESSION_SECRET;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+// TextEncoder#encode is typed as Uint8Array<ArrayBufferLike>; WebCrypto wants
+// a BufferSource backed by a (non-shared) ArrayBuffer, so narrow the type here.
+function utf8(value: string): Uint8Array<ArrayBuffer> {
+  return encoder.encode(value) as Uint8Array<ArrayBuffer>;
+}
+
+function bytesToBase64url(bytes: ArrayBuffer | Uint8Array): string {
+  const arr = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = '';
+  for (const byte of arr) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBytes(value: string): Uint8Array<ArrayBuffer> {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    utf8(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+/**
+ * Create a signed session token of the form `<payload>.<signature>`,
+ * both base64url-encoded.
+ *
+ * The HMAC-SHA256 signature over the payload is what makes the token
+ * unforgeable: without `secret`, an attacker cannot mint a token for an
+ * arbitrary userId. (The previous implementation was a bare base64(JSON)
+ * with no signature, so any userId could be impersonated.)
+ */
+export async function createSessionToken(
+  userId: string,
+  secret: string,
+  expiresInMs = 7 * 24 * 60 * 60 * 1000
+): Promise<string> {
+  if (!secret) {
+    throw new Error('SESSION_SECRET is not configured');
+  }
+
+  const payload: SessionPayload = {
+    userId,
+    exp: Date.now() + expiresInMs,
+  };
+  const payloadB64 = bytesToBase64url(utf8(JSON.stringify(payload)));
+  const key = await importHmacKey(secret);
+  const signature = await crypto.subtle.sign('HMAC', key, utf8(payloadB64));
+
+  return `${payloadB64}.${bytesToBase64url(signature)}`;
+}
+
+/**
+ * Verify a signed session token. Returns the payload only when the signature
+ * is valid (verified in constant time by `crypto.subtle.verify`) and the
+ * token has not expired. Returns null for any tampering/format/expiry error.
+ */
+export async function verifySessionToken(
+  token: string,
+  secret: string
+): Promise<SessionPayload | null> {
+  if (!secret) {
+    return null;
+  }
+
+  const dotIndex = token.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === token.length - 1) {
+    return null;
+  }
+  const payloadB64 = token.slice(0, dotIndex);
+  const signatureB64 = token.slice(dotIndex + 1);
+
+  let signature: Uint8Array<ArrayBuffer>;
+  try {
+    signature = base64urlToBytes(signatureB64);
+  } catch {
+    return null;
+  }
+
+  const key = await importHmacKey(secret);
+  const valid = await crypto.subtle.verify('HMAC', key, signature, utf8(payloadB64));
+  if (!valid) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(decoder.decode(base64urlToBytes(payloadB64))) as SessionPayload;
+    if (!payload.userId || !payload.exp || payload.exp < Date.now()) {
+      return null;
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
 export async function authMiddleware(c: Context, next: Next) {
   const sessionId = getCookie(c, 'session');
 
@@ -23,37 +165,31 @@ export async function authMiddleware(c: Context, next: Next) {
     return c.json({ message: '認証が必要です' }, 401);
   }
 
-  // For simplicity, we use the session cookie as a JWT-like token
-  // In production, use proper session storage or JWT validation
+  let secret: string;
   try {
-    const payload = JSON.parse(atob(sessionId));
-
-    if (!payload.userId || !payload.exp || payload.exp < Date.now()) {
-      return c.json({ message: 'セッションが無効です' }, 401);
-    }
-
-    const db = c.get('db');
-    const user = await db
-      .select({ id: schema.users.id, email: schema.users.email })
-      .from(schema.users)
-      .where(eq(schema.users.id, payload.userId))
-      .get();
-
-    if (!user) {
-      return c.json({ message: 'ユーザーが見つかりません' }, 401);
-    }
-
-    c.set('user', user);
-    await next();
+    secret = resolveSessionSecret(c.env as { SESSION_SECRET?: string; ENVIRONMENT?: string });
   } catch {
+    // Misconfiguration (production without a secret): fail closed.
+    console.error('SESSION_SECRET is not configured; rejecting authenticated request');
     return c.json({ message: '認証に失敗しました' }, 401);
   }
-}
 
-export function createSessionToken(userId: string, expiresInMs = 7 * 24 * 60 * 60 * 1000): string {
-  const payload = {
-    userId,
-    exp: Date.now() + expiresInMs,
-  };
-  return btoa(JSON.stringify(payload));
+  const payload = await verifySessionToken(sessionId, secret);
+  if (!payload) {
+    return c.json({ message: 'セッションが無効です' }, 401);
+  }
+
+  const db = c.get('db');
+  const user = await db
+    .select({ id: schema.users.id, email: schema.users.email })
+    .from(schema.users)
+    .where(eq(schema.users.id, payload.userId))
+    .get();
+
+  if (!user) {
+    return c.json({ message: 'ユーザーが見つかりません' }, 401);
+  }
+
+  c.set('user', user);
+  await next();
 }

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -8,7 +8,7 @@ import {
   passwordResetConfirmSchema,
 } from '@lifestyle-app/shared';
 import { AuthService } from '../services/auth';
-import { createSessionToken, authMiddleware } from '../middleware/auth';
+import { createSessionToken, authMiddleware, resolveSessionSecret } from '../middleware/auth';
 import type { Database } from '../db';
 import {
   requestPasswordReset,
@@ -21,6 +21,7 @@ import { webauthn } from './auth/webauthn';
 type Bindings = {
   DB: D1Database;
   ENVIRONMENT: string;
+  SESSION_SECRET?: string;
   RESEND_API_KEY: string;
   FROM_EMAIL: string;
   FRONTEND_URL: string;
@@ -62,7 +63,7 @@ export const auth = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       );
     }
 
-    const token = createSessionToken(user.id);
+    const token = await createSessionToken(user.id, resolveSessionSecret(c.env));
 
     const isProduction = c.env.ENVIRONMENT === 'production';
     setCookie(c, 'session', token, {
@@ -81,7 +82,7 @@ export const auth = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     const authService = new AuthService(db);
 
     const user = await authService.login(input);
-    const token = createSessionToken(user.id);
+    const token = await createSessionToken(user.id, resolveSessionSecret(c.env));
 
     const isProduction = c.env.ENVIRONMENT === 'production';
     setCookie(c, 'session', token, {

--- a/packages/backend/src/routes/auth/webauthn.ts
+++ b/packages/backend/src/routes/auth/webauthn.ts
@@ -16,7 +16,7 @@ import {
   passkeyRegisterVerifySchema,
   passkeyAuthVerifySchema,
 } from '@lifestyle-app/shared';
-import { authMiddleware, createSessionToken } from '../../middleware/auth';
+import { authMiddleware, createSessionToken, resolveSessionSecret } from '../../middleware/auth';
 import { AppError } from '../../middleware/error';
 import type { Database } from '../../db';
 import {
@@ -35,6 +35,7 @@ import { AuthService } from '../../services/auth';
 type Bindings = {
   DB: D1Database;
   ENVIRONMENT: string;
+  SESSION_SECRET?: string;
   RP_ID: string;
   RP_NAME: string;
   RP_ORIGIN: string;
@@ -214,7 +215,7 @@ export const webauthn = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       const authService = new AuthService(db);
       const user = await authService.getUserById(credentialRow.userId);
 
-      const token = createSessionToken(user.id);
+      const token = await createSessionToken(user.id, resolveSessionSecret(c.env));
       const isProduction = c.env.ENVIRONMENT === 'production';
       setCookie(c, 'session', token, {
         httpOnly: true,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -3,6 +3,7 @@ import type { Database } from './db';
 export type Bindings = {
   DB: D1Database;
   ENVIRONMENT: string;
+  SESSION_SECRET?: string;
   // AI meal analysis
   PHOTOS: R2Bucket;
   GOOGLE_GENERATIVE_AI_API_KEY?: string;

--- a/specs/019-email-delivery/SETUP_SECRETS.md
+++ b/specs/019-email-delivery/SETUP_SECRETS.md
@@ -18,6 +18,39 @@
 
 ---
 
+## 🔑 SESSION_SECRET（セッションCookie署名鍵 / Issue #95）
+
+セッションCookieを HMAC-SHA256 で署名するための鍵。挙動は環境で異なる:
+
+- **Production（`ENVIRONMENT=production`）**: 未設定だと**全ての認証が fail-closed で失敗**する（推測可能な鍵を黙って使わないための設計）。→ デプロイ前に必ず設定。
+- **dev / test / preview**: 未設定なら共有の**insecureなdevフォールバック鍵**で動作する（ローカル・CIはそのまま動く）。preview は公開URLなので、フォールバックに頼らず実シークレットを設定することを推奨。
+
+| 環境 | 保存場所 | 対応 |
+|------|---------|------|
+| ローカル開発 / CI統合テスト | （未設定でOK＝devフォールバック） | ✅ 対応不要 |
+| Production（`lifestyle-tracker`） | Cloudflare Workers Secret | ⚠️ **デプロイ前に手動設定（必須・一度のみ）** |
+| Main Preview（`lifestyle-tracker-preview`） | Cloudflare Workers Secret | 🔸 推奨（未設定でも起動はする） |
+| PR Preview（動的Worker） | GitHub Secrets → CI自動設定 | `gh secret set SESSION_SECRET` を一度実行 |
+
+### 設定手順（本番デプロイ前に必須）
+
+```bash
+# 1. 強い鍵を生成
+openssl rand -base64 48
+
+# 2. Production と Main Preview の Worker に設定（生成値を貼り付け）
+cd packages/backend
+pnpm exec wrangler secret put SESSION_SECRET             # production (lifestyle-tracker)
+pnpm exec wrangler secret put SESSION_SECRET --env preview  # main preview
+
+# 3. PR Preview を使う場合は GitHub Secrets にも追加
+gh secret set SESSION_SECRET    # プロンプトに同じ値（または別の値）を貼り付け
+```
+
+> 既存ユーザーの旧形式（署名なし）Cookieは検証に失敗し401になるため、初回は再ログインが必要。
+
+---
+
 ## 🔐 環境変数の3層管理
 
 ```

--- a/tests/unit/session-token.test.ts
+++ b/tests/unit/session-token.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createSessionToken,
+  verifySessionToken,
+  resolveSessionSecret,
+} from '../../packages/backend/src/middleware/auth';
+
+const SECRET = 'unit-test-session-secret';
+const OTHER_SECRET = 'a-different-secret';
+const USER_ID = 'user-123';
+
+describe('session token (HMAC-signed)', () => {
+  it('round-trips a valid token', async () => {
+    const token = await createSessionToken(USER_ID, SECRET);
+    const payload = await verifySessionToken(token, SECRET);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.userId).toBe(USER_ID);
+    expect(payload?.exp).toBeGreaterThan(Date.now());
+  });
+
+  it('produces a two-part `<payload>.<signature>` token', async () => {
+    const token = await createSessionToken(USER_ID, SECRET);
+    expect(token.split('.')).toHaveLength(2);
+  });
+
+  // The core vulnerability (issue #95): the old format was a bare base64(JSON)
+  // with no signature, so anyone could mint a token for an arbitrary userId.
+  it('rejects a forged unsigned token (old base64-JSON format)', async () => {
+    const forged = btoa(JSON.stringify({ userId: 'victim', exp: Date.now() + 100000 }));
+    expect(await verifySessionToken(forged, SECRET)).toBeNull();
+  });
+
+  it('rejects a token whose payload was tampered without re-signing', async () => {
+    const token = await createSessionToken(USER_ID, SECRET);
+    const [, signature] = token.split('.');
+    const forgedPayload = btoa(JSON.stringify({ userId: 'victim', exp: Date.now() + 100000 }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const tampered = `${forgedPayload}.${signature}`;
+
+    expect(await verifySessionToken(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a token whose signature was tampered', async () => {
+    const token = await createSessionToken(USER_ID, SECRET);
+    const [payload] = token.split('.');
+    const tampered = `${payload}.AAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+
+    expect(await verifySessionToken(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a token signed with a different secret', async () => {
+    const token = await createSessionToken(USER_ID, OTHER_SECRET);
+    expect(await verifySessionToken(token, SECRET)).toBeNull();
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await createSessionToken(USER_ID, SECRET, -1000);
+    expect(await verifySessionToken(token, SECRET)).toBeNull();
+  });
+
+  it('rejects malformed tokens', async () => {
+    expect(await verifySessionToken('', SECRET)).toBeNull();
+    expect(await verifySessionToken('no-dot-here', SECRET)).toBeNull();
+    expect(await verifySessionToken('.onlysig', SECRET)).toBeNull();
+    expect(await verifySessionToken('onlypayload.', SECRET)).toBeNull();
+    expect(await verifySessionToken('not!base64.sig', SECRET)).toBeNull();
+  });
+
+  it('refuses to sign without a secret and never verifies one', async () => {
+    await expect(createSessionToken(USER_ID, '')).rejects.toThrow();
+    const token = await createSessionToken(USER_ID, SECRET);
+    expect(await verifySessionToken(token, '')).toBeNull();
+  });
+});
+
+describe('resolveSessionSecret', () => {
+  it('uses the configured secret when present (any environment)', () => {
+    expect(resolveSessionSecret({ SESSION_SECRET: 'real', ENVIRONMENT: 'production' })).toBe('real');
+    expect(resolveSessionSecret({ SESSION_SECRET: 'real', ENVIRONMENT: 'development' })).toBe('real');
+  });
+
+  it('falls back to a dev key in non-production when unset', () => {
+    const devSecret = resolveSessionSecret({ ENVIRONMENT: 'development' });
+    expect(devSecret).toBeTruthy();
+    // preview/test behave the same
+    expect(resolveSessionSecret({ ENVIRONMENT: 'preview' })).toBe(devSecret);
+    expect(resolveSessionSecret({ ENVIRONMENT: 'test' })).toBe(devSecret);
+  });
+
+  it('fails closed in production when the secret is missing', () => {
+    expect(() => resolveSessionSecret({ ENVIRONMENT: 'production' })).toThrow();
+  });
+});


### PR DESCRIPTION
## 概要
セッションCookieが署名なしの `btoa(JSON.stringify({userId, exp}))` だったため、**被害者の userId を知る攻撃者が任意ユーザーになりすませた**（認証バイパス → `WHERE user_id = ...` による全テナント分離の無効化）。WebCrypto の HMAC-SHA256 で署名・検証する方式に変更する。

Closes #95

## 脆弱性（Before → After）
| | Before | After |
|---|---|---|
| トークン | `base64(JSON)`（署名なし） | `base64url(payload).base64url(HMAC-SHA256)` |
| 検証 | `userId`/`exp` を見るだけ | `crypto.subtle.verify` で署名を定数時間検証してから `exp` 判定 |
| 偽造 | 任意 userId で可能 | 署名鍵なしでは不可（旧形式は 401） |

## 変更点
- `middleware/auth.ts`: `createSessionToken` / `verifySessionToken` を署名付きに置換。`authMiddleware` は署名検証を必須化。
- `resolveSessionSecret(env)` を追加: **本番（`ENVIRONMENT=production`）は実シークレット必須＝未設定なら fail-closed**、dev/test/preview は共有の insecure な dev フォールバック鍵で動作（ローカル・CI はそのまま動く）。
- `SESSION_SECRET` を各 Bindings 型に追加。
- テスト追加 `tests/unit/session-token.test.ts`（署名往復／旧形式偽造拒否／payload改竄拒否／署名改竄拒否／誤鍵拒否／期限切れ拒否／フォールバック挙動、計12件）。
- CI(PR Preview) の secret 設定に `SESSION_SECRET` を追加、`SETUP_SECRETS.md` / `.dev.vars.example` に手順を追記。

## ⚠️ マージ/デプロイ前に必要な運用作業（オーナー対応）
本番は未設定だと認証が全失敗（fail-closed）になるため、**デプロイ前に**シークレットを設定してください:

```bash
openssl rand -base64 48   # 強い鍵を生成

cd packages/backend
pnpm exec wrangler secret put SESSION_SECRET                # production (lifestyle-tracker) 必須
pnpm exec wrangler secret put SESSION_SECRET --env preview  # main preview 推奨

gh secret set SESSION_SECRET   # PR Preview を使う場合（CIが動的Workerに注入）
```

> 既存ユーザーの旧形式Cookieは検証失敗で401になるため、初回は再ログインが必要です。

## 検証
- ✅ `pnpm typecheck` / `pnpm lint`（0 errors）/ unit 12件パス
- ✅ ローカルE2E（`ENVIRONMENT=test`）:
  - 正規ログイン → `/api/auth/me` **200**（署名付きCookie発行を確認）
  - 実在 userId で偽造した旧形式トークン → **401**
  - 署名改竄トークン → **401** / Cookie なし → **401**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
