### PR TITLE
fix: 写真削除の整合性を共通関数に集約しFKをCASCADE化 (#101)

### DIFF
--- a/packages/backend/migrations/0035_meal_food_items_photo_cascade.sql
+++ b/packages/backend/migrations/0035_meal_food_items_photo_cascade.sql
@@ -1,0 +1,42 @@
+-- Migration 0035: meal_food_items.photo_id を ON DELETE SET NULL → CASCADE に変更（#101）
+--
+-- 背景: 写真削除時はアプリ側で明細(meal_food_items)も削除し totals を再計算する実装に
+--   統一した（共通関数 deletePhotosWithFoodItems）。FK の SET NULL は実態と逆（明細を
+--   孤児として残す）で死蔵していたため CASCADE に揃える。これで万一 meal_photos 行を
+--   直接削除しても紐づく明細が自動削除され、孤児化を防ぐ（多層防御）。
+--
+-- SQLite は FK の ON DELETE を ALTER で変更できないためテーブル再構築（0031 と同手法）。
+-- meal_food_items は被参照テーブルが無いため DROP/RENAME は安全。
+-- 既存 photo_id は SET NULL の性質上 NULL か有効な meal_photos.id のみ（dangling 無し）
+-- のため、CASCADE FK 付き新テーブルへの移行は FK 違反を起こさない。
+-- カラム順・インデックス名は schema.ts(Drizzle 定義) に合わせる
+-- （photo_id index 名は 0031 で解消済みの実態 idx_meal_food_items_photo）。
+
+CREATE TABLE meal_food_items_new (
+  id TEXT PRIMARY KEY NOT NULL,
+  meal_id TEXT NOT NULL,
+  photo_id TEXT,
+  name TEXT NOT NULL,
+  portion TEXT NOT NULL,
+  calories INTEGER NOT NULL,
+  protein REAL NOT NULL,
+  fat REAL NOT NULL,
+  carbs REAL NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (meal_id) REFERENCES meal_records(id) ON DELETE CASCADE,
+  FOREIGN KEY (photo_id) REFERENCES meal_photos(id) ON DELETE CASCADE
+);
+
+INSERT INTO meal_food_items_new (
+  id, meal_id, photo_id, name, portion, calories, protein, fat, carbs, created_at
+)
+SELECT
+  id, meal_id, photo_id, name, portion, calories, protein, fat, carbs, created_at
+FROM meal_food_items;
+
+DROP TABLE meal_food_items;
+
+ALTER TABLE meal_food_items_new RENAME TO meal_food_items;
+
+CREATE INDEX idx_food_items_meal ON meal_food_items(meal_id);
+CREATE INDEX idx_meal_food_items_photo ON meal_food_items(photo_id);

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -83,7 +83,7 @@ export const mealFoodItems = sqliteTable(
     mealId: text('meal_id')
       .notNull()
       .references(() => mealRecords.id, { onDelete: 'cascade' }),
-    photoId: text('photo_id').references(() => mealPhotos.id, { onDelete: 'set null' }),
+    photoId: text('photo_id').references(() => mealPhotos.id, { onDelete: 'cascade' }),
     name: text('name').notNull(),
     portion: text('portion').notNull(), // 'small' | 'medium' | 'large'
     calories: integer('calories').notNull(),

--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -6,7 +6,11 @@ import { eq, and } from 'drizzle-orm';
 import { authMiddleware } from '../middleware/auth';
 import { mealRecords, mealFoodItems, mealPhotos } from '../db/schema';
 import { PhotoStorageService } from '../services/photo-storage';
-import { MealPhotoService } from '../services/meal-photo.service';
+import {
+  MealPhotoService,
+  recalculateMealTotals,
+  deletePhotosWithFoodItems,
+} from '../services/meal-photo.service';
 import { AIAnalysisService } from '../services/ai-analysis';
 import { AIUsageService } from '../services/ai-usage';
 import { aiUsageLimitCheck } from '../middleware/ai-usage-limit';
@@ -18,7 +22,6 @@ import {
   saveMealAnalysisSchema,
   textAnalysisRequestSchema,
   type FoodItem,
-  type NutritionTotals,
 } from '@lifestyle-app/shared';
 
 type Bindings = {
@@ -379,7 +382,7 @@ mealAnalysis.post(
     };
 
     // Recalculate totals
-    const updatedTotals = await recalculateTotals(db, mealId);
+    const updatedTotals = await recalculateMealTotals(db, mealId);
 
     return c.json({ foodItem, updatedTotals }, 201);
   }
@@ -434,7 +437,7 @@ mealAnalysis.patch(
     };
 
     // Recalculate totals
-    const updatedTotals = await recalculateTotals(db, mealId);
+    const updatedTotals = await recalculateMealTotals(db, mealId);
 
     return c.json({ foodItem, updatedTotals });
   }
@@ -461,7 +464,7 @@ mealAnalysis.delete('/:mealId/food-items/:foodItemId', async (c) => {
   );
 
   // Recalculate totals
-  const updatedTotals = await recalculateTotals(db, mealId);
+  const updatedTotals = await recalculateMealTotals(db, mealId);
 
   return c.json({ message: '削除しました', updatedTotals });
 });
