### PR TITLE
chore: 肥大化ログ2表に保持削除追加+AI使用量の生涯累計ロールアップ表導入 (#104)

### DIFF
--- a/packages/backend/migrations/0036_add_ai_usage_totals.sql
+++ b/packages/backend/migrations/0036_add_ai_usage_totals.sql
@@ -1,0 +1,22 @@
+-- Migration 0036: per-user lifetime AI token rollup (#104)
+--
+-- ai_usage_records is append-only and will be pruned (~90 days) by the retention
+-- cron. The settings screen shows a lifetime "total tokens" figure, which would
+-- shrink if it kept summing the (now-pruned) detail rows. This rollup holds the
+-- lifetime total per user; recordUsage increments it on every call and
+-- getSummary reads it, so the displayed total stays correct after pruning.
+--
+-- Backfill the rollup from the existing detail rows so totals are accurate from
+-- day one (including usage recorded before this migration).
+
+CREATE TABLE ai_usage_totals (
+  user_id TEXT PRIMARY KEY NOT NULL,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT INTO ai_usage_totals (user_id, total_tokens, updated_at)
+SELECT user_id, COALESCE(SUM(total_tokens), 0), strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+FROM ai_usage_records
+GROUP BY user_id;

--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -4,6 +4,10 @@
  * Runs daily at 2:00 AM UTC to clean up:
  * 1. Unverified user accounts (>7 days old)
  * 2. Expired/used tokens (>7 days old)
+ * 3. Expired WebAuthn challenges
+ * 4. Append-only logs past their retention window (#104):
+ *    email_delivery_logs and ai_usage_records (detail; lifetime AI total is kept
+ *    in ai_usage_totals so pruning detail does not affect the displayed total).
  */
 
 import { drizzle } from 'drizzle-orm/d1';
@@ -14,6 +18,8 @@ import * as webauthnSchema from '../db/schema/webauthn';
 
 const UNVERIFIED_ACCOUNT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const TOKEN_CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const EMAIL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (operational logs, recipient PII)
+const AI_USAGE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (detail; total kept in rollup)
 
 interface CleanupResult {
   deletedUsers: number;
@@ -21,6 +27,8 @@ interface CleanupResult {
   deletedEmailVerificationTokens: number;
   deletedEmailChangeRequests: number;
   deletedExpiredChallenges: number;
+  deletedEmailLogs: number;
+  deletedAiUsageRecords: number;
 }
 
 /**
@@ -31,6 +39,10 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
   const now = Date.now();
   const unverifiedCutoff = now - UNVERIFIED_ACCOUNT_RETENTION_MS;
   const tokenCutoff = now - TOKEN_CLEANUP_AGE_MS;
+  // Type-matched cutoffs: email_delivery_logs.created_at is INTEGER epoch ms;
+  // ai_usage_records.created_at is TEXT ISO8601.
+  const emailLogCutoffEpoch = now - EMAIL_LOG_RETENTION_MS;
+  const aiUsageCutoffIso = new Date(now - AI_USAGE_RETENTION_MS).toISOString();
 
   console.log('[Cleanup] Starting scheduled cleanup tasks...');
 
@@ -160,12 +172,52 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     console.error('[Cleanup] Error deleting expired WebAuthn challenges:', error);
   }
 
+  // 6. Delete email delivery logs older than the retention window.
+  //    created_at is INTEGER epoch ms; uses idx_email_logs_created_at.
+  let deletedEmailLogs = 0;
+  try {
+    const result = await orm
+      .delete(emailSchema.emailDeliveryLogs)
+      .where(lt(emailSchema.emailDeliveryLogs.createdAt, emailLogCutoffEpoch))
+      .run();
+    deletedEmailLogs = result.meta?.changes ?? 0;
+    console.log(
+      deletedEmailLogs > 0
+        ? `[Cleanup] Deleted ${deletedEmailLogs} old email delivery logs`
+        : '[Cleanup] No old email delivery logs to delete'
+    );
+  } catch (error) {
+    console.error('[Cleanup] Error deleting email delivery logs:', error);
+  }
+
+  // 7. Delete AI usage detail rows older than the retention window. The lifetime
+  //    total lives in ai_usage_totals and daily/monthly views only read recent
+  //    rows, so this does not affect any displayed figure. created_at is TEXT
+  //    ISO8601; uses idx_ai_usage_user_date.
+  let deletedAiUsageRecords = 0;
+  try {
+    const result = await orm
+      .delete(schema.aiUsageRecords)
+      .where(lt(schema.aiUsageRecords.createdAt, aiUsageCutoffIso))
+      .run();
+    deletedAiUsageRecords = result.meta?.changes ?? 0;
+    console.log(
+      deletedAiUsageRecords > 0
+        ? `[Cleanup] Deleted ${deletedAiUsageRecords} old AI usage records`
+        : '[Cleanup] No old AI usage records to delete'
+    );
+  } catch (error) {
+    console.error('[Cleanup] Error deleting AI usage records:', error);
+  }
+
   const result = {
     deletedUsers,
     deletedPasswordResetTokens,
     deletedEmailVerificationTokens,
     deletedEmailChangeRequests,
     deletedExpiredChallenges,
+    deletedEmailLogs,
+    deletedAiUsageRecords,
   };
 
   console.log('[Cleanup] Cleanup tasks completed:', result);

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -139,6 +139,10 @@ export const exerciseRecords = sqliteTable(
   })
 );
 
+// Append-only AI usage detail. Pruned by the retention cron (#104, ~90 days)
+// using idx_ai_usage_user_date; the daily limit/usage views only read the
+// current day, and the lifetime "total tokens" display reads ai_usage_totals,
+// so old detail rows are safe to delete. created_at is TEXT ISO8601.
 export const aiUsageRecords = sqliteTable(
   'ai_usage_records',
   {
@@ -156,6 +160,17 @@ export const aiUsageRecords = sqliteTable(
     idx_ai_usage_user_date: index('idx_ai_usage_user_date').on(table.userId, table.createdAt),
   })
 );
+
+// Per-user lifetime AI token rollup. Maintained incrementally on every
+// recordUsage so the settings "total tokens" display stays accurate even after
+// old ai_usage_records detail rows are pruned by the retention cron (#104).
+export const aiUsageTotals = sqliteTable('ai_usage_totals', {
+  userId: text('user_id')
+    .primaryKey()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  totalTokens: integer('total_tokens').notNull().default(0),
+  updatedAt: text('updated_at').notNull(),
+});
 
 // Aliases for convenience
 export { weightRecords as weights };
@@ -179,6 +194,8 @@ export type MealChatMessage = typeof mealChatMessages.$inferSelect;
 export type NewMealChatMessage = typeof mealChatMessages.$inferInsert;
 export type AIUsageRecord = typeof aiUsageRecords.$inferSelect;
 export type NewAIUsageRecord = typeof aiUsageRecords.$inferInsert;
+export type AIUsageTotal = typeof aiUsageTotals.$inferSelect;
+export type NewAIUsageTotal = typeof aiUsageTotals.$inferInsert;
 
 // Email-related tables
 export * from './schema/email';

--- a/packages/backend/src/db/schema/email.ts
+++ b/packages/backend/src/db/schema/email.ts
@@ -101,7 +101,11 @@ export const emailChangeRequests = sqliteTable(
 /**
  * Email delivery logs table
  *
- * Tracks all email delivery attempts for debugging and monitoring
+ * Tracks all email delivery attempts for debugging and monitoring.
+ * Append-only: rows are INSERTed by the email service and never read back into
+ * any user-facing aggregate. Pruned by the retention cron (~90 days) using
+ * idx_email_logs_created_at; recipient_email is PII, so retention is bounded
+ * (#104). created_at is INTEGER epoch ms.
  */
 export const emailDeliveryLogs = sqliteTable(
   'email_delivery_logs',

--- a/packages/backend/src/services/ai-usage.ts
+++ b/packages/backend/src/services/ai-usage.ts
@@ -1,6 +1,6 @@
 import { eq, sql, and, gte, desc } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
-import { aiUsageRecords, mealRecords } from '../db/schema';
+import { aiUsageRecords, aiUsageTotals, mealRecords } from '../db/schema';
 import { AI_USAGE_LIMITS } from '@lifestyle-app/shared';
 import type { AIFeatureType, AIUsageSummary, AIDailyUsage } from '@lifestyle-app/shared';
 import type { Database } from '../db';
@@ -38,7 +38,23 @@ export class AIUsageService {
         createdAt: new Date().toISOString(),
       };
       console.log('Inserting record:', record);
-      await this.db.insert(aiUsageRecords).values(record);
+      // Write the detail row and increment the per-user lifetime rollup
+      // ATOMICALLY (D1 batch = implicit transaction): either both commit or
+      // neither. The rollup is what getSummary reads and it cannot be rebuilt
+      // once old detail is pruned, so it must never drift from its detail (#104).
+      await this.db.batch([
+        this.db.insert(aiUsageRecords).values(record),
+        this.db
+          .insert(aiUsageTotals)
+          .values({ userId, totalTokens: usage.totalTokens, updatedAt: record.createdAt })
+          .onConflictDoUpdate({
+            target: aiUsageTotals.userId,
+            set: {
+              totalTokens: sql`${aiUsageTotals.totalTokens} + ${usage.totalTokens}`,
+              updatedAt: record.createdAt,
+            },
+          }),
+      ]);
       console.log('Record inserted successfully');
     } catch (error) {
       console.error('Failed to record AI usage:', error);
@@ -50,13 +66,15 @@ export class AIUsageService {
    * Get usage summary for a user.
    */
   async getSummary(userId: string): Promise<AIUsageSummary> {
-    // Get total tokens
+    // Lifetime total comes from the rollup, not the (prunable) detail rows, so
+    // it stays accurate after the retention cron deletes old detail (#104).
     const totalResult = await this.db
-      .select({ total: sql<number>`COALESCE(SUM(${aiUsageRecords.totalTokens}), 0)` })
-      .from(aiUsageRecords)
-      .where(eq(aiUsageRecords.userId, userId));
+      .select({ total: aiUsageTotals.totalTokens })
+      .from(aiUsageTotals)
+      .where(eq(aiUsageTotals.userId, userId));
 
-    // Get monthly tokens (current calendar month)
+    // Get monthly tokens (current calendar month). The current month is always
+    // within the retention window, so detail-based SUM stays accurate.
     const startOfMonth = new Date();
     startOfMonth.setDate(1);
     startOfMonth.setHours(0, 0, 0, 0);

--- a/tests/unit/ai-usage.service.test.ts
+++ b/tests/unit/ai-usage.service.test.ts
@@ -9,7 +9,11 @@ describe('AIUsageService', () => {
     vi.clearAllMocks();
     mockDb = {
       insert: vi.fn().mockReturnThis(),
-      values: vi.fn().mockResolvedValue(undefined),
+      // values()/onConflictDoUpdate() build the statements that are handed to
+      // db.batch([...]) (the detail insert + the ai_usage_totals rollup, #104).
+      values: vi.fn().mockReturnThis(),
+      onConflictDoUpdate: vi.fn().mockReturnThis(),
+      batch: vi.fn().mockResolvedValue([]),
       select: vi.fn().mockReturnThis(),
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockResolvedValue([]),
@@ -82,7 +86,7 @@ describe('AIUsageService', () => {
     });
 
     it('should not throw on database error (fire-and-forget)', async () => {
-      mockDb.values.mockRejectedValue(new Error('Database error'));
+      mockDb.batch.mockRejectedValue(new Error('Database error'));
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const userId = 'user-123';
@@ -102,6 +106,25 @@ describe('AIUsageService', () => {
       );
 
       consoleSpy.mockRestore();
+    });
+
+    it('atomically writes the detail row and the lifetime rollup (ai_usage_totals, #104)', async () => {
+      await service.recordUsage('user-roll', 'image_analysis', {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      });
+
+      // Both statements (detail insert + rollup upsert) go through one atomic batch.
+      expect(mockDb.batch).toHaveBeenCalledTimes(1);
+      expect(mockDb.batch.mock.calls[0][0]).toHaveLength(2);
+      // Two values() builds: the detail row and the rollup upsert.
+      expect(mockDb.values).toHaveBeenCalledTimes(2);
+      // The rollup uses onConflictDoUpdate to add this call's token total.
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+      expect(mockDb.values).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-roll', totalTokens: 150, updatedAt: expect.any(String) })
+      );
     });
   });
 


### PR DESCRIPTION
## 概要

日次cron `executeScheduledCleanup` の削除対象は users(未認証)・各種トークン・webauthn_challenges の5種のみで、**append-only で増え続ける `email_delivery_logs` / `ai_usage_records` に保持・削除が無く無制限肥大化**していた（分析機能の利用に比例。`email_delivery_logs.recipient_email` はPIIで退会後も残存）。

Closes #104

## 対応

### 1. 保持期間の削除をcronに追加（`cron/cleanup.ts`）
webauthn_challenges と同じ `orm.delete(...).where(lt(createdAt, cutoff)).run()` 形式で2つ追加。**型差に対応**:
- `email_delivery_logs`: `created_at` は **INTEGER epoch** → cutoff も epoch。`idx_email_logs_created_at` 利用。90日保持。
- `ai_usage_records`: `created_at` は **TEXT ISO8601** → cutoff は ISO 文字列。`idx_ai_usage_user_date` 利用。90日保持。

### 2. AI使用量の生涯累計ロールアップ表（表示要件の保護）
`Settings` 画面が `totalTokens`=**全期間累計** を表示するため、明細を剪定すると累計が縮む。これを防ぐロールアップ表を導入:
- **`ai_usage_totals`(user_id PK, total_tokens, updated_at)** を追加（`schema.ts`）。
- **migration `0036`**: 表作成 + 既存明細から `SUM(total_tokens) GROUP BY user_id` で**バックフィル**。
- `recordUsage` が明細INSERTに加え `onConflictDoUpdate` で**ロールアップを加算**。
- `getSummary.totalTokens` は**ロールアップ表から読む**（明細剪定に非依存）。`monthlyTokens` は今月明細SUM（今月は常に保持窓内なので正確）。

### 3. スキーマにappend-only/保持方針をコメント明記（両表）

## 検証

- ✅ **実D1 e2e**: migration 0036 が2明細(500+1000)から `ai_usage_totals.total_tokens=1500` を**バックフィル**。`GET /api/user/ai-usage` → `{total:1500, monthly:500}`。**>90日明細を剪定後も `{total:1500, monthly:500}`**（累計はロールアップ由来で不変、明細は1件に減少）。
- ✅ **ユニットテスト**: `recordUsage` がロールアップを `onConflictDoUpdate` で加算（明細+ロールアップの2 insert）を検証。既存 getSummary テストも維持。
- ✅ `pnpm typecheck` / `lint`(0 error) / `test:unit`(246 passed) / `find-deadcode`(0件)。
- ✅ 敵対的レビュー（3視点・各finding独立検証）実施。

## 補足

- 保持は両表 **90日**（`email_delivery_logs` はPIIのため上限付き、`ai_usage_records` は明細のみ・生涯累計は保持）。日次/月次のAI使用量ビューは保持窓内のみ参照するため影響なし（今月は常に保持窓内）。
- `recordUsage` は明細とロールアップを **`db.batch`（D1の暗黙トランザクション）でアトミックに**書き込む。片方だけ成功して累計がドリフトすることはない（敵対的レビューの主要指摘を反映）。`ON CONFLICT ... total_tokens + X` の加算は実D1で確認済み。
- バックフィルは migration 時の1回スナップショット。CIは migrate→deploy 順なので、その僅少な窓で旧コードが記録した明細はロールアップ未計上になりうるが、低トラフィックでは無視可能（既知の許容事項）。
- ⚠ PR Preview ではマイグレーション自動適用なし。`0036` は本番デプロイ時に適用（バックフィル込み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
