### PR TITLE
docs: 日時保存型(ISO/epoch)の規約明文化 + cutoff生成を型別ヘルパに集約 (#105)

### DIFF
--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -15,6 +15,7 @@ import { eq, and, lt } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import * as emailSchema from '../db/schema/email';
 import * as webauthnSchema from '../db/schema/webauthn';
+import { epochCutoff, isoCutoff } from '../lib/dateCutoff';
 
 const UNVERIFIED_ACCOUNT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const TOKEN_CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -37,12 +38,16 @@ interface CleanupResult {
 export async function executeScheduledCleanup(db: D1Database): Promise<CleanupResult> {
   const orm = drizzle(db, { schema: { ...schema, ...emailSchema, ...webauthnSchema } });
   const now = Date.now();
-  const unverifiedCutoff = now - UNVERIFIED_ACCOUNT_RETENTION_MS;
-  const tokenCutoff = now - TOKEN_CLEANUP_AGE_MS;
-  // Type-matched cutoffs: email_delivery_logs.created_at is INTEGER epoch ms;
-  // ai_usage_records.created_at is TEXT ISO8601.
-  const emailLogCutoffEpoch = now - EMAIL_LOG_RETENTION_MS;
-  const aiUsageCutoffIso = new Date(now - AI_USAGE_RETENTION_MS).toISOString();
+  // Each cutoff uses the helper matching its column's storage type so the
+  // INTEGER-epoch vs TEXT-ISO split is decided in one place (#105):
+  //   users.created_at (ISO), *_tokens/email_change.created_at (epoch),
+  //   email_delivery_logs.created_at (epoch), ai_usage_records.created_at (ISO),
+  //   webauthn_challenges.expires_at (ISO).
+  const unverifiedCutoffIso = isoCutoff(now, UNVERIFIED_ACCOUNT_RETENTION_MS);
+  const tokenCutoffEpoch = epochCutoff(now, TOKEN_CLEANUP_AGE_MS);
+  const emailLogCutoffEpoch = epochCutoff(now, EMAIL_LOG_RETENTION_MS);
+  const aiUsageCutoffIso = isoCutoff(now, AI_USAGE_RETENTION_MS);
+  const nowIso = isoCutoff(now, 0);
 
   console.log('[Cleanup] Starting scheduled cleanup tasks...');
 
@@ -55,7 +60,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
       .where(
         and(
           eq(schema.users.emailVerified, 0),
-          lt(schema.users.createdAt, new Date(unverifiedCutoff).toISOString())
+          lt(schema.users.createdAt, unverifiedCutoffIso)
         )
       )
       .all();
@@ -81,7 +86,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
       .from(emailSchema.passwordResetTokens)
       .where(
         and(
-          lt(emailSchema.passwordResetTokens.createdAt, tokenCutoff),
+          lt(emailSchema.passwordResetTokens.createdAt, tokenCutoffEpoch),
           // Delete tokens that are used OR expired
           // Used tokens have usedAt != null
           // Expired tokens have expiresAt < now
@@ -110,7 +115,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     const oldTokens = await orm
       .select({ id: emailSchema.emailVerificationTokens.id })
       .from(emailSchema.emailVerificationTokens)
-      .where(lt(emailSchema.emailVerificationTokens.createdAt, tokenCutoff))
+      .where(lt(emailSchema.emailVerificationTokens.createdAt, tokenCutoffEpoch))
       .all();
 
     if (oldTokens.length > 0) {
@@ -136,7 +141,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     const oldRequests = await orm
       .select({ id: emailSchema.emailChangeRequests.id })
       .from(emailSchema.emailChangeRequests)
-      .where(lt(emailSchema.emailChangeRequests.createdAt, tokenCutoff))
+      .where(lt(emailSchema.emailChangeRequests.createdAt, tokenCutoffEpoch))
       .all();
 
     if (oldRequests.length > 0) {
@@ -157,7 +162,6 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
   // 5. Delete expired WebAuthn challenges (5-minute TTL, so anything past now is dead)
   let deletedExpiredChallenges = 0;
   try {
-    const nowIso = new Date(now).toISOString();
     const result = await orm
       .delete(webauthnSchema.webauthnChallenges)
       .where(lt(webauthnSchema.webauthnChallenges.expiresAt, nowIso))

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -1,3 +1,17 @@
+/**
+ * Datetime storage-type convention (#105).
+ *
+ * Timestamps are stored in one of two forms; new tables MUST pick one, and
+ * cross-table code must never compare the two forms directly (use the matching
+ * helper in lib/dateCutoff.ts — epochCutoff / isoCutoff):
+ *
+ *  - TEXT ISO8601 — this file's tables (users, weight_records, meal_records,
+ *    exercise_records, ai_usage_records) and webauthn (schema/webauthn.ts).
+ *    recorded_at carries a local "+09:00" offset; created_at / updated_at are UTC "Z".
+ *  - INTEGER epoch ms — the token / email family (schema/email.ts:
+ *    password_reset_tokens, email_verification_tokens, email_change_requests,
+ *    email_delivery_logs, email_rate_limits).
+ */
 import { sqliteTable, text, real, integer, index } from 'drizzle-orm/sqlite-core';
 
 export const users = sqliteTable('users', {

--- a/packages/backend/src/db/schema/email.ts
+++ b/packages/backend/src/db/schema/email.ts
@@ -7,6 +7,11 @@
  * - email_change_requests
  * - email_delivery_logs
  * - email_rate_limits
+ *
+ * Datetime convention (#105): all timestamps here (expires_at / created_at /
+ * used_at, etc.) are INTEGER epoch ms — NOT TEXT ISO like the records tables.
+ * Compare against an epoch cutoff (lib/dateCutoff.ts epochCutoff). See the
+ * full convention in db/schema.ts.
  */
 
 import { sqliteTable, integer, text, index, uniqueIndex } from 'drizzle-orm/sqlite-core';

--- a/packages/backend/src/db/schema/webauthn.ts
+++ b/packages/backend/src/db/schema/webauthn.ts
@@ -1,3 +1,11 @@
+/**
+ * WebAuthn / passkey schema (Drizzle ORM).
+ *
+ * Datetime convention (#105): timestamps here (created_at / last_used_at /
+ * expires_at) are TEXT ISO8601, like the records tables — NOT epoch ms like the
+ * token/email family. Compare against an ISO cutoff (lib/dateCutoff.ts isoCutoff).
+ * See the full convention in db/schema.ts.
+ */
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 import { users } from '../schema';
 

--- a/packages/backend/src/lib/dateCutoff.ts
+++ b/packages/backend/src/lib/dateCutoff.ts
@@ -1,0 +1,29 @@
+/**
+ * Datetime storage-type convention (#105).
+ *
+ * Timestamps are stored in one of two forms depending on the table family.
+ * Cross-table/cleanup code must compare against a cutoff of the MATCHING type —
+ * mixing them makes a `lt`/`gte` comparison silently always-true/always-false
+ * (e.g. an INTEGER epoch column compared to an ISO string). These helpers are
+ * the single place that knows the type-to-cutoff mapping, so callers pick the
+ * one matching the column instead of hand-writing `new Date(...).toISOString()`.
+ *
+ *  - INTEGER epoch ms — the token / email family:
+ *    password_reset_tokens, email_verification_tokens, email_change_requests,
+ *    email_delivery_logs, email_rate_limits (expires_at / created_at).  -> epochCutoff
+ *
+ *  - TEXT ISO8601 — everything else:
+ *    users, weight_records, meal_records, exercise_records, ai_usage_records,
+ *    webauthn (passkey_credentials / webauthn_challenges).  -> isoCutoff
+ *    (recorded_at carries a local "+09:00" offset; created_at / updated_at are UTC "Z".)
+ */
+
+/** Cutoff for INTEGER epoch-ms columns: the epoch ms `ageMs` before `now`. */
+export function epochCutoff(now: number, ageMs: number): number {
+  return now - ageMs;
+}
+
+/** Cutoff for TEXT ISO8601 columns: the ISO string `ageMs` before `now`. */
+export function isoCutoff(now: number, ageMs: number): string {
+  return new Date(now - ageMs).toISOString();
+}


### PR DESCRIPTION
## 概要

日時保存型が **TEXT(ISO8601) と INTEGER(epoch ms)** に二分しており、横断クエリ/cleanupで単位ミスを踏みやすい「将来の地雷」だった。能動バグは無いため全面移行はせず、規約の明文化＋型分岐の集約で対応（issue方針どおり）。

Closes #105

## 変更

1. **各スキーマ先頭に規約コメント**（`db/schema.ts` に全規約、`schema/email.ts`=INTEGER epoch、`schema/webauthn.ts`=TEXT ISO の注記）:
   - token/email系（password_reset_tokens, email_verification_tokens, email_change_requests, email_delivery_logs, email_rate_limits）= **INTEGER epoch ms**
   - それ以外（users, weight/meal/exercise records, ai_usage_records, webauthn）= **TEXT ISO8601**（recorded_atは+09:00、created/updatedはUTC Z）
2. **`lib/dateCutoff.ts`（新規）**: `epochCutoff` / `isoCutoff` を新設し、型→cutoff の分岐を1箇所に集約。
3. **`cleanup.ts`**: 手書きの cutoff 生成（`now - age` / `new Date(...).toISOString()`）をヘルパ使用に置換。**返す値は完全に同一**（挙動不変のリファクタ）。

## 検証

- ✅ **実cron で動作確認**: `wrangler dev --test-scheduled` → `/__scheduled` で `executeScheduledCleanup` を実行。epoch系（password_reset_tokens 10日前 / email_delivery_logs 100日前）と ISO系（ai_usage_records 100日前）の**古い行が削除・直近行は残存**することを実D1で確認（型別cutoffが正しく機能）。
- ✅ `pnpm typecheck` / `lint`(0 error) / `test:unit`(246 passed) / `find-deadcode`(0件)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)