### PR TITLE
fix: 食事写真配信の無認証IDORを修正（認証必須化＋所有者照合） (#97)

### DIFF
--- a/packages/backend/migrations/0033_add_meal_photos_photo_key_index.sql
+++ b/packages/backend/migrations/0033_add_meal_photos_photo_key_index.sql
@@ -1,0 +1,4 @@
+-- #97: photo serving now verifies ownership by looking up meal_photos.photo_key
+-- on every image request (join to meal_records.user_id). Add an index on
+-- photo_key so that per-request lookup does not scan the table.
+CREATE INDEX IF NOT EXISTS idx_meal_photos_photo_key ON meal_photos(photo_key);

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -70,6 +70,9 @@ export const mealPhotos = sqliteTable(
   },
   (table) => ({
     idx_meal_photos_meal: index('idx_meal_photos_meal').on(table.mealId, table.displayOrder),
+    // Photo serving verifies ownership by looking up photo_key on every image
+    // request (#97); index it so that lookup stays O(log n).
+    idx_meal_photos_photo_key: index('idx_meal_photos_photo_key').on(table.photoKey),
   })
 );
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -15,7 +15,6 @@ import { mealAnalysis } from './routes/meal-analysis';
 import { mealChat } from './routes/meal-chat';
 import { emailVerify } from './routes/email/verify';
 import { emailChange } from './routes/email/change';
-import { PhotoStorageService } from './services/photo-storage';
 import { requestContext } from './middleware/requestContext';
 import { executeScheduledCleanup } from './cron/cleanup';
 
@@ -112,24 +111,9 @@ app.get('/api/health', (c) => {
   });
 });
 
-// Photo serving - no auth required (keys are unguessable UUIDs)
-app.get('/api/meals/photos/*', async (c) => {
-  const key = c.req.path.replace('/api/meals/photos/', '');
-  const decodedKey = decodeURIComponent(key);
-  const photoStorage = new PhotoStorageService(c.env.PHOTOS);
-
-  const result = await photoStorage.getPhotoForServing(decodedKey);
-  if (!result) {
-    return c.json({ error: 'not_found', message: '写真が見つかりません' }, 404);
-  }
-
-  return new Response(result.body, {
-    headers: {
-      'Content-Type': result.contentType,
-      'Cache-Control': 'public, max-age=31536000',
-    },
-  });
-});
+// Photo serving is handled by the meal-analysis router (`/api/meals/photos/*`),
+// behind authMiddleware with an owner check. It used to be duplicated here
+// without auth, which let it shadow the secured handler — removed for #97.
 
 // Routes - chain format for RPC type inference
 const routes = app

