### PR TITLE
perf: recorded_atの範囲フィルタをDB側に降ろしindex range scanを有効化 (#103)

### DIFF
--- a/packages/backend/src/lib/localDate.ts
+++ b/packages/backend/src/lib/localDate.ts
@@ -1,0 +1,33 @@
+/**
+ * Local-date helpers for filtering recorded_at on the DB side (#103).
+ *
+ * recorded_at is stored as an offset-aware ISO string whose first 10 characters
+ * are the local date ("2026-01-17T08:00:00+09:00" -> "2026-01-17"). Because of
+ * that prefix property, a local-date range filter can be pushed into SQL as a
+ * lexicographic range on recorded_at itself — and it is EXACTLY equivalent to
+ * the JS `extractLocalDate(recordedAt)` comparison:
+ *
+ *   extractLocalDate(r) >= start   <=>   r >= start
+ *   extractLocalDate(r) <= end     <=>   r <  nextLocalDate(end)
+ *
+ * (The upper bound is exclusive of the *next* day so the whole `end` day is
+ * included regardless of the time/offset suffix.) Using these against the
+ * idx_*_user_date indexes turns a full-history scan into a range scan.
+ */
+
+/** First 10 chars (YYYY-MM-DD): the local date of an offset-aware ISO string. */
+export function extractLocalDate(recordedAt: string): string {
+  return recordedAt.slice(0, 10);
+}
+
+/**
+ * The day after a YYYY-MM-DD local date, as YYYY-MM-DD. Used as an EXCLUSIVE
+ * upper bound so that `recordedAt < nextLocalDate(end)` includes every record
+ * on the `end` day (any time/offset).
+ */
+export function nextLocalDate(localDate: string): string {
+  const base = extractLocalDate(localDate);
+  const d = new Date(`${base}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}

--- a/packages/backend/src/services/dashboard.ts
+++ b/packages/backend/src/services/dashboard.ts
@@ -1,19 +1,7 @@
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and, gte, lt } from 'drizzle-orm';
 import { weights, meals, exercises } from '../db/schema';
 import type { Database } from '../db';
-
-/**
- * Extract local date from ISO 8601 datetime with offset.
- * For offset-aware strings like "2026-01-17T08:00:00+09:00",
- * the first 10 characters are always the local date.
- *
- * @example
- * extractLocalDate("2026-01-17T08:00:00+09:00") // "2026-01-17"
- * extractLocalDate("2026-01-16T23:00:00Z")     // "2026-01-16"
- */
-export const extractLocalDate = (recordedAt: string): string => {
-  return recordedAt.slice(0, 10);
-};
+import { extractLocalDate, nextLocalDate } from '../lib/localDate';
 
 interface DateRange {
   startDate: Date;
@@ -125,38 +113,54 @@ export class DashboardService {
     const startISO = startDate.toISOString();
     const endISO = endDate.toISOString();
 
-    // recorded_at carries a local offset (e.g. "+09:00"); the period bounds are
-    // instants. Comparing the raw ISO strings in SQL mixes "Z" and "+09:00"
-    // forms, and SQLite's lexicographic TEXT compare then drifts by the offset,
-    // systematically dropping/mixing edge records (#99). Filter by LOCAL date
-    // instead — the approach getDailyActivity and the meal/weight services use.
+    // recorded_at's first 10 chars are the local date. Push a LOCAL-date range
+    // into SQL — gte(startLocal) + lt(nextDay(endLocal)) — so the
+    // idx_*_user_date range scan is used instead of fetching the whole history
+    // and filtering in JS (#103). This is exactly equivalent to the previous
+    // extractLocalDate JS filter (#99), including the "+09:00" vs "Z" handling.
     const startLocalDate = extractLocalDate(startISO);
     const endLocalDate = extractLocalDate(endISO);
-    const inRange = (recordedAt: string): boolean => {
-      const localDate = extractLocalDate(recordedAt);
-      return localDate >= startLocalDate && localDate <= endLocalDate;
-    };
+    const endExclusive = nextLocalDate(endLocalDate);
 
-    // Get weight data, then filter by local date (kept ordered so the summary
-    // start/end weights are the chronological first/last in range).
-    const weightRecords = (
-      await this.db
-        .select()
-        .from(weights)
-        .where(eq(weights.userId, userId))
-        .orderBy(weights.recordedAt)
-        .all()
-    ).filter((r) => inRange(r.recordedAt));
+    // Weight data (kept ordered so summary start/end weights are first/last).
+    const weightRecords = await this.db
+      .select()
+      .from(weights)
+      .where(
+        and(
+          eq(weights.userId, userId),
+          gte(weights.recordedAt, startLocalDate),
+          lt(weights.recordedAt, endExclusive)
+        )
+      )
+      .orderBy(weights.recordedAt)
+      .all();
 
-    // Get meal data, then filter by local date
-    const mealRecords = (
-      await this.db.select().from(meals).where(eq(meals.userId, userId)).all()
-    ).filter((r) => inRange(r.recordedAt));
+    // Meal data
+    const mealRecords = await this.db
+      .select()
+      .from(meals)
+      .where(
+        and(
+          eq(meals.userId, userId),
+          gte(meals.recordedAt, startLocalDate),
+          lt(meals.recordedAt, endExclusive)
+        )
+      )
+      .all();
 
-    // Get exercise data, then filter by local date
-    const exerciseRecords = (
-      await this.db.select().from(exercises).where(eq(exercises.userId, userId)).all()
-    ).filter((r) => inRange(r.recordedAt));
+    // Exercise data
+    const exerciseRecords = await this.db
+      .select()
+      .from(exercises)
+      .where(
+        and(
+          eq(exercises.userId, userId),
+          gte(exercises.recordedAt, startLocalDate),
+          lt(exercises.recordedAt, endExclusive)
+        )
+      )
+      .all();
 
     // Calculate weight summary
     const weightSummary = this.calculateWeightSummary(weightRecords);
@@ -288,24 +292,48 @@ export class DashboardService {
   async getWeeklyTrend(userId: string, weeks: number = 4): Promise<WeeklyTrendItem[]> {
     const endDate = new Date();
 
-    // Fetch each dataset once, then bucket by LOCAL date per week. Filtering by
-    // local date (not a raw ISO compare) avoids the "+09:00" vs "Z"
-    // lexicographic drift that dropped edge records (#99).
+    // Bound the fetch to the overall trend window [oldest weekStart .. today] on
+    // the DB side so only that window is read instead of the whole history
+    // (#103); the per-week bucketing below stays in JS. The oldest week starts
+    // (weeks-1)*7 + 6 days before today.
+    const overallStart = new Date(endDate);
+    overallStart.setDate(overallStart.getDate() - ((weeks - 1) * 7 + 6));
+    const rangeStartLocal = extractLocalDate(overallStart.toISOString());
+    const rangeEndExclusive = nextLocalDate(extractLocalDate(endDate.toISOString()));
+
     const allWeights = await this.db
       .select()
       .from(weights)
-      .where(eq(weights.userId, userId))
+      .where(
+        and(
+          eq(weights.userId, userId),
+          gte(weights.recordedAt, rangeStartLocal),
+          lt(weights.recordedAt, rangeEndExclusive)
+        )
+      )
       .orderBy(desc(weights.recordedAt))
       .all();
     const allMeals = await this.db
       .select()
       .from(meals)
-      .where(eq(meals.userId, userId))
+      .where(
+        and(
+          eq(meals.userId, userId),
+          gte(meals.recordedAt, rangeStartLocal),
+          lt(meals.recordedAt, rangeEndExclusive)
+        )
+      )
       .all();
     const allExercises = await this.db
       .select()
       .from(exercises)
-      .where(eq(exercises.userId, userId))
+      .where(
+        and(
+          eq(exercises.userId, userId),
+          gte(exercises.recordedAt, rangeStartLocal),
+          lt(exercises.recordedAt, rangeEndExclusive)
+        )
+      )
       .all();
 
     const result: WeeklyTrendItem[] = [];
@@ -372,15 +400,21 @@ export class DashboardService {
       .limit(1)
       .all();
 
-    // Get weekly exercise total (filtered by local date)
-    const weeklyExercises = (
-      await this.db.select().from(exercises).where(eq(exercises.userId, userId)).all()
-    ).filter((e) => extractLocalDate(e.recordedAt) >= weekStartLocal);
+    // Get weekly exercise total — filtered by local date on the DB side (#103).
+    // gte(recordedAt, weekStartLocal) is equivalent to the extractLocalDate >=
+    // comparison; there is no upper bound (everything from weekStart forward).
+    const weeklyExercises = await this.db
+      .select()
+      .from(exercises)
+      .where(and(eq(exercises.userId, userId), gte(exercises.recordedAt, weekStartLocal)))
+      .all();
 
-    // Get weekly meals (filtered by local date)
-    const weeklyMeals = (
-      await this.db.select().from(meals).where(eq(meals.userId, userId)).all()
-    ).filter((m) => extractLocalDate(m.recordedAt) >= weekStartLocal);
+    // Get weekly meals — filtered by local date on the DB side (#103).
+    const weeklyMeals = await this.db
+      .select()
+      .from(meals)
+      .where(and(eq(meals.userId, userId), gte(meals.recordedAt, weekStartLocal)))
+      .all();
 
     const currentWeight = latestWeight.length > 0 ? latestWeight[0]?.weight ?? null : null;
     const targetWeight = goals.targetWeight || 65;
@@ -452,19 +486,22 @@ export class DashboardService {
       current.setDate(current.getDate() + 1);
     }
 
-    // Get all weight records for user, then filter by local date
-    // This avoids string comparison issues with mixed timezone formats
-    const allWeightRecords = await this.db
+    // Push the local-date range into SQL so the idx_*_user_date range scan is
+    // used instead of fetching the user's whole history (#103). gte(start) +
+    // lt(nextDay(end)) is equivalent to the extractLocalDate filter.
+    const endExclusive = nextLocalDate(endDateStr);
+
+    const weightRecords = await this.db
       .select({ recordedAt: weights.recordedAt, weight: weights.weight })
       .from(weights)
-      .where(eq(weights.userId, userId))
+      .where(
+        and(
+          eq(weights.userId, userId),
+          gte(weights.recordedAt, startDateStr),
+          lt(weights.recordedAt, endExclusive)
+        )
+      )
       .all();
-
-    // Filter by local date range
-    const weightRecords = allWeightRecords.filter((r) => {
-      const localDate = extractLocalDate(r.recordedAt);
-      return localDate >= startDateStr && localDate <= endDateStr;
-    });
 
     // Map date to latest weight value using extractLocalDate
     const weightByDate = new Map<string, number>();
@@ -473,18 +510,17 @@ export class DashboardService {
       weightByDate.set(date, r.weight);
     }
 
-    // Get all meal records for user, then filter by local date
-    const allMealRecords = await this.db
+    const mealRecords = await this.db
       .select({ recordedAt: meals.recordedAt, calories: meals.calories })
       .from(meals)
-      .where(eq(meals.userId, userId))
+      .where(
+        and(
+          eq(meals.userId, userId),
+          gte(meals.recordedAt, startDateStr),
+          lt(meals.recordedAt, endExclusive)
+        )
+      )
       .all();
-
-    // Filter by local date range
-    const mealRecords = allMealRecords.filter((r) => {
-      const localDate = extractLocalDate(r.recordedAt);
-      return localDate >= startDateStr && localDate <= endDateStr;
-    });
 
     // Map date to total calories using extractLocalDate
     const caloriesByDate = new Map<string, number>();
@@ -494,18 +530,17 @@ export class DashboardService {
       caloriesByDate.set(date, current + (r.calories || 0));
     }
 
-    // Get all exercise records for user, then filter by local date
-    const allExerciseRecords = await this.db
+    const exerciseRecords = await this.db
       .select({ recordedAt: exercises.recordedAt })
       .from(exercises)
-      .where(eq(exercises.userId, userId))
+      .where(
+        and(
+          eq(exercises.userId, userId),
+          gte(exercises.recordedAt, startDateStr),
+          lt(exercises.recordedAt, endExclusive)
+        )
+      )
       .all();
-
-    // Filter by local date range
-    const exerciseRecords = allExerciseRecords.filter((r) => {
-      const localDate = extractLocalDate(r.recordedAt);
-      return localDate >= startDateStr && localDate <= endDateStr;
-    });
 
     // Map date to total sets using extractLocalDate
     const setsByDate = new Map<string, number>();

--- a/packages/backend/src/services/exercise.ts
+++ b/packages/backend/src/services/exercise.ts
@@ -1,8 +1,9 @@
-import { eq, desc, and, sql } from 'drizzle-orm';
+import { eq, desc, and, sql, gte, lt } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { Database } from '../db';
 import { schema } from '../db';
 import { AppError } from '../middleware/error';
+import { extractLocalDate, nextLocalDate } from '../lib/localDate';
 import type { CreateExerciseInput, UpdateExerciseInput, ExerciseImportSummary, ExerciseRecord, RecentExerciseItem } from '@lifestyle-app/shared';
 import { z } from 'zod';
 import { createExerciseSetsSchema, calculate1RM } from '@lifestyle-app/shared';
@@ -114,38 +115,33 @@ export class ExerciseService {
     userId: string,
     options?: { startDate?: string; endDate?: string; limit?: number; exerciseType?: string }
   ) {
-    const records = await this.db
+    // Push filters into SQL so the idx_exercise_user_type_date range scan is
+    // used instead of fetching the user's whole history and filtering in JS
+    // (#103). For bare "YYYY-MM-DD" bounds (the /, /summary, /weekly callers)
+    // this is exactly equivalent to the old `recordedAt.split('T')[0]` compare.
+    // For full-ISO bounds (the /by-date route passes `${date}T00:00:00.000Z`),
+    // the old `'YYYY-MM-DD' >= '...T00:00:00.000Z'` was always false and dropped
+    // every same-day row — normalizing via extractLocalDate FIXES that.
+    const conditions = [eq(schema.exerciseRecords.userId, userId)];
+    if (options?.exerciseType) {
+      conditions.push(eq(schema.exerciseRecords.exerciseType, options.exerciseType));
+    }
+    if (options?.startDate) {
+      conditions.push(gte(schema.exerciseRecords.recordedAt, extractLocalDate(options.startDate)));
+    }
+    if (options?.endDate) {
+      conditions.push(lt(schema.exerciseRecords.recordedAt, nextLocalDate(options.endDate)));
+    }
+
+    const baseQuery = this.db
       .select()
       .from(schema.exerciseRecords)
-      .where(eq(schema.exerciseRecords.userId, userId))
-      .orderBy(desc(schema.exerciseRecords.recordedAt))
-      .all();
+      .where(and(...conditions))
+      .orderBy(desc(schema.exerciseRecords.recordedAt));
 
-    let filtered = records;
-
-    if (options?.exerciseType) {
-      filtered = filtered.filter((r) => r.exerciseType === options.exerciseType);
-    }
-
-    if (options?.startDate) {
-      filtered = filtered.filter((r) => {
-        const recordDate = r.recordedAt.split('T')[0] ?? '';
-        return recordDate >= options.startDate!;
-      });
-    }
-
-    if (options?.endDate) {
-      filtered = filtered.filter((r) => {
-        const recordDate = r.recordedAt.split('T')[0] ?? '';
-        return recordDate <= options.endDate!;
-      });
-    }
-
-    if (options?.limit) {
-      filtered = filtered.slice(0, options.limit);
-    }
-
-    return filtered;
+    return options?.limit
+      ? await baseQuery.limit(options.limit).all()
+      : await baseQuery.all();
   }
 
   async getLastByType(userId: string, exerciseType: string) {

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -1,10 +1,10 @@
-import { eq, desc, inArray } from 'drizzle-orm';
+import { eq, desc, inArray, and, gte, lt } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { Database } from '../db';
 import { schema } from '../db';
 import { AppError } from '../middleware/error';
 import type { CreateMealInput, UpdateMealInput, MealType } from '@lifestyle-app/shared';
-import { extractLocalDate } from './dashboard';
+import { extractLocalDate, nextLocalDate } from '../lib/localDate';
 
 export class MealService {
   constructor(private db: Database) {}
@@ -58,46 +58,31 @@ export class MealService {
     userId: string,
     options?: { startDate?: string; endDate?: string; mealType?: MealType; limit?: number }
   ) {
-    const records = await this.db
+    // Push filters into SQL so the idx_meal_user_date range scan is used instead
+    // of fetching the user's whole history and filtering in JS (#103). The
+    // local-date range gte(extractLocalDate(start)) + lt(nextLocalDate(end)) is
+    // exactly equivalent to the previous extractLocalDate JS comparison (handles
+    // both "YYYY-MM-DD" and full ISO start/end inputs and the "+09:00"/"Z" mix).
+    const conditions = [eq(schema.mealRecords.userId, userId)];
+    if (options?.startDate) {
+      conditions.push(gte(schema.mealRecords.recordedAt, extractLocalDate(options.startDate)));
+    }
+    if (options?.endDate) {
+      conditions.push(lt(schema.mealRecords.recordedAt, nextLocalDate(options.endDate)));
+    }
+    if (options?.mealType) {
+      conditions.push(eq(schema.mealRecords.mealType, options.mealType));
+    }
+
+    const baseQuery = this.db
       .select()
       .from(schema.mealRecords)
-      .where(eq(schema.mealRecords.userId, userId))
-      .orderBy(desc(schema.mealRecords.recordedAt))
-      .all();
+      .where(and(...conditions))
+      .orderBy(desc(schema.mealRecords.recordedAt));
 
-    let filtered = records;
-
-    if (options?.startDate) {
-      // recordedAtのオフセット付きISO形式から直接ローカル日付を抽出して比較
-      // 例: "2026-01-17T08:00:00+09:00" → "2026-01-17"
-      const isIsoFormat = options.startDate.includes('T');
-      if (isIsoFormat) {
-        // ISO形式の場合は日付部分を抽出して比較
-        const startLocalDate = extractLocalDate(options.startDate);
-        filtered = filtered.filter((r) => extractLocalDate(r.recordedAt) >= startLocalDate);
-      } else {
-        // YYYY-MM-DD形式の場合はそのまま比較
-        filtered = filtered.filter((r) => extractLocalDate(r.recordedAt) >= options.startDate!);
-      }
-    }
-
-    if (options?.endDate) {
-      const isIsoFormat = options.endDate.includes('T');
-      if (isIsoFormat) {
-        const endLocalDate = extractLocalDate(options.endDate);
-        filtered = filtered.filter((r) => extractLocalDate(r.recordedAt) <= endLocalDate);
-      } else {
-        filtered = filtered.filter((r) => extractLocalDate(r.recordedAt) <= options.endDate!);
-      }
-    }
-
-    if (options?.mealType) {
-      filtered = filtered.filter((r) => r.mealType === options.mealType);
-    }
-
-    if (options?.limit) {
-      filtered = filtered.slice(0, options.limit);
-    }
+    const filtered = options?.limit
+      ? await baseQuery.limit(options.limit).all()
+      : await baseQuery.all();
 
     // Get photo counts, first photo keys, and photos array for all filtered meals
     const mealIds = filtered.map((m) => m.id);

--- a/packages/backend/src/services/weight.ts
+++ b/packages/backend/src/services/weight.ts
@@ -1,5 +1,6 @@
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and, gte, lt } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
+import { extractLocalDate, nextLocalDate } from '../lib/localDate';
 import type { Database } from '../db';
 import { schema } from '../db';
 import { AppError } from '../middleware/error';
@@ -53,31 +54,28 @@ export class WeightService {
     userId: string,
     options?: { startDate?: string; endDate?: string; limit?: number }
   ) {
-    const query = this.db
+    // Push filters into SQL so the idx_weight_user_date range scan is used
+    // instead of fetching the user's whole history and filtering in JS (#103).
+    // Filter by LOCAL date (gte(extractLocalDate(start)) + lt(nextLocalDate(end)))
+    // — this both enables the index AND fixes the previous full-string compare,
+    // which excluded same-day records when end was a bare "YYYY-MM-DD" date.
+    const conditions = [eq(schema.weightRecords.userId, userId)];
+    if (options?.startDate) {
+      conditions.push(gte(schema.weightRecords.recordedAt, extractLocalDate(options.startDate)));
+    }
+    if (options?.endDate) {
+      conditions.push(lt(schema.weightRecords.recordedAt, nextLocalDate(options.endDate)));
+    }
+
+    const baseQuery = this.db
       .select()
       .from(schema.weightRecords)
-      .where(eq(schema.weightRecords.userId, userId))
+      .where(and(...conditions))
       .orderBy(desc(schema.weightRecords.recordedAt));
 
-    // Note: For D1/SQLite, complex queries need to be built differently
-    // This is a simplified version
-    const records = await query.all();
-
-    let filtered = records;
-
-    if (options?.startDate) {
-      filtered = filtered.filter((r) => r.recordedAt >= options.startDate!);
-    }
-
-    if (options?.endDate) {
-      filtered = filtered.filter((r) => r.recordedAt <= options.endDate!);
-    }
-
-    if (options?.limit) {
-      filtered = filtered.slice(0, options.limit);
-    }
-
-    return filtered;
+    return options?.limit
+      ? await baseQuery.limit(options.limit).all()
+      : await baseQuery.all();
   }
 
   async update(id: string, userId: string, input: UpdateWeightInput) {

--- a/tests/integration/meals.test.ts
+++ b/tests/integration/meals.test.ts
@@ -263,4 +263,47 @@ describe('Meal API Integration Tests', () => {
       expect(true).toBe(true);
     });
   });
+
+  // #103: the date-range filter is pushed into SQL (gte(start) + lt(nextDay(end))
+  // on recorded_at). Verify the local-day boundary against a real backend: a
+  // same-local-day JST record (even early-morning / late-night) is included, and
+  // the adjacent local days are excluded.
+  describe('GET /api/meals — date range boundary (#103)', () => {
+    it('includes only the requested local day, excluding the adjacent days', async () => {
+      const tag = `tz103-${Date.now()}`;
+      const createMeal = async (recordedAt: string, content: string): Promise<string> => {
+        const res = await session.request('/api/meals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mealType: 'lunch', content, calories: 100, recordedAt }),
+        });
+        expect(res.status).toBe(201);
+        const data = (await res.json()) as { meal: { id: string } };
+        return data.meal.id;
+      };
+
+      // 23:30 JST on the 16th, 07:00 JST on the 17th, 07:00 JST on the 18th.
+      const id16 = await createMeal('2026-01-16T23:30:00+09:00', `${tag}-d16`);
+      const id17 = await createMeal('2026-01-17T07:00:00+09:00', `${tag}-d17`);
+      const id18 = await createMeal('2026-01-18T07:00:00+09:00', `${tag}-d18`);
+
+      try {
+        const res = await session.request('/api/meals?startDate=2026-01-17&endDate=2026-01-17');
+        expect(res.status).toBe(200);
+        const json = (await res.json()) as
+          | { meals?: Array<{ id: string }> }
+          | Array<{ id: string }>;
+        const meals: Array<{ id: string }> = Array.isArray(json) ? json : json.meals ?? [];
+        const ids = new Set(meals.map((m) => m.id));
+
+        expect(ids.has(id17)).toBe(true); // same local day (07:00 JST) — included
+        expect(ids.has(id16)).toBe(false); // previous local day — excluded
+        expect(ids.has(id18)).toBe(false); // next local day — excluded
+      } finally {
+        for (const id of [id16, id17, id18]) {
+          await session.request(`/api/meals/${id}`, { method: 'DELETE' });
+        }
+      }
+    });
+  });
 });

--- a/tests/unit/dashboard.service.test.ts
+++ b/tests/unit/dashboard.service.test.ts
@@ -237,29 +237,24 @@ describe('DashboardService', () => {
   // code the boundary used startDate.toISOString() (a "Z" instant), which
   // dropped/mixed records near the day edge.
   describe('timezone boundary (#99)', () => {
-    it('getSummary keeps JST same-day edge records and drops the previous local day', async () => {
+    it('getSummary aggregates the in-range rows the DB returns (range filtered in SQL, #103)', async () => {
       const userId = 'user-tz';
-      // Frontend asks for local day 2026-01-17; the route builds new Date('2026-01-17').
       const startDate = new Date('2026-01-17');
       const endDate = new Date('2026-01-17');
 
+      // The date range is now filtered in SQL — gte(startLocal) + lt(nextDay(end))
+      // on recorded_at (#103) — so the query returns only the Jan-17 rows; a
+      // previous-day row never reaches JS. (The actual SQL boundary
+      // inclusion/exclusion is covered by the dashboard range integration/e2e.)
       mockDb.all.mockResolvedValueOnce([]); // weights
       mockDb.all.mockResolvedValueOnce([
-        // 23:30 JST on Jan 17 (14:30Z same day): the old end-bound (Z midnight)
-        // dropped this true same-day record.
         { calories: 700, mealType: 'dinner', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-17T23:30:00+09:00' },
-        // 07:00 JST on Jan 17 (22:00Z on the 16th): still belongs to Jan 17.
         { calories: 300, mealType: 'breakfast', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-17T07:00:00+09:00' },
-        // Previous local day — must be excluded.
-        { calories: 999, mealType: 'dinner', totalProtein: 0, totalFat: 0, totalCarbs: 0, recordedAt: '2026-01-16T23:30:00+09:00' },
       ]);
       mockDb.all.mockResolvedValueOnce([]); // exercises
 
       const result = await service.getSummary(userId, { startDate, endDate });
 
-      // Both Jan-17 records counted; the Jan-16 one excluded. (Old code returned
-      // all 3 because the SQL bound is a no-op against the mock and there was no
-      // local-date filter.)
       expect(result.meals.mealCount).toBe(2);
       expect(result.meals.totalCalories).toBe(1000);
     });
@@ -300,15 +295,15 @@ describe('DashboardService', () => {
         expect(result[0]!.weight).toBe(70.0);
       });
 
-      it('getGoalProgress filters by local date and averages calories per local day', async () => {
-        // now=2026-01-17T05:00:00Z => weekStart (local) = 2026-01-10
+      it('getGoalProgress aggregates the weekly rows the DB returns (range filtered in SQL, #103)', async () => {
+        // The weekly window is now filtered in SQL — gte(weekStartLocal) on
+        // recorded_at (#103) — so the query returns only in-window rows.
         mockDb.all.mockResolvedValueOnce([{ weight: 68.0 }]); // latest weight
         mockDb.all.mockResolvedValueOnce([
-          { reps: 10, recordedAt: '2026-01-17T23:30:00+09:00' }, // local 01-17 >= 01-10 => kept
-          { reps: 8, recordedAt: '2026-01-09T12:00:00+09:00' }, // local 01-09 < 01-10 => dropped
+          { reps: 10, recordedAt: '2026-01-17T23:30:00+09:00' },
         ]); // weekly exercises
         mockDb.all.mockResolvedValueOnce([
-          { calories: 1950, recordedAt: '2026-01-17T23:30:00+09:00' }, // kept; one local day
+          { calories: 1950, recordedAt: '2026-01-17T23:30:00+09:00' }, // one local day
         ]); // weekly meals
 
         const result = await service.getGoalProgress('user-tz', {
@@ -316,9 +311,7 @@ describe('DashboardService', () => {
           dailyCalories: 2000,
         });
 
-        // Edge record kept, stale (pre-window) one dropped.
         expect(result.exercise.currentSets).toBe(1);
-        // 1950 over a single local day.
         expect(result.calories.average).toBe(1950);
       });
     });

--- a/tests/unit/localDate.test.ts
+++ b/tests/unit/localDate.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { extractLocalDate, nextLocalDate } from '../../packages/backend/src/lib/localDate';
+
+describe('extractLocalDate', () => {
+  it('takes the first 10 chars (local date) of an offset-aware ISO string', () => {
+    expect(extractLocalDate('2026-01-17T08:00:00+09:00')).toBe('2026-01-17');
+    expect(extractLocalDate('2026-01-16T23:00:00Z')).toBe('2026-01-16');
+    expect(extractLocalDate('2026-01-17')).toBe('2026-01-17');
+  });
+});
+
+describe('nextLocalDate (exclusive upper bound for #103 range filters)', () => {
+  it('returns the next calendar day', () => {
+    expect(nextLocalDate('2026-01-17')).toBe('2026-01-18');
+  });
+
+  it('rolls over month boundaries', () => {
+    expect(nextLocalDate('2026-01-31')).toBe('2026-02-01');
+    expect(nextLocalDate('2026-04-30')).toBe('2026-05-01');
+  });
+
+  it('rolls over year boundaries', () => {
+    expect(nextLocalDate('2026-12-31')).toBe('2027-01-01');
+  });
+
+  it('handles leap years', () => {
+    expect(nextLocalDate('2024-02-28')).toBe('2024-02-29');
+    expect(nextLocalDate('2024-02-29')).toBe('2024-03-01');
+    expect(nextLocalDate('2026-02-28')).toBe('2026-03-01'); // non-leap
+  });
+
+  it('accepts a full ISO string and uses only its local date', () => {
+    expect(nextLocalDate('2026-01-17T23:30:00+09:00')).toBe('2026-01-18');
+  });
+
+  it('is consistent with the local-date range equivalence', () => {
+    // extractLocalDate(r) <= end   <=>   r < nextLocalDate(end)
+    const end = '2026-01-17';
+    const exclusive = nextLocalDate(end);
+    // A same-day record (any time/offset) is < the exclusive bound...
+    expect('2026-01-17T23:59:59+09:00' < exclusive).toBe(true);
+    // ...and a next-day record is not.
+    expect('2026-01-18T00:00:00+09:00' < exclusive).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

`recorded_at` の範囲フィルタが DB に降りず JS 側で実行され、複合索引（`idx_meal_user_date` / `idx_weight_user_date` / `idx_exercise_user_type_date`）が range scan として使われていなかった。各サービスの `findByUserId`（meal/exercise/weight）とダッシュボード集計が `eq(userId)` のみでクエリし、ユーザーの**全期間レコードを毎回フル取得**して JS で `filter`/`slice` していた（数百〜数千行に育つとボトルネック）。

TZ混在（`+09:00`/`Z`）回避のため `extractLocalDate` で JS 比較していた点に注意。

Closes #103

## 対応の鍵：ローカル日比較のSQL等価変換

`recorded_at` の先頭10文字がローカル日（`YYYY-MM-DD`）である性質から、JS の `extractLocalDate` 比較は **lexicographic な range 述語に厳密に等価**:

```
extractLocalDate(recordedAt) >= start  ⇔  recordedAt >= start
extractLocalDate(recordedAt) <= end    ⇔  recordedAt <  nextLocalDate(end)   // 翌日を排他的上限に
```

→ 生成列などのスキーマ変更なしで、#99 の安全な意味論を保ったまま index range scan を有効化。

## 変更

- **`lib/localDate.ts`（新規）**: `extractLocalDate`（dashboard.ts から移設・集約）+ `nextLocalDate`（排他的上限。月末/年末/閏年ロールオーバー対応）。
- **`meal.ts` findByUserId**: `startDate`/`endDate`/`mealType`/`limit` を WHERE/`.limit()` で DB に降ろす（写真エンリッチは限定後の集合に対して従来どおり）。
- **`exercise.ts` findByUserId**: 同上（`exerciseType` 含む）。bare-date入力（`/`・`/summary`・`/weekly`）では旧 `split('T')[0]` 比較と等価。フルISO入力の `/by-date`（`${date}T00:00:00.000Z` を渡す）では、旧比較が `'YYYY-MM-DD' >= '...T00:00:00.000Z'` で常に false となり**同日を全件取りこぼしていたバグを修正**（`extractLocalDate` で正規化）。※ `by-date` はフロント未使用。
- **`weight.ts` findByUserId**: 旧「全文字列比較」を**正しいローカル日比較に統一**（index有効化 ＋ bare-date end で同日を取りこぼす潜在バグも解消）。
- **`dashboard.ts`**: `getSummary` / `getDailyActivity` の JS 範囲フィルタを SQL range に置換。`getWeeklyTrend` は全体トレンド窓 `[最古weekStart..今日]` を DB で絞り、週次バケットは JS 維持。`getGoalProgress` は週次 exercises/meals を `gte(weekStartLocal)` で DB フィルタ。

## 検証

- ✅ **実D1 end-to-end で境界フィルタを確認**: `2026-01-16T23:30:00+09:00` / `...17T07:00` / `...17T23:30` / `...18T07:00` を seed し、`GET /api/dashboard/summary?startDate=2026-01-17&endDate=2026-01-17` → `mealCount=2/totalCalories=1000`（Jan-17の2件のみ、Jan-16/18を除外）。`GET /api/meals?startDate=2026-01-17&endDate=2026-01-17` → Jan-17の2件のみ。
- ✅ **ユニットテスト追加**（`localDate.test.ts`）: `extractLocalDate` / `nextLocalDate`（月末・年末・閏年・ISO入力・排他的上限の等価性）。
- ✅ #99 のdashboard境界ユニットは「SQL側でフィルタ済みのDB返却行を集計する」形に更新（mockはWHEREを適用できないため。実フィルタ境界は上記e2eで担保）。`getWeeklyTrend` の inWeek(JS) は不変。
- ✅ `pnpm typecheck` / `lint`(0 error) / `test:unit`(245 passed) / `find-deadcode`(0件)。
- ✅ 敵対的レビュー（3視点・各finding独立検証）実施。

## 補足

- `weight.ts` の挙動は境界でのみ変化（bare-date end で同日を**含む**ように修正）。`exercise`/`meal`/`dashboard` は厳密等価で結果不変・転送量とindex効率のみ改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
