### PR TITLE
fix: トークンをDBにハッシュ保存（平文保存をやめ漏洩時のreplayを防止） (#98)

### DIFF
--- a/packages/backend/migrations/0034_purge_plaintext_tokens.sql
+++ b/packages/backend/migrations/0034_purge_plaintext_tokens.sql
@@ -1,0 +1,11 @@
+-- #98: password-reset / email-verification / email-change tokens are now stored
+-- as SHA-256 hashes instead of the raw value. Rows written before this deploy
+-- still hold the RAW (plaintext) token and can no longer be verified (the
+-- verifier hashes the submitted token and looks up by hash). Delete the
+-- still-pending (unconsumed) ones so that no replayable plaintext token lingers
+-- at rest after the cutover. Users with an in-flight link simply re-request.
+-- Already-consumed rows are left untouched (their one-time-use guard makes them
+-- non-replayable, and they age out via the scheduled cleanup).
+DELETE FROM password_reset_tokens WHERE used_at IS NULL;
+DELETE FROM email_verification_tokens WHERE used_at IS NULL;
+DELETE FROM email_change_requests WHERE confirmed_at IS NULL AND cancelled_at IS NULL;

--- a/packages/backend/src/services/auth/password-reset.service.ts
+++ b/packages/backend/src/services/auth/password-reset.service.ts
@@ -12,7 +12,7 @@ import type { D1Database } from '@cloudflare/workers-types';
 import { eq, and, isNull, gt } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../../db/schema';
-import { generateSecureToken } from '../token/crypto';
+import { generateSecureToken, hashToken } from '../token/crypto';
 import { sendEmail } from '../email/email.service';
 import { generatePasswordResetEmail } from '../email/templates/password-reset';
 import {
@@ -77,21 +77,23 @@ export async function requestPasswordReset(
   }
 
   try {
-    // Generate secure token
+    // Generate secure token. Only its SHA-256 hash is stored; the raw token
+    // goes in the email link (#98).
     const token = await generateSecureToken();
+    const tokenHash = await hashToken(token);
     const now = Date.now();
     const expiresAt = now + PASSWORD_RESET_TOKEN_EXPIRATION_MS;
 
-    // Save token to database
+    // Save token hash to database
     await orm.insert(schema.passwordResetTokens).values({
       userId: user.id,
-      token,
+      token: tokenHash,
       expiresAt,
       usedAt: null,
       createdAt: now,
     });
 
-    // Generate reset URL
+    // Generate reset URL (carries the raw token)
     const resetUrl = `${frontendUrl}/reset-password?token=${token}`;
 
     // Send email
@@ -145,10 +147,13 @@ export async function confirmPasswordReset(
   const now = Date.now();
 
   try {
+    // Look up by the token's hash (raw token is never stored).
+    const tokenHash = await hashToken(token);
+
     // Find valid token (not used, not expired)
     const tokenRecord = await orm.query.passwordResetTokens.findFirst({
       where: and(
-        eq(schema.passwordResetTokens.token, token),
+        eq(schema.passwordResetTokens.token, tokenHash),
         isNull(schema.passwordResetTokens.usedAt),
         gt(schema.passwordResetTokens.expiresAt, now)
       ),

--- a/packages/backend/src/services/email/email-change.service.ts
+++ b/packages/backend/src/services/email/email-change.service.ts
@@ -11,7 +11,7 @@ import { drizzle } from 'drizzle-orm/d1';
 import { eq, and, isNull } from 'drizzle-orm';
 import * as schema from '../../db/schema/email';
 import { users } from '../../db/schema';
-import { generateSecureToken } from '../token/crypto';
+import { generateSecureToken, hashToken } from '../token/crypto';
 import { sendEmail } from './email.service';
 import {
   generateEmailChangeConfirmationEmail,
@@ -71,23 +71,26 @@ export async function requestEmailChange(
       };
     }
 
+    // Only the token's SHA-256 hash is stored; the raw token goes in the email
+    // links (#98).
     const token = await generateSecureToken();
+    const tokenHash = await hashToken(token);
     const now = Date.now();
     const expiresAt = now + EMAIL_CHANGE_TOKEN_EXPIRATION_MS;
 
-    // Create email change request
+    // Create email change request (stores the token hash)
     await orm.insert(schema.emailChangeRequests).values({
       userId,
       oldEmail,
       newEmail,
-      token,
+      token: tokenHash,
       expiresAt,
       confirmedAt: null,
       cancelledAt: null,
       createdAt: now,
     });
 
-    // Send confirmation email to NEW address
+    // Send confirmation email to NEW address (carries the raw token)
     const confirmationUrl = `${frontendUrl}/change-email/confirm?token=${token}`;
     const confirmationResult = await sendEmail(db, resendApiKey, fromEmail, {
       to: newEmail,
@@ -150,11 +153,12 @@ export async function confirmEmailChange(
   const orm = drizzle(db, { schema });
 
   try {
-    // Find the email change request
+    // Look up by the token's hash (raw token is never stored).
+    const tokenHash = await hashToken(token);
     const request = await orm
       .select()
       .from(schema.emailChangeRequests)
-      .where(eq(schema.emailChangeRequests.token, token))
+      .where(eq(schema.emailChangeRequests.token, tokenHash))
       .get();
 
     if (!request) {
@@ -227,11 +231,12 @@ export async function cancelEmailChange(
   const orm = drizzle(db, { schema });
 
   try {
-    // Find the email change request
+    // Look up by the token's hash (raw token is never stored).
+    const tokenHash = await hashToken(token);
     const request = await orm
       .select()
       .from(schema.emailChangeRequests)
-      .where(eq(schema.emailChangeRequests.token, token))
+      .where(eq(schema.emailChangeRequests.token, tokenHash))
       .get();
 
     if (!request) {

--- a/packages/backend/src/services/email/email-verification.service.ts
+++ b/packages/backend/src/services/email/email-verification.service.ts
@@ -14,7 +14,7 @@ import type { D1Database } from '@cloudflare/workers-types';
 import { eq, and, isNull, gt } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../../db/schema';
-import { generateSecureToken } from '../token/crypto';
+import { generateSecureToken, hashToken } from '../token/crypto';
 import { sendEmail } from './email.service';
 import { emailVerificationTemplate } from './templates/email-verification';
 
@@ -42,21 +42,23 @@ export async function sendVerificationEmail(
   const orm = drizzle(db, { schema });
 
   try {
-    // Generate secure token
+    // Generate secure token. Only its SHA-256 hash is stored; the raw token
+    // goes in the verification link (#98).
     const token = await generateSecureToken();
+    const tokenHash = await hashToken(token);
     const now = Date.now();
     const expiresAt = now + EMAIL_VERIFICATION_TOKEN_EXPIRATION_MS;
 
-    // Insert token into database
+    // Insert token hash into database
     await orm.insert(schema.emailVerificationTokens).values({
       userId,
-      token,
+      token: tokenHash,
       expiresAt,
       usedAt: null,
       createdAt: now,
     });
 
-    // Generate verification link
+    // Generate verification link (carries the raw token)
     const verificationLink = `${frontendUrl}/verify-email?token=${token}`;
 
     // Send email
@@ -97,10 +99,13 @@ export async function verifyEmail(
   const now = Date.now();
 
   try {
+    // Look up by the token's hash (raw token is never stored).
+    const tokenHash = await hashToken(token);
+
     // Find valid token (not used, not expired)
     const tokenRecord = await orm.query.emailVerificationTokens.findFirst({
       where: and(
-        eq(schema.emailVerificationTokens.token, token),
+        eq(schema.emailVerificationTokens.token, tokenHash),
         isNull(schema.emailVerificationTokens.usedAt),
         gt(schema.emailVerificationTokens.expiresAt, now)
       ),

--- a/packages/backend/src/services/token/crypto.ts
+++ b/packages/backend/src/services/token/crypto.ts
@@ -28,6 +28,27 @@ export async function generateSecureToken(): Promise<string> {
 }
 
 /**
+ * Hash a token with SHA-256 for storage at rest.
+ *
+ * The raw token is what travels in the email link and is what the user submits;
+ * only its hash is persisted in the DB. A leaked DB/backup therefore cannot be
+ * replayed to reset a password or hijack an email — an attacker would need to
+ * invert SHA-256 of a 256-bit random value (#98). Verification re-hashes the
+ * submitted token and looks it up by hash, so the existing unique index and
+ * one-time-use logic keep working unchanged.
+ *
+ * @param {string} token - Raw token (as sent to the user)
+ * @returns {Promise<string>} 64-character lowercase hex SHA-256 digest
+ */
+export async function hashToken(token: string): Promise<string> {
+  const bytes = new TextEncoder().encode(token) as Uint8Array<ArrayBuffer>;
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
  * Convert ArrayBuffer to base64url encoding
  *
  * @param {Uint8Array} buffer - Buffer to encode

--- a/tests/unit/services/token.service.test.ts
+++ b/tests/unit/services/token.service.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import {
   generateSecureToken,
   isValidTokenFormat,
+  hashToken,
 } from '../../../packages/backend/src/services/token/crypto';
 
 describe('Token Generation Service', () => {
@@ -101,6 +102,37 @@ describe('Token Generation Service', () => {
 
     it('should reject empty strings', () => {
       expect(isValidTokenFormat('')).toBe(false);
+    });
+  });
+
+  describe('hashToken', () => {
+    it('should return a 64-character lowercase hex digest', async () => {
+      const hash = await hashToken(await generateSecureToken());
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('should be deterministic for the same input', async () => {
+      const token = await generateSecureToken();
+      expect(await hashToken(token)).toBe(await hashToken(token));
+    });
+
+    it('should produce different hashes for different inputs', async () => {
+      const a = await hashToken(await generateSecureToken());
+      const b = await hashToken(await generateSecureToken());
+      expect(a).not.toBe(b);
+    });
+
+    it('should match the known SHA-256 vector for "abc"', async () => {
+      // SHA-256("abc") — confirms hex encoding/byte order, so a stored hash is
+      // reproducible from the raw token submitted at verification time (#98).
+      expect(await hashToken('abc')).toBe(
+        'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+      );
+    });
+
+    it('should not return the raw token (token is not stored in the clear)', async () => {
+      const token = await generateSecureToken();
+      expect(await hashToken(token)).not.toBe(token);
     });
   });
 });


### PR DESCRIPTION
## 概要

パスワードリセット / メール認証 / メール変更の3種トークンが、`generateSecureToken()` の**生値をそのまま `token` カラムに保存**し、検証も `eq(token, 生値)` で行っていた。エントロピーは256bitで十分だが、**保存形態**が問題で、DB漏洩（バックアップ流出・D1スナップショット等）時に有効期限内トークンでパスワードリセットやメールアドレス乗っ取りが即座に可能だった。

Closes #98

## 対応方針

メール送信URLには引き続き**生トークン**を使い、DBには `SHA-256(token)`（64桁hex）のみ保存。検証時は受領した生トークンを同方式でハッシュ化して `eq(token, hashedToken)` で lookup。既存の unique index・ワンタイム化ロジックはそのまま機能する（変更は局所的）。

## 変更

1. **`token/crypto.ts`**: `hashToken(token)` を追加（`crypto.subtle.digest('SHA-256')` → 64桁lowercase hex）。
2. **3サービスを「保存=ハッシュ / URL=生 / 検証=入力をハッシュして照合」に変更**:
   - `auth/password-reset.service.ts`（保存 + confirm）
   - `email/email-verification.service.ts`（保存 + verify）
   - `email/email-change.service.ts`（保存 + confirm + cancel）
3. **migration `0034_purge_plaintext_tokens.sql`**: デプロイ前に書かれた**未消費（pending）の平文トークン行を削除**。検証不能になった＝replay可能な平文を at-rest に残さない。消費済み行はワンタイム化済みで replay 不可・cron で自然消滅するため非対象。
4. **ユニットテスト追加**（`token.service.test.ts`）: 64桁hex / 決定性 / 既知ベクタ `SHA-256("abc")` 一致 / 生トークン非一致。

## 検証

- ✅ **実バックエンド + D1 で at-rest 検証**: register 後 `email_verification_tokens.token` が **64桁hex（ハッシュ）** で、生の32桁base64urlでないことを確認。
- ✅ **ラウンドトリップ実証**: `H(既知トークン)` を行挿入 → **生トークン**で `POST /api/email/verify` → 成功 + `used_at` 設定 + `users.email_verified=1`。検証側が入力をハッシュ化して照合していることを実証。
- ✅ これら3表への読み書きは全てサービス経由（cron は id/日付のみ操作）で、生トークン照合の残存経路なし。
- ✅ `pnpm typecheck` / `pnpm lint`（0 error）/ `pnpm test:unit`（230 passed）/ `pnpm find-deadcode`（0件）。

## 補足

- デプロイ時に進行中のリセット/認証/変更リンクは無効化される（migration purge ＋ 既存リンクの生トークンはハッシュ照合で不一致）。ユーザーは再リクエストすれば良い（24hワンタイムの性質上、影響は限定的）。
- `email_change_requests` の `old_email`/`new_email`（PII）の保護は本issueの方針どおり**別途検討（スコープ外）**。
- ⚠ PR Previewではマイグレーション自動適用なし。`0034` は本番デプロイ時に適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
