### PR TITLE
fix: 食事編集の写真別栄養表示を撤去しfood_items由来の合計に一本化 (#100)

### DIFF
--- a/packages/frontend/src/components/meal/MealEditMode.tsx
+++ b/packages/frontend/src/components/meal/MealEditMode.tsx
@@ -392,15 +392,14 @@ export function MealEditMode({
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                     </svg>
                   </button>
-                  {/* Nutrition info tooltip on hover */}
-                  {photo.analysisStatus === 'complete' && (
-                    <div className="absolute bottom-2 left-2 right-2 rounded bg-black bg-opacity-75 p-2 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
-                      <div className="flex justify-between">
-                        <span>{photo.calories} kcal</span>
-                        <span>P:{photo.protein?.toFixed(1) ?? 0}g F:{photo.fat?.toFixed(1) ?? 0}g C:{photo.carbs?.toFixed(1) ?? 0}g</span>
-                      </div>
-                    </div>
-                  )}
+                  {/*
+                    Per-photo nutrition (meal_photos.calories etc.) is an AI
+                    analysis-time snapshot that is NOT recomputed on chat/manual
+                    food edits, so it drifts out of sync (#100). The single
+                    source of truth is meal_food_items; only the food-item-derived
+                    "栄養合計" below is shown. Per-photo breakdown is intentionally
+                    omitted to avoid displaying stale numbers.
+                  */}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## 概要

`meal_records.total_*`（合計栄養）を再計算する経路が複数あり、集計元テーブルが経路ごとに異なる（初回複数写真は `meal_photos`、再解析/削除/チャット編集は `meal_food_items`）。単一の再計算関数（SSoT）が無く、**写真別栄養（`meal_photos.calories` 等）がAI解析時の値で固定**され、チャット/手動編集後に陳腐化していた。

`meal_records` の合計は最終的に `meal_food_items` へ収束するため dashboard / 一覧 / MealDetail の集計は正しく、**実害は食事編集画面の per-photo 内訳（ホバーツールチップ）表示のズレに限定**されていた。

Closes #100

## 対応（issue推奨の最小修正）

- フロント全体で唯一 `meal_photos` 由来の写真別栄養を表示していた **`MealEditMode` のホバーツールチップ（`photo.calories/protein/fat/carbs`）を撤去**。
- すぐ下の **「栄養合計」表示は `food_items` 由来（`photoTotals`）で正確**なので維持。これにより唯一の乖離源が解消。
- 撤去理由を明示するコメントを残置。

## 調査結果

- `photo.calories/protein/fat/carbs`（`meal_photos` 由来）を読む箇所は**フロント全体で `MealEditMode.tsx:399-400` のみ**（`PhotoCarousel` / `PhotoAnalysisReview` / `usePhotoMealFlow` は `analysisStatus` 等のみ参照、栄養は非参照）。
- `meal_photos` の栄養カラムは初回複数写真アップロードの合計計算（`meal-photo.service.calculateTotals`）でバックエンド側では引き続き使用されるため、**カラムや書き込みは温存**（表示しないので陳腐化は不可視化）。
- `MealEditMode` の専用テストは無し。

## 検証

- ✅ `pnpm typecheck` / `pnpm lint`（0 error）/ `pnpm test:unit`（233 passed）/ `pnpm find-deadcode`（0件）
- ✅ フロントビルド成功（`build:shared` → frontend build, PWA生成OK）

## 補足（follow-up・スコープ外）

- 根治（全再計算経路を `food_items` のみに統一し `meal_photos` 栄養を導出スナップショット化 or 廃止＝issueの方針2）は、写真別内訳を正確に出すなら `food_items` に `photo_id` をAPI公開する変更が必要で規模が大きいため別途。本PRは実害（stale表示）の解消に絞った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
