### PR TITLE
fix: ダッシュボード集計の日時比較TZ不一致で境界レコードを取りこぼす不具合を修正 (#99)

### DIFF
--- a/packages/backend/src/services/dashboard.ts
+++ b/packages/backend/src/services/dashboard.ts
@@ -1,4 +1,4 @@
-import { eq, and, gte, lte, desc } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import { weights, meals, exercises } from '../db/schema';
 import type { Database } from '../db';
 
@@ -125,45 +125,38 @@ export class DashboardService {
     const startISO = startDate.toISOString();
     const endISO = endDate.toISOString();
 
-    // Get weight data for the period
-    const weightRecords = await this.db
-      .select()
-      .from(weights)
-      .where(
-        and(
-          eq(weights.userId, userId),
-          gte(weights.recordedAt, startISO),
-          lte(weights.recordedAt, endISO)
-        )
-      )
-      .orderBy(weights.recordedAt)
-      .all();
+    // recorded_at carries a local offset (e.g. "+09:00"); the period bounds are
+    // instants. Comparing the raw ISO strings in SQL mixes "Z" and "+09:00"
+    // forms, and SQLite's lexicographic TEXT compare then drifts by the offset,
+    // systematically dropping/mixing edge records (#99). Filter by LOCAL date
+    // instead — the approach getDailyActivity and the meal/weight services use.
+    const startLocalDate = extractLocalDate(startISO);
+    const endLocalDate = extractLocalDate(endISO);
+    const inRange = (recordedAt: string): boolean => {
+      const localDate = extractLocalDate(recordedAt);
+      return localDate >= startLocalDate && localDate <= endLocalDate;
+    };
 
-    // Get meal data for the period
-    const mealRecords = await this.db
-      .select()
-      .from(meals)
-      .where(
-        and(
-          eq(meals.userId, userId),
-          gte(meals.recordedAt, startISO),
-          lte(meals.recordedAt, endISO)
-        )
-      )
-      .all();
+    // Get weight data, then filter by local date (kept ordered so the summary
+    // start/end weights are the chronological first/last in range).
+    const weightRecords = (
+      await this.db
+        .select()
+        .from(weights)
+        .where(eq(weights.userId, userId))
+        .orderBy(weights.recordedAt)
+        .all()
+    ).filter((r) => inRange(r.recordedAt));
 
-    // Get exercise data for the period
-    const exerciseRecords = await this.db
-      .select()
-      .from(exercises)
-      .where(
-        and(
-          eq(exercises.userId, userId),
-          gte(exercises.recordedAt, startISO),
-          lte(exercises.recordedAt, endISO)
-        )
-      )
-      .all();
+    // Get meal data, then filter by local date
+    const mealRecords = (
+      await this.db.select().from(meals).where(eq(meals.userId, userId)).all()
+    ).filter((r) => inRange(r.recordedAt));
+
+    // Get exercise data, then filter by local date
+    const exerciseRecords = (
+      await this.db.select().from(exercises).where(eq(exercises.userId, userId)).all()
+    ).filter((r) => inRange(r.recordedAt));
 
     // Calculate weight summary
     const weightSummary = this.calculateWeightSummary(weightRecords);
@@ -294,8 +287,26 @@ export class DashboardService {
 
   async getWeeklyTrend(userId: string, weeks: number = 4): Promise<WeeklyTrendItem[]> {
     const endDate = new Date();
-    const startDate = new Date();
-    startDate.setDate(startDate.getDate() - weeks * 7);
+
+    // Fetch each dataset once, then bucket by LOCAL date per week. Filtering by
+    // local date (not a raw ISO compare) avoids the "+09:00" vs "Z"
+    // lexicographic drift that dropped edge records (#99).
+    const allWeights = await this.db
+      .select()
+      .from(weights)
+      .where(eq(weights.userId, userId))
+      .orderBy(desc(weights.recordedAt))
+      .all();
+    const allMeals = await this.db
+      .select()
+      .from(meals)
+      .where(eq(meals.userId, userId))
+      .all();
+    const allExercises = await this.db
+      .select()
+      .from(exercises)
+      .where(eq(exercises.userId, userId))
+      .all();
 
     const result: WeeklyTrendItem[] = [];
 
@@ -305,46 +316,18 @@ export class DashboardService {
       const weekStart = new Date(weekEnd);
       weekStart.setDate(weekStart.getDate() - 6);
 
-      // Get latest weight for this week
-      const weekWeights = await this.db
-        .select()
-        .from(weights)
-        .where(
-          and(
-            eq(weights.userId, userId),
-            gte(weights.recordedAt, weekStart.toISOString()),
-            lte(weights.recordedAt, weekEnd.toISOString())
-          )
-        )
-        .orderBy(desc(weights.recordedAt))
-        .limit(1)
-        .all();
+      const weekStartLocal = extractLocalDate(weekStart.toISOString());
+      const weekEndLocal = extractLocalDate(weekEnd.toISOString());
+      const inWeek = (recordedAt: string): boolean => {
+        const localDate = extractLocalDate(recordedAt);
+        return localDate >= weekStartLocal && localDate <= weekEndLocal;
+      };
 
-      // Get total calories for this week
-      const weekMeals = await this.db
-        .select()
-        .from(meals)
-        .where(
-          and(
-            eq(meals.userId, userId),
-            gte(meals.recordedAt, weekStart.toISOString()),
-            lte(meals.recordedAt, weekEnd.toISOString())
-          )
-        )
-        .all();
+      // Latest weight in this week (allWeights is ordered desc, so first match)
+      const latestWeekWeight = allWeights.find((w) => inWeek(w.recordedAt));
 
-      // Get total exercise minutes for this week
-      const weekExercises = await this.db
-        .select()
-        .from(exercises)
-        .where(
-          and(
-            eq(exercises.userId, userId),
-            gte(exercises.recordedAt, weekStart.toISOString()),
-            lte(exercises.recordedAt, weekEnd.toISOString())
-          )
-        )
-        .all();
+      const weekMeals = allMeals.filter((m) => inWeek(m.recordedAt));
+      const weekExercises = allExercises.filter((e) => inWeek(e.recordedAt));
 
       const totalCalories = weekMeals
         .filter((m) => m.calories != null)
@@ -354,9 +337,9 @@ export class DashboardService {
       const exerciseSets = weekExercises.length;
 
       result.unshift({
-        weekStart: weekStart.toISOString().split('T')[0] ?? '',
-        weekEnd: weekEnd.toISOString().split('T')[0] ?? '',
-        weight: weekWeights.length > 0 ? weekWeights[0]?.weight ?? null : null,
+        weekStart: weekStartLocal,
+        weekEnd: weekEndLocal,
+        weight: latestWeekWeight?.weight ?? null,
         totalCalories,
         exerciseSets,
       });
@@ -376,8 +359,11 @@ export class DashboardService {
     const now = new Date();
     const weekStart = new Date(now);
     weekStart.setDate(weekStart.getDate() - 7);
+    // Compare by LOCAL date to avoid the "+09:00" vs "Z" lexicographic drift
+    // that dropped edge records (#99).
+    const weekStartLocal = extractLocalDate(weekStart.toISOString());
 
-    // Get latest weight
+    // Get latest weight (overall, no date filter)
     const latestWeight = await this.db
       .select()
       .from(weights)
@@ -386,29 +372,15 @@ export class DashboardService {
       .limit(1)
       .all();
 
-    // Get weekly exercise total
-    const weeklyExercises = await this.db
-      .select()
-      .from(exercises)
-      .where(
-        and(
-          eq(exercises.userId, userId),
-          gte(exercises.recordedAt, weekStart.toISOString())
-        )
-      )
-      .all();
+    // Get weekly exercise total (filtered by local date)
+    const weeklyExercises = (
+      await this.db.select().from(exercises).where(eq(exercises.userId, userId)).all()
+    ).filter((e) => extractLocalDate(e.recordedAt) >= weekStartLocal);
 
-    // Get weekly meal average
-    const weeklyMeals = await this.db
-      .select()
-      .from(meals)
-      .where(
-        and(
-          eq(meals.userId, userId),
-          gte(meals.recordedAt, weekStart.toISOString())
-        )
-      )
-      .all();
+    // Get weekly meals (filtered by local date)
+    const weeklyMeals = (
+      await this.db.select().from(meals).where(eq(meals.userId, userId)).all()
+    ).filter((m) => extractLocalDate(m.recordedAt) >= weekStartLocal);
 
     const currentWeight = latestWeight.length > 0 ? latestWeight[0]?.weight ?? null : null;
     const targetWeight = goals.targetWeight || 65;
@@ -419,7 +391,7 @@ export class DashboardService {
     const mealsWithCalories = weeklyMeals.filter((m) => m.calories != null);
     const totalCalories = mealsWithCalories.reduce((sum, m) => sum + (m.calories || 0), 0);
     const daysWithMeals = new Set(
-      weeklyMeals.map((m) => new Date(m.recordedAt).toDateString())
+      weeklyMeals.map((m) => extractLocalDate(m.recordedAt))
     ).size;
     const averageCalories = daysWithMeals > 0 ? totalCalories / daysWithMeals : 0;
     const targetCalories = goals.dailyCalories || 2000;

--- a/tests/unit/dashboard.service.test.ts
+++ b/tests/unit/dashboard.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardService } from '../../packages/backend/src/services/dashboard';
 
 describe('DashboardService', () => {
@@ -36,11 +36,12 @@ describe('DashboardService', () => {
         { calories: 2200, mealType: 'dinner', recordedAt: '2025-01-02T19:00:00+09:00' },
       ]);
 
-      // Mock exercise data (each record = 1 set)
+      // Mock exercise data (each record = 1 set). recordedAt is within
+      // [startDate, endDate] so the local-date filter keeps them (#99).
       mockDb.all.mockResolvedValueOnce([
-        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 10 },
-        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 10 },
-        { exerciseType: 'スクワット', setNumber: 1, reps: 12 },
+        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 10, recordedAt: '2025-01-02T10:00:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 10, recordedAt: '2025-01-02T10:05:00+09:00' },
+        { exerciseType: 'スクワット', setNumber: 1, reps: 12, recordedAt: '2025-01-03T18:00:00+09:00' },
       ]);
 
       const result = await service.getSummary(userId, { startDate, endDate });
@@ -140,20 +141,21 @@ describe('DashboardService', () => {
 
       mockDb.all.mockResolvedValueOnce([]);
       mockDb.all.mockResolvedValueOnce([]);
-      // Each record = 1 set. Total: 7 ベンチプレス + 3 スクワット + 2 ランジ = 12 sets
+      // Each record = 1 set. Total: 7 ベンチプレス + 3 スクワット + 2 ランジ = 12 sets.
+      // recordedAt is within [startDate, endDate] so the local-date filter keeps them (#99).
       mockDb.all.mockResolvedValueOnce([
-        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 10 },
-        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 10 },
-        { exerciseType: 'ベンチプレス', setNumber: 3, reps: 10 },
-        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 8 },
-        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 8 },
-        { exerciseType: 'ベンチプレス', setNumber: 3, reps: 8 },
-        { exerciseType: 'ベンチプレス', setNumber: 4, reps: 8 },
-        { exerciseType: 'スクワット', setNumber: 1, reps: 12 },
-        { exerciseType: 'スクワット', setNumber: 2, reps: 12 },
-        { exerciseType: 'スクワット', setNumber: 3, reps: 12 },
-        { exerciseType: 'ランジ', setNumber: 1, reps: 15 },
-        { exerciseType: 'ランジ', setNumber: 2, reps: 15 },
+        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 10, recordedAt: '2025-01-02T10:00:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 10, recordedAt: '2025-01-02T10:05:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 3, reps: 10, recordedAt: '2025-01-02T10:10:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 1, reps: 8, recordedAt: '2025-01-04T10:00:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 2, reps: 8, recordedAt: '2025-01-04T10:05:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 3, reps: 8, recordedAt: '2025-01-04T10:10:00+09:00' },
+        { exerciseType: 'ベンチプレス', setNumber: 4, reps: 8, recordedAt: '2025-01-04T10:15:00+09:00' },
+        { exerciseType: 'スクワット', setNumber: 1, reps: 12, recordedAt: '2025-01-05T18:00:00+09:00' },
+        { exerciseType: 'スクワット', setNumber: 2, reps: 12, recordedAt: '2025-01-05T18:05:00+09:00' },
+        { exerciseType: 'スクワット', setNumber: 3, reps: 12, recordedAt: '2025-01-05T18:10:00+09:00' },
+        { exerciseType: 'ランジ', setNumber: 1, reps: 15, recordedAt: '2025-01-06T19:00:00+09:00' },
+        { exerciseType: 'ランジ', setNumber: 2, reps: 15, recordedAt: '2025-01-06T19:05:00+09:00' },
       ]);
 
       const result = await service.getSummary(userId, { startDate, endDate });
@@ -212,16 +214,113 @@ describe('DashboardService', () => {
         dailyCalories: 2000,
       };
 
-      mockDb.all.mockResolvedValueOnce([{ weight: 68.0 }]);
-      mockDb.all.mockResolvedValueOnce([{ total: 120 }]);
-      mockDb.all.mockResolvedValueOnce([{ avg: 1950 }]);
+      // Real row shapes carry recordedAt (the local-date filter reads it, #99).
+      // Use "now" so the records fall inside the trailing-7-day window.
+      const recentISO = new Date().toISOString();
+      mockDb.all.mockResolvedValueOnce([{ weight: 68.0 }]); // latest weight (no date filter)
+      mockDb.all.mockResolvedValueOnce([{ reps: 10, recordedAt: recentISO }]); // weekly exercises
+      mockDb.all.mockResolvedValueOnce([{ calories: 1950, recordedAt: recentISO }]); // weekly meals
 
       const result = await service.getGoalProgress(userId, goals);
 
       expect(result).toBeDefined();
-      expect(result.weight).toBeDefined();
-      expect(result.exercise).toBeDefined();
-      expect(result.calories).toBeDefined();
+      expect(result.weight.current).toBe(68.0);
+      // One in-window exercise record => 1 set; one meal of 1950 on a single
+      // local day => daily average 1950 (locks the local-date filter output).
+      expect(result.exercise.currentSets).toBe(1);
+      expect(result.calories.average).toBe(1950);
+    });
+  });
+
+  // Regression for #99: aggregation must bucket records by their LOCAL date,
+  // not by a UTC ("Z") vs "+09:00" lexicographic string compare. Under the old
+  // code the boundary used startDate.toISOString() (a "Z" instant), which
+  // dropped/mixed records near the day edge.
+  describe('timezone boundary (#99)', () => {
+    it('getSummary keeps JST same-day edge records and drops the previous local day', async () => {
+      const userId = 'user-tz';
+      // Frontend asks for local day 2026-01-17; the route builds new Date('2026-01-17').
+      const startDate = new Date('2026-01-17');
+      const endDate = new Date('2026-01-17');
+
+      mockDb.all.mockResolvedValueOnce([]); // weights
+      mockDb.all.mockResolvedValueOnce([
+        // 23:30 JST on Jan 17 (14:30Z same day): the old end-bound (Z midnight)
+        // dropped this true same-day record.
+        { calories: 700, mealType: 'dinner', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-17T23:30:00+09:00' },
+        // 07:00 JST on Jan 17 (22:00Z on the 16th): still belongs to Jan 17.
+        { calories: 300, mealType: 'breakfast', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-17T07:00:00+09:00' },
+        // Previous local day — must be excluded.
+        { calories: 999, mealType: 'dinner', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-16T23:30:00+09:00' },
+      ]);
+      mockDb.all.mockResolvedValueOnce([]); // exercises
+
+      const result = await service.getSummary(userId, { startDate, endDate });
+
+      // Both Jan-17 records counted; the Jan-16 one excluded. (Old code returned
+      // all 3 because the SQL bound is a no-op against the mock and there was no
+      // local-date filter.)
+      expect(result.meals.mealCount).toBe(2);
+      expect(result.meals.totalCalories).toBe(1000);
+    });
+
+    // getWeeklyTrend / getGoalProgress use a "now"-relative window, so pin the
+    // clock to make the local-date bucketing deterministic.
+    describe('now-relative windows', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        // 2026-01-17T05:00:00Z = 2026-01-17 14:00 JST
+        vi.setSystemTime(new Date('2026-01-17T05:00:00Z'));
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('getWeeklyTrend buckets a late-night JST record into the correct week', async () => {
+        // weeks=1 => single window: local 2026-01-11 .. 2026-01-17
+        mockDb.all.mockResolvedValueOnce([
+          { weight: 70.0, recordedAt: '2026-01-17T23:30:00+09:00' }, // local 01-17, in week
+        ]); // allWeights
+        mockDb.all.mockResolvedValueOnce([
+          { calories: 500, recordedAt: '2026-01-17T23:30:00+09:00' }, // in week (late-night JST)
+          { calories: 999, recordedAt: '2026-01-10T12:00:00+09:00' }, // local 01-10, before weekStart
+        ]); // allMeals
+        mockDb.all.mockResolvedValueOnce([
+          { recordedAt: '2026-01-17T07:00:00+09:00' }, // local 01-17, in week
+        ]); // allExercises
+
+        const result = await service.getWeeklyTrend('user-tz', 1);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]!.weekStart).toBe('2026-01-11');
+        expect(result[0]!.weekEnd).toBe('2026-01-17');
+        // Late-night JST record kept; the 01-10 record dropped.
+        expect(result[0]!.totalCalories).toBe(500);
+        expect(result[0]!.exerciseSets).toBe(1);
+        expect(result[0]!.weight).toBe(70.0);
+      });
+
+      it('getGoalProgress filters by local date and averages calories per local day', async () => {
+        // now=2026-01-17T05:00:00Z => weekStart (local) = 2026-01-10
+        mockDb.all.mockResolvedValueOnce([{ weight: 68.0 }]); // latest weight
+        mockDb.all.mockResolvedValueOnce([
+          { reps: 10, recordedAt: '2026-01-17T23:30:00+09:00' }, // local 01-17 >= 01-10 => kept
+          { reps: 8, recordedAt: '2026-01-09T12:00:00+09:00' }, // local 01-09 < 01-10 => dropped
+        ]); // weekly exercises
+        mockDb.all.mockResolvedValueOnce([
+          { calories: 1950, recordedAt: '2026-01-17T23:30:00+09:00' }, // kept; one local day
+        ]); // weekly meals
+
+        const result = await service.getGoalProgress('user-tz', {
+          targetWeight: 65,
+          dailyCalories: 2000,
+        });
+
+        // Edge record kept, stale (pre-window) one dropped.
+        expect(result.exercise.currentSets).toBe(1);
+        // 1950 over a single local day.
+        expect(result.calories.average).toBe(1950);
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

ダッシュボード集計が、`recorded_at`（migration 0026 で全件 `+09:00` オフセット付き文字列に正規化済み）に対し `startDate.toISOString()`（UTC `...Z` 文字列）を SQL の `gte`/`lte` に渡していた。SQLite は TEXT を辞書順比較するため `...+09:00` と `...Z` の大小が実時刻順と一致せず、**ウィンドウ端のレコードを系統的に取りこぼし／混入**していた（合計カロリー・週次トレンド・目標進捗の表示値が恒常的に不正確）。

例: ローカル日 `2026-01-17` 指定（route は `new Date('2026-01-17')`＝UTC 0時を境界に使う）で、`2026-01-17T23:30:00+09:00`（JST当日夜）が **除外**される。

Closes #99

## 対応方針

同コードベースで既に正しい `getDailyActivity` / meal・weight service と同じく、**`recorded_at` の SQL 日時比較を撤去し、userId で取得後に `extractLocalDate`（ローカル日 `YYYY-MM-DD`）で範囲フィルタ**する方式に統一。

## 変更（`packages/backend/src/services/dashboard.ts`）

- **`getSummary`**: weight/meal/exercise を userId で取得 → `extractLocalDate(recordedAt)` が `[startLocalDate, endLocalDate]` に入るものだけ集計。`period` 表示値は従来どおり ISO を返す。
- **`getWeeklyTrend`**: 各データセットを**ループ前に1回ずつ**取得（旧: 週×3クエリ）し、週ごとに `extractLocalDate` でバケット化。週内最新体重は desc 並びの `find()`。表示の `weekStart`/`weekEnd` は従来と同値（`toISOString().slice(0,10)`）。
- **`getGoalProgress`**: 週次 exercise/meal を `extractLocalDate(recordedAt) >= weekStartLocal` でフィルタ。あわせて `daysWithMeals` の `new Date(...).toDateString()`（サーバTZ依存の副次バグ）も `extractLocalDate` に統一。
- 未使用化した drizzle import `gte`/`lte`/`and` を削除（`eq`/`desc` は継続）。`getWeeklyTrend` の死んだ `startDate` 変数も除去。

## 検証

- ✅ **回帰テスト追加**（`dashboard.service.test.ts` の `timezone boundary (#99)`）— 3メソッド全てをカバー:
  - `getSummary`: `2026-01-17T23:30:00+09:00`・`...T07:00:00+09:00` を**含み**前日 `2026-01-16T23:30:00+09:00` を**除外**（`mealCount=2`/`totalCalories=1000`）。旧コード（SQLフィルタはモック素通り）なら `mealCount=3` で **fail** ＝修正をロック。
  - `getWeeklyTrend` / `getGoalProgress`: `vi.setSystemTime` で「今」を固定し、週/週次ウィンドウの境界（JST当日夜を含む・週開始前を除外）と `daysWithMeals` による日次平均を値で検証。
- ✅ 既存ユニットの運動/目標モックに `recordedAt` を補完（JSフィルタ化で必要に）＋値アサーション強化。`.all()` 呼び出し順は各メソッドのクエリ順を維持。
- ✅ `pnpm typecheck` / `pnpm lint`（0 error）/ `pnpm test:unit`（233 passed）/ `pnpm find-deadcode`（0件）。
- ✅ 敵対的レビュー（3視点 → 各findingを独立検証）実施。コード自体の欠陥は0、確認された4件は全て low かつ本PR起因でない既存事項（下記 follow-up）。

## 補足

- 全3メソッドは userId 単位で全件取得→JSフィルタになる（`getDailyActivity` と同じ既存方針）。個人トラッカー規模では妥当。
- 期間プリセット（`?period=week` 等）の「今日」端は `new Date()`＝UTC基準で、これは `getDailyActivity` を含むアプリ全体の既存挙動に**合わせた**もの（サーバTZ=UTCの「今日」定義の是非は #99 のスコープ外）。本 PR が直すのは「日付レンジ指定時に同日端レコードが落ちる」辞書順比較バグ。

## レビュー由来の follow-up（本PRスコープ外・別途検討）

レビューで確認された既存の制約。いずれも本PRが**新たに導入したものではなく**、退行もしない:

1. **`Z`形式行の日付バケット誤り**: `extractLocalDate` は先頭10文字を切るだけのためオフセット非考慮で、AI-chatの日付編集経路（`ai-chat.ts`→`meal-chat.ts`）が `toISOString()` の `Z` 形式で `recorded_at` を保存すると、JST早朝のレコードが1日早くバケットされうる。`getDailyActivity` 等も同じ既存仕様。完全解決には「書き込み時に `+09:00` へ正規化」または「`extractLocalDate` をオフセット対応」が必要。
2. **全件フェッチ**: 3メソッドは userId 単位で全履歴を取得→JSフィルタする（`meal.ts`/`weight.ts`/`getDailyActivity` と同じ既存方針）。`idx_*_user_date` でインデックス走査され個人規模では問題ないが、履歴増加に対し線形にコスト増。将来的に「先頭日付部分文字列でのSQL粗フィルタ」or「ローカル日付列の永続化」で上限を設けるのが望ましい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