@@ -491,16 +494,10 @@ mealAnalysis.delete('/:mealId/photo', async (c) => {
     return c.json({ error: 'not_found', message: '写真が設定されていません' }, 404);
   }
 
-  // Delete all photos for this meal
-  for (const photo of photos) {
-    try {
-      await photoStorage.deletePhoto(photo.photoKey);
-    } catch (error) {
-      console.error('Failed to delete photo from storage:', error);
-      // Continue even if storage deletion fails
-    }
-    await db.delete(mealPhotos).where(eq(mealPhotos.id, photo.id));
-  }
+  // Delete all photos + their food items, then recompute totals (#101).
+  // Previously this only removed meal_photos rows, leaving orphaned food items
+  // and stale meal_records totals.
+  await deletePhotosWithFoodItems(db, photoStorage, mealId, photos);
 
   return c.json({ success: true, message: '写真を削除しました' });
 });
@@ -541,16 +538,12 @@ mealAnalysis.post('/:mealId/photo', async (c) => {
     return c.json({ error: 'invalid_request', message: 'ファイルサイズは10MB以下にしてください' }, 400);
   }
 
-  // Delete old photos if exist (legacy single-photo replacement behavior)
+  // Delete old photos (+ their food items) and reconcile totals before adding
+  // the replacement (legacy single-photo behavior). Previously this left
+  // orphaned food items and stale totals (#101).
   const existingPhotos = await photoService.getMealPhotos(mealId);
-  for (const existingPhoto of existingPhotos) {
-    try {
-      await photoStorage.deletePhoto(existingPhoto.photoKey);
-    } catch (error) {
-      console.error('Failed to delete old photo:', error);
-      // Continue even if old photo deletion fails
-    }
-    await db.delete(mealPhotos).where(eq(mealPhotos.id, existingPhoto.id));
+  if (existingPhotos.length > 0) {
+    await deletePhotosWithFoodItems(db, photoStorage, mealId, existingPhotos);
   }
 
   // Upload new photo directly as permanent (not temp)
@@ -652,34 +645,5 @@ mealAnalysis.post(
   }
 );
 
-// Helper function to recalculate meal totals
-async function recalculateTotals(db: Database, mealId: string): Promise<NutritionTotals> {
-  const items = await db.query.mealFoodItems.findMany({
-    where: eq(mealFoodItems.mealId, mealId),
-  });
-
-  const totals: NutritionTotals = items.reduce(
-    (acc, item) => ({
-      calories: acc.calories + item.calories,
-      protein: Math.round((acc.protein + item.protein) * 10) / 10,
-      fat: Math.round((acc.fat + item.fat) * 10) / 10,
-      carbs: Math.round((acc.carbs + item.carbs) * 10) / 10,
-    }),
-    { calories: 0, protein: 0, fat: 0, carbs: 0 }
-  );
-
-  const now = new Date().toISOString();
-  await db
-    .update(mealRecords)
-    .set({
-      calories: totals.calories,
-      totalProtein: totals.protein,
-      totalFat: totals.fat,
-      totalCarbs: totals.carbs,
-      content: items.map((i) => i.name).join(', '),
-      updatedAt: now,
-    })
-    .where(eq(mealRecords.id, mealId));
-
-  return totals;
-}
+// recalculateTotals was consolidated into recalculateMealTotals in
+// services/meal-photo.service.ts (the single source of truth for meal totals, #101).

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { nanoid } from 'nanoid';
 import { createMealSchema, updateMealSchema, dateRangeSchema, mealTypeSchema, mealDatesQuerySchema } from '@lifestyle-app/shared';
 import { MealService } from '../services/meal';
-import { MealPhotoService } from '../services/meal-photo.service';
+import { MealPhotoService, deletePhotosWithFoodItems } from '../services/meal-photo.service';
 import { PhotoStorageService } from '../services/photo-storage';
 import { AIAnalysisService } from '../services/ai-analysis';
 import { AIUsageService } from '../services/ai-usage';
@@ -564,57 +564,27 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     const photoService = new MealPhotoService(db);
     const photoStorage = new PhotoStorageService(c.env.PHOTOS);
 
-    try {
-      // Delete food items associated with this photo
-      await db.delete(schema.mealFoodItems)
-        .where(eq(schema.mealFoodItems.photoId, photoId));
-
-      const { photoKey } = await photoService.deletePhoto(photoId);
-
-      // Delete from R2
-      await photoStorage.deletePhoto(photoKey);
-
-      // Recalculate totals from remaining food items
-      const remainingFoodItems = await db.query.mealFoodItems.findMany({
-        where: eq(schema.mealFoodItems.mealId, mealId),
-      });
-
-      const totalCalories = remainingFoodItems.reduce((sum, item) => sum + item.calories, 0);
-      const totalProtein = remainingFoodItems.reduce((sum, item) => sum + item.protein, 0);
-      const totalFat = remainingFoodItems.reduce((sum, item) => sum + item.fat, 0);
-      const totalCarbs = remainingFoodItems.reduce((sum, item) => sum + item.carbs, 0);
-      const contentNames = remainingFoodItems.map(item => item.name).join('、');
-
-      await db.update(mealRecords)
-        .set({
-          content: contentNames,
-          calories: totalCalories,
-          totalProtein,
-          totalFat,
-          totalCarbs,
-        })
-        .where(eq(mealRecords.id, mealId));
-
-      const updatedTotals = {
-        calories: totalCalories,
-        protein: totalProtein,
-        fat: totalFat,
-        carbs: totalCarbs,
-      };
-
-      const remainingPhotos = await photoService.getMealPhotos(mealId);
-
-      return c.json({
-        success: true,
-        remainingPhotos: remainingPhotos.length,
-        updatedTotals,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('at least one')) {
-        return c.json({ message: error.message, code: 'LAST_PHOTO' }, 400);
-      }
-      throw error;
+    const photos = await photoService.getMealPhotos(mealId);
+    const target = photos.find((p) => p.id === photoId);
+    if (!target) {
+      return c.json({ message: 'Photo not found' }, 404);
     }
+    // A meal must keep at least one photo.
+    if (photos.length === 1) {
+      return c.json({ message: 'Meals must have at least one photo', code: 'LAST_PHOTO' }, 400);
+    }
+
+    // Delete the photo + its food items and recompute totals via the shared
+    // reconcile helper (single source of truth, #101).
+    const updatedTotals = await deletePhotosWithFoodItems(db, photoStorage, mealId, [target]);
+
+    const remainingPhotos = await photoService.getMealPhotos(mealId);
+
+    return c.json({
+      success: true,
+      remainingPhotos: remainingPhotos.length,
+      updatedTotals,
+    });
   })
   // T071: Photo reorder endpoint
   .patch('/:id/photos/reorder', async (c) => {

--- a/packages/backend/src/services/meal-photo.service.ts
+++ b/packages/backend/src/services/meal-photo.service.ts
@@ -1,7 +1,9 @@
 import { nanoid } from 'nanoid';
 import { eq, asc } from 'drizzle-orm';
 import type { Database } from '../db';
-import { mealPhotos, type MealPhoto } from '../db/schema';
+import { mealPhotos, mealFoodItems, mealRecords, type MealPhoto } from '../db/schema';
+import type { NutritionTotals } from '@lifestyle-app/shared';
+import type { PhotoStorageService } from './photo-storage';
 
 export class MealPhotoService {
   constructor(private db: Database) {}
@@ -43,26 +45,6 @@ export class MealPhotoService {
     }
 
     return photo;
-  }
-
-  async deletePhoto(photoId: string): Promise<{ photoKey: string }> {
-    const photo = await this.db.query.mealPhotos.findFirst({
-      where: eq(mealPhotos.id, photoId),
-    });
-
-    if (!photo) {
-      throw new Error('Photo not found');
-    }
-
-    // Check if last photo
-    const remaining = await this.getMealPhotos(photo.mealId);
-    if (remaining.length === 1) {
-      throw new Error('Meals must have at least one photo');
-    }
-
-    await this.db.delete(mealPhotos).where(eq(mealPhotos.id, photoId));
-
-    return { photoKey: photo.photoKey };
   }
 
   async updateAnalysisResult(
@@ -114,4 +96,75 @@ export class MealPhotoService {
       analyzedPhotoCount: analyzed.length,
     };
   }
+}
+
+/**
+ * Recalculate a meal's stored totals from its food items and persist them.
+ *
+ * meal_food_items is the single source of truth for meal_records.calories /
+ * total_* — every edit path (chat, manual, photo delete) converges here so the
+ * stored totals never drift (#100/#101). Protein/fat/carbs are rounded to one
+ * decimal to match the other recompute call sites.
+ */
+export async function recalculateMealTotals(
+  db: Database,
+  mealId: string
+): Promise<NutritionTotals> {
+  const items = await db.query.mealFoodItems.findMany({
+    where: eq(mealFoodItems.mealId, mealId),
+  });
+
+  const totals: NutritionTotals = items.reduce(
+    (acc, item) => ({
+      calories: acc.calories + item.calories,
+      protein: Math.round((acc.protein + item.protein) * 10) / 10,
+      fat: Math.round((acc.fat + item.fat) * 10) / 10,
+      carbs: Math.round((acc.carbs + item.carbs) * 10) / 10,
+    }),
+    { calories: 0, protein: 0, fat: 0, carbs: 0 }
+  );
+
+  await db
+    .update(mealRecords)
+    .set({
+      calories: totals.calories,
+      totalProtein: totals.protein,
+      totalFat: totals.fat,
+      totalCarbs: totals.carbs,
+      content: items.map((i) => i.name).join(', '),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(mealRecords.id, mealId));
+
+  return totals;
+}
+
+/**
+ * Delete the given photos for a meal and reconcile state in one place (#101):
+ * for each photo, remove its meal_food_items (so they don't orphan), the
+ * meal_photos row, and the R2 object (best-effort), then recompute the meal
+ * totals from the remaining food items. All photo-deletion paths funnel through
+ * this so food items never orphan and meal_records totals never drift.
+ */
+export async function deletePhotosWithFoodItems(
+  db: Database,
+  photoStorage: PhotoStorageService,
+  mealId: string,
+  photos: { id: string; photoKey: string }[]
+): Promise<NutritionTotals> {
+  for (const photo of photos) {
+    // Remove food items captured from this photo. (The FK is ON DELETE CASCADE
+    // since #101, so deleting the photo row would also clear them; doing it
+    // explicitly keeps the behavior correct regardless of FK enforcement.)
+    await db.delete(mealFoodItems).where(eq(mealFoodItems.photoId, photo.id));
+    await db.delete(mealPhotos).where(eq(mealPhotos.id, photo.id));
+    try {
+      await photoStorage.deletePhoto(photo.photoKey);
+    } catch (error) {
+      console.error('Failed to delete photo from storage:', error);
+      // Continue even if storage deletion fails — DB state is the source of truth.
+    }
+  }
+
+  return recalculateMealTotals(db, mealId);
 }

--- a/packages/backend/tests/unit/meal-photo.service.test.ts
+++ b/packages/backend/tests/unit/meal-photo.service.test.ts
@@ -134,71 +134,8 @@ describe('MealPhotoService', () => {
     });
   });
 
-  describe('deletePhoto', () => {
-    it('should delete photo successfully', async () => {
-      const photo: MealPhoto = {
-        id: 'photo2',
-        mealId: 'meal1',
-        photoKey: 'photos/user1/meal1/photo2.jpg',
-        displayOrder: 1,
-        analysisStatus: 'complete',
-        calories: 100,
-        protein: 10,
-        fat: 5,
-        carbs: 15,
-        createdAt: new Date().toISOString(),
-      };
-
-      const remainingPhotos: MealPhoto[] = [
-        {
-          id: 'photo1',
-          mealId: 'meal1',
-          photoKey: 'photos/user1/meal1/photo1.jpg',
-          displayOrder: 0,
-          analysisStatus: 'complete',
-          calories: 100,
-          protein: 10,
-          fat: 5,
-          carbs: 15,
-          createdAt: new Date().toISOString(),
-        },
-        photo,
-      ];
-
-      mockDb.query.mealPhotos.findFirst = vi.fn().mockResolvedValue(photo);
-      mockDb.query.mealPhotos.findMany = vi.fn().mockResolvedValue(remainingPhotos);
-
-      const mockDelete = vi.fn().mockResolvedValue(undefined);
-      mockDb.delete = vi.fn().mockReturnValue({ where: mockDelete });
-
-      const result = await service.deletePhoto('photo2');
-
-      expect(result.photoKey).toBe('photos/user1/meal1/photo2.jpg');
-      expect(mockDelete).toHaveBeenCalled();
-    });
-
-    it('should throw error when deleting last photo', async () => {
-      const photo: MealPhoto = {
-        id: 'photo1',
-        mealId: 'meal1',
-        photoKey: 'photos/user1/meal1/photo1.jpg',
-        displayOrder: 0,
-        analysisStatus: 'complete',
-        calories: 100,
-        protein: 10,
-        fat: 5,
-        carbs: 15,
-        createdAt: new Date().toISOString(),
-      };
-
-      mockDb.query.mealPhotos.findFirst = vi.fn().mockResolvedValue(photo);
-      mockDb.query.mealPhotos.findMany = vi.fn().mockResolvedValue([photo]);
-
-      await expect(service.deletePhoto('photo1')).rejects.toThrow(
-        'Meals must have at least one photo'
-      );
-    });
-  });
+  // NOTE: MealPhotoService.deletePhoto was removed in #101 — photo deletion is
+  // now handled by deletePhotosWithFoodItems (see tests/unit/meal-photo-reconcile.test.ts).
 
   describe('calculateTotals', () => {
     it('should calculate totals from complete photos only', () => {

--- a/tests/unit/meal-photo-reconcile.test.ts
+++ b/tests/unit/meal-photo-reconcile.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  recalculateMealTotals,
+  deletePhotosWithFoodItems,
+} from '../../packages/backend/src/services/meal-photo.service';
+
+/**
+ * Unit tests for the consolidated meal-totals / photo-deletion helpers (#101).
+ * A minimal drizzle-shaped mock records the calls so we can assert the
+ * reconcile logic without a real DB.
+ */
+function makeDb() {
+  const deleteWhere = vi.fn().mockResolvedValue(undefined);
+  const del = vi.fn((_table: unknown) => ({ where: deleteWhere }));
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+  const updateSet = vi.fn((_values: Record<string, unknown>) => ({ where: updateWhere }));
+  const update = vi.fn((_table: unknown) => ({ set: updateSet }));
+  const findMany = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db: any = {
+    delete: del,
+    update,
+    query: { mealFoodItems: { findMany } },
+  };
+  return { db, del, update, updateSet, findMany };
+}
+
+describe('recalculateMealTotals (#101 SSoT)', () => {
+  it('sums food items and persists the totals to meal_records', async () => {
+    const { db, updateSet, findMany } = makeDb();
+    findMany.mockResolvedValue([
+      { name: 'A', calories: 100, protein: 10, fat: 5, carbs: 20 },
+      { name: 'B', calories: 50, protein: 5, fat: 3, carbs: 10 },
+    ]);
+
+    const totals = await recalculateMealTotals(db, 'meal-1');
+
+    expect(totals).toEqual({ calories: 150, protein: 15, fat: 8, carbs: 30 });
+    // Totals + concatenated content are written back to meal_records.
+    const written = updateSet.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written).toMatchObject({
+      calories: 150,
+      totalProtein: 15,
+      totalFat: 8,
+      totalCarbs: 30,
+      content: 'A, B',
+    });
+  });
+
+  it('returns zeros for a meal with no food items', async () => {
+    const { db, findMany } = makeDb();
+    findMany.mockResolvedValue([]);
+
+    const totals = await recalculateMealTotals(db, 'meal-empty');
+
+    expect(totals).toEqual({ calories: 0, protein: 0, fat: 0, carbs: 0 });
+  });
+});
+
+describe('deletePhotosWithFoodItems (#101)', () => {
+  it("deletes each photo's food items + row, removes the R2 object, then recomputes", async () => {
+    const { db, del, findMany } = makeDb();
+    // Remaining food items after the photos (and their items) are removed.
+    findMany.mockResolvedValue([{ name: 'C', calories: 70, protein: 7, fat: 3, carbs: 12 }]);
+    const photoStorage = { deletePhoto: vi.fn().mockResolvedValue(undefined) };
+
+    const totals = await deletePhotosWithFoodItems(
+      db,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      photoStorage as any,
+      'meal-1',
+      [
+        { id: 'p1', photoKey: 'k1' },
+        { id: 'p2', photoKey: 'k2' },
+      ]
+    );
+
+    // 2 photos × (food-items delete + photo-row delete) = 4 delete calls.
+    expect(del).toHaveBeenCalledTimes(4);
+    // Each photo's R2 object is deleted.
+    expect(photoStorage.deletePhoto).toHaveBeenCalledWith('k1');
+    expect(photoStorage.deletePhoto).toHaveBeenCalledWith('k2');
+    // Totals recomputed from the remaining food items.
+    expect(totals).toEqual({ calories: 70, protein: 7, fat: 3, carbs: 12 });
+  });
+
+  it('tolerates an R2 deletion failure and still recomputes totals', async () => {
+    const { db, findMany } = makeDb();
+    findMany.mockResolvedValue([]);
+    const photoStorage = { deletePhoto: vi.fn().mockRejectedValue(new Error('R2 down')) };
+
+    const totals = await deletePhotosWithFoodItems(
+      db,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      photoStorage as any,
+      'meal-1',
+      [{ id: 'p1', photoKey: 'k1' }]
+    );
+
+    expect(totals).toEqual({ calories: 0, protein: 0, fat: 0, carbs: 0 });
+  });
+});


### PR DESCRIPTION
## 概要

食事写真の削除経路が複数あり、集計元・後処理が不統一だった。

- 正規パス `DELETE /api/meals/:id/photos/:photoId`（`meals.ts`）は明細削除＋totals再計算済みで正しい。
- **壊れた2経路**（`meal-analysis.ts`）: `DELETE /:mealId/photo`（全写真削除）と `POST /:mealId/photo`（レガシー単一置換）は `meal_photos` 行を直接削除するだけで、**(a) 明細(`meal_food_items`)を削除せず、(b) `meal_records` totals も再計算しない**。
- さらに `meal_food_items.photo_id` の FK が `ON DELETE SET NULL`（明細を孤児として残す）で、明細を消すアプリ実装と逆方向・死蔵していた。

→ 壊れた経路では明細が `photo_id=NULL` で残存し totals が古いまま（**写真ゼロなのに totals 非ゼロ / 旧明細の蓄積**＝3階層の不整合）。

Closes #101

## 変更

1. **共通関数に集約**（`services/meal-photo.service.ts`）:
   - `recalculateMealTotals(db, mealId)`: `meal_food_items` を唯一の集計元(SSoT)として `meal_records` totals/content を再計算・永続化。`meal-analysis.ts` の旧 private `recalculateTotals` を統合（3呼出元も差し替え）。
   - `deletePhotosWithFoodItems(db, photoStorage, mealId, photos)`: 写真ごとに「明細削除＋`meal_photos`行削除＋R2削除(best-effort)」を行い、最後に totals 再計算。
2. **3経路を共通関数経由に統一**: `meals.ts` 正規パス（LAST_PHOTO/404 ガード維持）、`meal-analysis.ts` 全削除、レガシー置換。
3. **FK を実態に整合**: `meal_food_items.photo_id` を `ON DELETE SET NULL` → `ON DELETE CASCADE`（`schema.ts` + migration `0035`、0031 と同じテーブル再構築手法）。万一写真行を直接消しても明細が自動削除される多層防御。
4. 死蔵化した `MealPhotoService.deletePhoto` を削除（旧テスト内の同メソッド参照ブロックも除去。※ `packages/backend/tests/` はランナー未接続の孤児ツリーで、本対応は dangling 参照の掃除）。

## 検証

- ✅ **FK CASCADE（実D1）**: 写真行削除で紐づく明細が自動削除（`linked=0`）、`photo_id=NULL` 明細は残存（`null=1`）。
- ✅ **End-to-end（実バックエンド）**: seed した食事（130kcal = 写真紐づき100 + NULL明細30）に `DELETE /:mealId/photo` → 写真0・紐づき明細削除・NULL明細残存・`meal_records.calories` を **130→30 に再計算**・content も再計算。
- ✅ **ユニットテスト追加**（`meal-photo-reconcile.test.ts`）: `recalculateMealTotals`（合計・空・永続化）/ `deletePhotosWithFoodItems`（明細＋写真行delete回数・R2削除・再計算・R2失敗耐性）。
- ✅ migration 0035 ローカル適用OK。`pnpm typecheck` / `lint`(0 error) / `test:unit`(237 passed) / `find-deadcode`(0件)。
- ✅ 敵対的レビュー（3視点 → 各finding独立検証）実施。

## 補足

- `recalculateMealTotals` は p/f/c を小数第1位に丸める（他の再計算呼出と統一）。旧 `meals.ts` のインライン再計算は未丸めだったが、応答値の丸めが揃う方向の改善。
- ⚠ PR Preview ではマイグレーション自動適用なし。`0035` は本番デプロイ時に適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
