### PR TITLE
fix: 本番DBへのE2Eテストユーザー常設投入を停止し削除 (#96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           cd packages/backend
           pnpm exec wrangler d1 migrations apply DB --local
 
+      - name: Seed local test user (local DB only — never preview/production)
+        run: |
+          cd packages/backend
+          pnpm exec wrangler d1 execute DB --local --file seed/test-user.local.sql
+
       - name: Start backend server
         run: |
           cd packages/backend
@@ -157,6 +162,11 @@ jobs:
         run: |
           cd packages/backend
           pnpm exec wrangler d1 migrations apply DB --local
+
+      - name: Seed local test user (local DB only — never preview/production)
+        run: |
+          cd packages/backend
+          pnpm exec wrangler d1 execute DB --local --file seed/test-user.local.sql
 
       - name: Start backend server
         run: |

--- a/packages/backend/migrations/0032_remove_e2e_test_user.sql
+++ b/packages/backend/migrations/0032_remove_e2e_test_user.sql
@@ -1,0 +1,22 @@
+-- Migration 0032: 本番DBから E2E テストユーザー (test@example.com) を恒久削除する
+--
+-- 背景 (Issue #96):
+--   migration 0028 が環境ガード無しで test@example.com / password=test1234 という
+--   既知クレデンシャルのアカウントを INSERT しており、CI の本番デプロイ
+--   (`wrangler d1 migrations apply DB --remote`, .github/workflows/ci.yml) が
+--   本番(health-tracker-db)にも適用していた。結果として公開URLの本番に
+--   「誰でもログインできる email_verified 済みアカウント」が常設されていた。
+--
+-- 方針:
+--   テストユーザーはマイグレーションでは投入せず、テスト実行時にのみ用意する。
+--     - E2E : tests/setup/e2e-global-setup.ts がローカル miniflare D1 へ直接 seed
+--     - 統合: tests/integration/meals.test.ts が ensureTestUser() で register API 経由で作成
+--   よって全環境から削除しても local/CI/preview のテストは実行時に自前で
+--   再プロビジョニングされ、本番には二度と再投入されない。
+--   (0028 は適用済み履歴のため残置し、本マイグレーションで効果を打ち消す)
+--
+-- 注意:
+--   users への各 FK は ON DELETE CASCADE のため、当該ユーザーに紐づく記録
+--   (weight/meal/exercise 等) も連鎖削除される。テストアカウントのため問題なし。
+
+DELETE FROM users WHERE email = 'test@example.com';

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "wrangler d1 migrations apply health-tracker-db",
-    "db:migrate:local": "wrangler d1 migrations apply health-tracker-db --local"
+    "db:migrate:local": "wrangler d1 migrations apply health-tracker-db --local",
+    "db:seed:local": "wrangler d1 execute health-tracker-db --local --file seed/test-user.local.sql"
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.2",

--- a/packages/backend/seed/test-user.local.sql
+++ b/packages/backend/seed/test-user.local.sql
@@ -1,0 +1,25 @@
+-- Local / CI-only seed: E2E/統合テスト用ユーザー (test@example.com / test1234)
+--
+-- Issue #96: 以前は migration 0028 がこのユーザーを INSERT していたが、
+-- マイグレーションは本番(health-tracker-db)にも適用されるため、既知クレデンシャルの
+-- アカウントが本番に常設されていた。0032 で全環境から削除し、テストユーザーは
+-- 「ローカル D1 にのみ」適用するこの seed で供給する方式へ移行した。
+--
+-- 適用先は wrangler d1 execute --local のみ（.github/workflows/ci.yml の E2E ジョブ /
+-- ローカル開発の `pnpm db:seed:local`）。preview / production には決して適用しない。
+--
+-- CI の Playwright は globalSetup を無効化しているため(playwright.config.ts)、
+-- E2E のテストユーザーはこの seed が唯一の供給元になる。
+
+DELETE FROM users WHERE email = 'test@example.com';
+
+INSERT INTO users (id, email, password_hash, created_at, updated_at, email_verified, goal_calories)
+VALUES (
+  'e2e-test-user-00000000-0000-0000-0000-000000000001',
+  'test@example.com',
+  '$2a$10$8H6bb2j4r7FsSTvZmOxMmeGLA8yWqnr/zGnCaqdQBqGxHRymX510.',
+  datetime('now'),
+  datetime('now'),
+  1,
+  2000
+);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,11 +10,14 @@ export default defineConfig({
   workers: isCI ? 2 : undefined,
   reporter: isCI ? 'list' : 'html',
   timeout: 30000,
-  // Global setup ensures test user is properly configured before tests run
-  // In CI, we rely on migrations alone since they run on a fresh database
-  // Locally, global setup helps fix stale test user data
-  // Before running E2E tests locally, ensure migrations are applied:
+  // Global setup ensures the test user is configured before tests run.
+  // In CI, the test user is seeded into the local D1 by a dedicated workflow
+  // step (`db:seed:local`, see .github/workflows/ci.yml) — NOT by migrations,
+  // so the known-credential account never reaches preview/production (#96).
+  // Locally, global setup helps fix stale test user data. Before running E2E
+  // tests locally, apply migrations and seed:
   //   pnpm --filter @lifestyle-app/backend db:migrate:local
+  //   pnpm --filter @lifestyle-app/backend db:seed:local
   globalSetup: isCI ? undefined : './tests/setup/e2e-global-setup.ts',
   use: {
     baseURL: isCI ? 'http://localhost:4174' : 'http://localhost:5174',


### PR DESCRIPTION
## 概要
migration `0028_add_e2e_test_user.sql` が**環境ガード無し**で `test@example.com` / password=`test1234`（`email_verified=1`）を INSERT しており、CIの本番デプロイ（`wrangler d1 migrations apply DB --remote`）が**本番DBにも適用**していた。結果として公開URLの本番に「誰でもログインできるアカウント」が常設されていた。

Closes #96

## 根本原因と設計
- 本番に `test@example.com` が実在（`d1_migrations` 上で 0028 は 2026-01-31 本番適用済み）。
- **テストユーザーの実供給元は migration 0028 だった**。`playwright.config.ts` は CI で `globalSetup` を無効化しており（"In CI, we rely on migrations alone"）、E2Eのテストユーザーは 0028 に依存していた。統合テストは `ensureTestUser`(register API) で自前供給。
- そのため「マイグレーションでの投入をやめ、本番から削除」しつつ、**テストユーザーは local D1 限定の seed で供給**する設計に変更した。

## 変更
1. **`migrations/0032_remove_e2e_test_user.sql`**: `DELETE FROM users WHERE email='test@example.com'`。全環境に適用され、本番から恒久削除（再投入されない）。FK は CASCADE。
2. **`packages/backend/seed/test-user.local.sql`** + **`db:seed:local`** スクリプト追加: テストユーザーを **local D1 のみ**に投入（preview/production には絶対適用しない）。
3. **CI(`.github/workflows/ci.yml`)**: 統合・E2E 両ジョブで `migrations apply --local` 直後に seed ステップを実行。本番デプロイ経路には seed を置かない。
4. `playwright.config.ts` のコメントを実態に更新。

## 検証
- ✅ `db:seed:local` → `test@example.com`(fixed-id/`email_verified=1`/test1234) 作成 → backend に `login` 200
- ✅ `migrations apply --local` で 0032 が `test@example.com` を 1→0 件
- ✅ `meals.test.ts` 統合テスト 24/25 pass（再プロビジョン経由）
- ✅ **CI 全ジョブ green（Unit & Integration / E2E / Lint&Type / Build / Deploy PR Preview）**
- ✅ `pnpm typecheck` / `pnpm lint`(0 error) 通過

## 補足（オーナー対応）
- 本PRをデプロイ（`v*`タグ）すると 0032 が本番適用され、本番の `test@example.com` が削除されます。**それより早く消したい場合**は手動削除も可能（別途確認のうえ実行）。
- 0028 の bcrypt ハッシュ（`test1234`）は履歴に残ります。同じパスワードを他のテストアカウントで使っている場合はローテーション推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