--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -36,13 +36,42 @@ type Variables = {
 
 export const mealAnalysis = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-// Photo serving (no auth required - photo keys are unguessable)
-// Use wildcard to capture keys with slashes (e.g., temp/uuid)
+// All meal-analysis routes require authentication — including photo serving.
+// Photos were previously served with no auth and no owner check, so any leaked
+// key (DB value, client response, log, Referer) let anyone view another user's
+// meal photo (IDOR, #97). The session cookie is httpOnly + same-origin
+// (SameSite=Lax), so <img> requests still carry it and image display is
+// unaffected by requiring auth here.
+mealAnalysis.use('*', authMiddleware);
+
+// GET /api/meals/photos/* - Serve a meal photo to its owner only.
+// The wildcard captures keys whose slashes the client percent-encodes.
 mealAnalysis.get('/photos/*', async (c) => {
+  const userId = c.get('user').id;
+  const db = c.get('db');
+
   const key = c.req.path.replace('/api/meals/photos/', '');
   const decodedKey = decodeURIComponent(key);
-  const photoStorage = new PhotoStorageService(c.env.PHOTOS);
 
+  // Ownership check: the requested key must belong to a photo on one of the
+  // caller's meals. meal_photos always stores the currently-served key (a
+  // temp/<uuid> key during the analysis review flow, a photos/<userId>/... key
+  // after save), linked via meal_id to meal_records.user_id — so this single
+  // lookup covers both temp and permanent keys without trusting the key format.
+  const owner = await db
+    .select({ userId: mealRecords.userId })
+    .from(mealPhotos)
+    .innerJoin(mealRecords, eq(mealPhotos.mealId, mealRecords.id))
+    .where(eq(mealPhotos.photoKey, decodedKey))
+    .get();
+
+  // Use the same 404 for "missing" and "not yours" so the response never
+  // reveals whether a key exists for a different user.
+  if (!owner || owner.userId !== userId) {
+    return c.json({ error: 'not_found', message: '写真が見つかりません' }, 404);
+  }
+
+  const photoStorage = new PhotoStorageService(c.env.PHOTOS);
   const result = await photoStorage.getPhotoForServing(decodedKey);
   if (!result) {
     return c.json({ error: 'not_found', message: '写真が見つかりません' }, 404);
@@ -51,20 +80,11 @@ mealAnalysis.get('/photos/*', async (c) => {
   return new Response(result.body, {
     headers: {
       'Content-Type': result.contentType,
-      'Cache-Control': 'public, max-age=31536000',
+      // Per-user private content: keep it out of shared/CDN caches. A short
+      // browser cache still avoids re-fetching within a viewing session.
+      'Cache-Control': 'private, max-age=3600',
     },
   });
-});
-
-// Auth middleware - exclude photo serving endpoint
-mealAnalysis.use('*', async (c, next) => {
-  // Skip auth for photo serving (keys are unguessable UUIDs)
-  // c.req.path in subrouter is relative, c.req.url has full path
-  const url = new URL(c.req.url);
-  if (url.pathname.startsWith('/api/meals/photos/')) {
-    return next();
-  }
-  return authMiddleware(c, next);
 });
 
 // POST /api/meals/analyze - Analyze meal photo

--- a/tests/integration/meal-analysis.test.ts
+++ b/tests/integration/meal-analysis.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  createTestSession,
+  ensureTestUser,
+  TEST_USERS,
+  API_BASE,
+  type TestSession,
+} from '../helpers/integration';
 
 /**
  * Integration tests for AI Meal Analysis API
@@ -13,7 +20,7 @@ import { describe, it, expect } from 'vitest';
  */
 
 describe('Meal Analysis API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
+  // API_BASE is imported from the helper (honors TEST_API_BASE).
 
   // Test data placeholders - actual implementation requires test fixtures
   // and proper authentication setup
@@ -198,23 +205,72 @@ describe('Meal Analysis API Integration Tests', () => {
     });
   });
 
-  describe('GET /api/photos/:key', () => {
-    it('should serve photo with correct content type', async () => {
-      // Expected: image/jpeg or image/png with Cache-Control header
-      expect(true).toBe(true);
+  // #97: photo serving now requires authentication AND owner verification.
+  // A leaked key must not expose another user's meal photo (IDOR).
+  describe('GET /api/meals/photos/* (auth + ownership)', () => {
+    // Minimal JPEG header bytes — enough for an image/* upload (no AI involved
+    // via the legacy single-photo endpoint).
+    const JPEG_BYTES = new Uint8Array([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+    ]);
+
+    let owner: TestSession;
+    let other: TestSession;
+    let photoKey: string;
+    let photoPath: string;
+
+    beforeAll(async () => {
+      await ensureTestUser(TEST_USERS.default.email, TEST_USERS.default.password);
+      await ensureTestUser(TEST_USERS.secondary.email, TEST_USERS.secondary.password);
+
+      owner = createTestSession();
+      await owner.login(TEST_USERS.default.email, TEST_USERS.default.password);
+      other = createTestSession();
+      await other.login(TEST_USERS.secondary.email, TEST_USERS.secondary.password);
+
+      // Create an empty meal and attach a photo (permanent key) as the owner.
+      const createRes = await owner.request('/api/meals/create-empty', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mealType: 'lunch' }),
+      });
+      expect(createRes.status).toBe(200);
+      const { mealId } = (await createRes.json()) as { mealId: string };
+
+      const form = new FormData();
+      form.append('photo', new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'p.jpg');
+      const upRes = await owner.request(`/api/meals/${mealId}/photo`, {
+        method: 'POST',
+        body: form,
+      });
+      expect(upRes.status).toBe(200);
+      const upData = (await upRes.json()) as { photoKey: string };
+      photoKey = upData.photoKey;
+      photoPath = `/api/meals/photos/${encodeURIComponent(photoKey)}`;
     });
 
-    it('should return 404 for non-existent photo', async () => {
-      expect(true).toBe(true);
+    it('serves the photo to its owner (200, image/*, private cache)', async () => {
+      const res = await owner.request(photoPath);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/^image\//);
+      expect(res.headers.get('cache-control') ?? '').toContain('private');
     });
 
-    it('should not require authentication (photo keys are unguessable)', async () => {
-      expect(true).toBe(true);
+    it('rejects unauthenticated requests (401)', async () => {
+      const res = await fetch(`${API_BASE}${photoPath}`);
+      expect(res.status).toBe(401);
     });
 
-    it('should not serve temp photos (security)', async () => {
-      // GET /api/photos/temp/xxx should return 404
-      expect(true).toBe(true);
+    it("does not serve another user's photo — 404 hides existence (IDOR)", async () => {
+      const res = await other.request(photoPath);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a non-existent key (authenticated)', async () => {
+      const res = await owner.request(
+        `/api/meals/photos/${encodeURIComponent('photos/nobody/none/none.jpg')}`
+      );
+      expect(res.status).toBe(404);
     });
   });
 });


### PR DESCRIPTION
## 概要

食事写真配信エンドポイント `GET /api/meals/photos/*` が**認証スキップ＋所有者照合なし**で R2 オブジェクトをそのまま返していた（IDOR）。キー形式は `photos/{userId}/{mealId}/{photoId}.jpg`（秘匿成分は nanoid のみ）で、キーが漏れれば**他人の食事写真（PII）を恒久的に閲覧可能**だった。さらに同一の無認証ハンドラが `index.ts` と `meal-analysis.ts` に**重複**しており、登録順で `index.ts` 側が先にヒットしていた。

Closes #97

## 根本原因

- `index.ts` に `app.get('/api/meals/photos/*', …)` が**無認証**で存在し、`meal-analysis.ts` のサブルーター側ハンドラを shadow していた。
- どちらも `Cache-Control: public, max-age=31536000`（CDN/共有キャッシュに保存されうる）。
- 他APIは `user_id` で分離しているのに、写真だけ security-by-obscurity の抜け穴になっていた。

## 変更

1. **重複ハンドラを1本化**: `index.ts` の無認証ハンドラを削除し、配信を `meal-analysis.ts` の `/photos/*` に集約（未使用になった `PhotoStorageService` import も削除）。
2. **認証必須化**: `meal-analysis.use('*', authMiddleware)` を写真ルートにも適用。セッションCookieはhttpOnly＋同一オリジン（本番/preview）かつ `SameSite=Lax`（ローカルは同一サイト）なので、`<img>` でもCookieが送られ**画像表示は壊れない**。
3. **所有者照合**: 要求キーを `meal_photos.photo_key` で引き、`meal_records.user_id` が認証ユーザーと一致する場合のみ配信。`temp/<uuid>`（レビュー中）も `photos/<userId>/…`（保存後）も meal_photos に現行キーが保持されるため、**1クエリで両対応**（キー形式を信用しない）。未所有/不存在は同一の **404** で存在を秘匿。
4. **キャッシュ降格**: `public, max-age=31536000` → `private, max-age=3600`（共有/CDNキャッシュ禁止・短縮）。
5. **インデックス追加**: 配信のたびに `photo_key` 照合が走るため `idx_meal_photos_photo_key` を追加（`schema.ts` + migration `0033`）。

## 検証

- ✅ **統合テスト（実バックエンド + R2 + D1）**: `GET /api/meals/photos/*` 所有者照合
  - owner → `200` / `image/*` / `Cache-Control: private`（画像表示維持を実証）
  - 無認証 → `401`
  - 他ユーザー → `404`（IDOR封鎖・存在秘匿）
  - 不存在キー → `404`
  - → `meal-analysis.test.ts` 36 tests passed
- ✅ 配信バイトを返す経路は `meal-analysis.ts` の保護済みハンドラ1本のみ（`meals.ts`/`meal-chat.ts` はURL文字列生成のみで同一エンドポイントを指す）
- ✅ `pnpm typecheck` / `pnpm lint`（0 error）/ `pnpm test:unit`（225 passed）/ `pnpm find-deadcode`（0件）

## 補足

- ⚠ PR Previewではマイグレーションが自動適用されないため、`0033`（インデックス）はpreviewには未反映。機能はインデックス無しでも正常動作（照合クエリが走るのみ）。本番デプロイ時に適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
