### PR TITLE
refactor: DBスキーマ/クエリの軽微な整合性改善まとめ (#106)

### DIFF
--- a/packages/backend/migrations/0037_meal_photos_food_items_updated_at.sql
+++ b/packages/backend/migrations/0037_meal_photos_food_items_updated_at.sql
@@ -1,0 +1,17 @@
+-- Migration 0037: add updated_at to meal_photos and meal_food_items (#106)
+--
+-- Both tables are UPDATEd in place (photo analysis result/status; chat & manual
+-- food-item edits) but only carried created_at, so the last-modified time was
+-- untrackable. Add updated_at, NOT NULL to match the other records tables.
+--
+-- SQLite cannot ADD a NOT NULL column without a constant default, so we seed a
+-- sentinel epoch default and immediately backfill every existing row to its
+-- created_at. The application always supplies updated_at on write (Drizzle
+-- $defaultFn on insert, $onUpdate on update), so the sentinel default is never
+-- actually used for new rows — it exists only to satisfy the ADD COLUMN.
+
+ALTER TABLE meal_photos ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z';
+UPDATE meal_photos SET updated_at = created_at;
+
+ALTER TABLE meal_food_items ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z';
+UPDATE meal_food_items SET updated_at = created_at;

--- a/packages/backend/migrations/0038_index_cleanup.sql
+++ b/packages/backend/migrations/0038_index_cleanup.sql
@@ -1,0 +1,18 @@
+-- Migration 0038: trim redundant indexes (#106)
+--
+-- email_delivery_logs is append-only and the only query against it is the
+-- retention cron's `WHERE created_at < cutoff`. Its user_id / status / email_type
+-- single-column indexes served no read path (status/email_type are also
+-- low-cardinality), so they only cost INSERT time and storage. Drop them and
+-- keep idx_email_logs_created_at for the cron. If per-user admin lookups are
+-- added later, prefer a (user_id, created_at) composite over a bare user_id index.
+DROP INDEX IF EXISTS idx_email_logs_user_id;
+DROP INDEX IF EXISTS idx_email_logs_status;
+DROP INDEX IF EXISTS idx_email_logs_email_type;
+
+-- users.email_verified is a 2-value column, so a single-column index barely
+-- narrows a scan. Its only consumer is the cleanup cron's
+-- `WHERE email_verified = 0 AND created_at < cutoff`; a composite on
+-- (email_verified, created_at) lets that seek straight to old unverified rows.
+DROP INDEX IF EXISTS idx_users_email_verified;
+CREATE INDEX IF NOT EXISTS idx_users_email_verified_created ON users(email_verified, created_at);

--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -8,6 +8,8 @@
  * 4. Append-only logs past their retention window (#104):
  *    email_delivery_logs and ai_usage_records (detail; lifetime AI total is kept
  *    in ai_usage_totals so pruning detail does not affect the displayed total).
+ * 5. Expired email_rate_limits rows (#106): previously only swept lazily on the
+ *    next send from the same IP, so they lingered if email went idle.
  */
 
 import { drizzle } from 'drizzle-orm/d1';
@@ -30,6 +32,7 @@ interface CleanupResult {
   deletedExpiredChallenges: number;
   deletedEmailLogs: number;
   deletedAiUsageRecords: number;
+  deletedRateLimits: number;
 }
 
 /**
@@ -84,14 +87,10 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     const oldTokens = await orm
       .select({ id: emailSchema.passwordResetTokens.id })
       .from(emailSchema.passwordResetTokens)
-      .where(
-        and(
-          lt(emailSchema.passwordResetTokens.createdAt, tokenCutoffEpoch),
-          // Delete tokens that are used OR expired
-          // Used tokens have usedAt != null
-          // Expired tokens have expiresAt < now
-        )
-      )
+      // Age-based prune only (createdAt < cutoff), matching the other two token
+      // tables. A used/expired token younger than the window is kept until it
+      // ages out — by then it is harmless (single-use + past expiry) (#106).
+      .where(lt(emailSchema.passwordResetTokens.createdAt, tokenCutoffEpoch))
       .all();
 
     if (oldTokens.length > 0) {
@@ -214,6 +213,25 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     console.error('[Cleanup] Error deleting AI usage records:', error);
   }
 
+  // 8. Delete expired email rate-limit rows. expires_at is INTEGER epoch ms, so
+  //    compare against `now` directly. These were only ever cleaned lazily when
+  //    the same IP sent again, leaving stale rows if email usage went quiet (#106).
+  let deletedRateLimits = 0;
+  try {
+    const result = await orm
+      .delete(emailSchema.emailRateLimits)
+      .where(lt(emailSchema.emailRateLimits.expiresAt, now))
+      .run();
+    deletedRateLimits = result.meta?.changes ?? 0;
+    console.log(
+      deletedRateLimits > 0
+        ? `[Cleanup] Deleted ${deletedRateLimits} expired email rate-limit rows`
+        : '[Cleanup] No expired email rate-limit rows to delete'
+    );
+  } catch (error) {
+    console.error('[Cleanup] Error deleting email rate-limit rows:', error);
+  }
+
   const result = {
     deletedUsers,
     deletedPasswordResetTokens,
@@ -222,6 +240,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     deletedExpiredChallenges,
     deletedEmailLogs,
     deletedAiUsageRecords,
+    deletedRateLimits,
   };
 
   console.log('[Cleanup] Cleanup tasks completed:', result);

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -11,19 +11,44 @@
  *  - INTEGER epoch ms — the token / email family (schema/email.ts:
  *    password_reset_tokens, email_verification_tokens, email_change_requests,
  *    email_delivery_logs, email_rate_limits).
+ *
+ * Primary-key-type convention (#106).
+ *
+ * Two PK styles coexist by role; this is intentional, not drift:
+ *  - TEXT (uuid / nanoid) — domain rows whose id is exposed to clients in URLs
+ *    and the RPC API (users, weight_records, meal_records, meal_photos,
+ *    meal_food_items, exercise_records, ai_usage_records, …). Opaque,
+ *    unguessable, and stable across environments.
+ *  - INTEGER AUTOINCREMENT — internal-only log/token rows never surfaced by id
+ *    (schema/email.ts: password_reset_tokens, email_verification_tokens,
+ *    email_change_requests, email_delivery_logs). The token itself (a separate
+ *    unique column), not the numeric id, is the externally-meaningful handle.
  */
 import { sqliteTable, text, real, integer, index } from 'drizzle-orm/sqlite-core';
 
-export const users = sqliteTable('users', {
-  id: text('id').primaryKey(),
-  email: text('email').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  emailVerified: integer('email_verified').notNull().default(0), // 0 = false, 1 = true
-  goalWeight: real('goal_weight'),
-  goalCalories: integer('goal_calories').default(2000),
-  createdAt: text('created_at').notNull(),
-  updatedAt: text('updated_at').notNull(),
-});
+export const users = sqliteTable(
+  'users',
+  {
+    id: text('id').primaryKey(),
+    email: text('email').notNull().unique(),
+    passwordHash: text('password_hash').notNull(),
+    emailVerified: integer('email_verified').notNull().default(0), // 0 = false, 1 = true
+    goalWeight: real('goal_weight'),
+    goalCalories: integer('goal_calories').default(2000),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => ({
+    // The cleanup cron filters `email_verified = 0 AND created_at < cutoff`.
+    // A lone email_verified index is near-useless (2 distinct values); the
+    // composite lets that scan seek straight to old unverified rows (#106,
+    // replaces idx_users_email_verified in migration 0038).
+    idx_users_email_verified_created: index('idx_users_email_verified_created').on(
+      table.emailVerified,
+      table.createdAt
+    ),
+  })
+);
 
 export const weightRecords = sqliteTable(
   'weight_records',
@@ -81,6 +106,17 @@ export const mealPhotos = sqliteTable(
     fat: real('fat'),
     carbs: real('carbs'),
     createdAt: text('created_at').notNull(),
+    // Photos are UPDATEd in place (analysis result / status), so track the last
+    // change time. $onUpdate auto-bumps it on every Drizzle .update(); $defaultFn
+    // seeds it on insert — no call site needs to set it manually (#106).
+    // NOTE: migration 0037 gives the DB column a sentinel DEFAULT '1970-...' that
+    // is intentionally NOT modeled here (SQLite needs a constant default to ADD a
+    // NOT NULL column); the app always writes a real value, so the default never
+    // fires for new rows.
+    updatedAt: text('updated_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString())
+      .$onUpdate(() => new Date().toISOString()),
   },
   (table) => ({
     idx_meal_photos_meal: index('idx_meal_photos_meal').on(table.mealId, table.displayOrder),
@@ -105,6 +141,14 @@ export const mealFoodItems = sqliteTable(
     fat: real('fat').notNull(),
     carbs: real('carbs').notNull(),
     createdAt: text('created_at').notNull(),
+    // Food items are UPDATEd in place (chat / manual edits), so track the last
+    // change time. $onUpdate auto-bumps on every Drizzle .update(); $defaultFn
+    // seeds it on insert (#106). As with meal_photos above, migration 0037's
+    // sentinel DB DEFAULT is intentionally not modeled here.
+    updatedAt: text('updated_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString())
+      .$onUpdate(() => new Date().toISOString()),
   },
   (table) => ({
     idx_food_items_meal: index('idx_food_items_meal').on(table.mealId),

--- a/packages/backend/src/db/schema/email.ts
+++ b/packages/backend/src/db/schema/email.ts
@@ -111,6 +111,14 @@ export const emailChangeRequests = sqliteTable(
  * any user-facing aggregate. Pruned by the retention cron (~90 days) using
  * idx_email_logs_created_at; recipient_email is PII, so retention is bounded
  * (#104). created_at is INTEGER epoch ms.
+ *
+ * Indexing (#106): the only query that touches this table is the cron's
+ * `WHERE created_at < cutoff` prune, so just one index — created_at — is kept.
+ * The former single-column user_id / status / email_type indexes were dropped
+ * (migration 0038): status/email_type are low-cardinality (2–3 values) and no
+ * read path filters on them, and user_id was never queried. See migration 0038
+ * for how to reintroduce a (user_id, created_at) composite if admin per-user
+ * lookups are added later.
  */
 export const emailDeliveryLogs = sqliteTable(
   'email_delivery_logs',
@@ -127,10 +135,7 @@ export const emailDeliveryLogs = sqliteTable(
     createdAt: integer('created_at').notNull(),
   },
   (table) => ({
-    userIdIdx: index('idx_email_logs_user_id').on(table.userId),
-    statusIdx: index('idx_email_logs_status').on(table.status),
     createdAtIdx: index('idx_email_logs_created_at').on(table.createdAt),
-    emailTypeIdx: index('idx_email_logs_email_type').on(table.emailType),
   })
 );
 

--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -21,6 +21,8 @@ import {
   updateFoodItemSchema,
   saveMealAnalysisSchema,
   textAnalysisRequestSchema,
+  ANALYSIS_SOURCE,
+  MEAL_CONTENT_DELIMITER,
   type FoodItem,
 } from '@lifestyle-app/shared';
 
@@ -145,12 +147,12 @@ mealAnalysis.post('/analyze', async (c) => {
       id: mealId,
       userId,
       mealType: 'lunch', // Default, will be set when saving
-      content: analysisResult.result.foodItems.map((f) => f.name).join(', '),
+      content: analysisResult.result.foodItems.map((f) => f.name).join(MEAL_CONTENT_DELIMITER),
       calories: analysisResult.result.totals.calories,
       totalProtein: analysisResult.result.totals.protein,
       totalFat: analysisResult.result.totals.fat,
       totalCarbs: analysisResult.result.totals.carbs,
-      analysisSource: 'ai',
+      analysisSource: ANALYSIS_SOURCE.ai,
       recordedAt,
       createdAt: now,
       updatedAt: now,
@@ -230,12 +232,12 @@ mealAnalysis.post(
       id: mealId,
       userId,
       mealType: analysisResult.result.inferredMealType,
-      content: analysisResult.result.foodItems.map((f) => f.name).join(', '),
+      content: analysisResult.result.foodItems.map((f) => f.name).join(MEAL_CONTENT_DELIMITER),
       calories: analysisResult.result.totals.calories,
       totalProtein: analysisResult.result.totals.protein,
       totalFat: analysisResult.result.totals.fat,
       totalCarbs: analysisResult.result.totals.carbs,
-      analysisSource: 'ai',
+      analysisSource: ANALYSIS_SOURCE.ai,
       recordedAt,
       createdAt: now,
       updatedAt: now,
@@ -301,7 +303,7 @@ mealAnalysis.post('/create-empty', zValidator('json', createEmptySchema), async 
     totalProtein: 0,
     totalFat: 0,
     totalCarbs: 0,
-    analysisSource: 'manual',
+    analysisSource: ANALYSIS_SOURCE.manual,
     recordedAt,
     createdAt: now,
     updatedAt: now,
@@ -607,7 +609,7 @@ mealAnalysis.post(
     const items = await db.query.mealFoodItems.findMany({
       where: eq(mealFoodItems.mealId, mealId),
     });
-    const content = items.map((i) => i.name).join(', ');
+    const content = items.map((i) => i.name).join(MEAL_CONTENT_DELIMITER);
 
     await db
       .update(mealRecords)

--- a/packages/backend/src/routes/meal-chat.ts
+++ b/packages/backend/src/routes/meal-chat.ts
@@ -17,6 +17,8 @@ import type { Database } from '../db';
 import {
   sendChatMessageSchema,
   applyChatSuggestionSchema,
+  ANALYSIS_SOURCE,
+  MEAL_CONTENT_DELIMITER,
   type FoodItem,
   type ChatMessage,
   type NutritionTotals,
@@ -236,6 +238,14 @@ mealChat.post(
     const now = new Date().toISOString();
     let newRecordedAt: string | undefined;
     let newMealType: 'breakfast' | 'lunch' | 'dinner' | 'snack' | undefined;
+    // Track whether the AI chat actually touched the food items. Editing food
+    // items through the chat is an AI-driven change, so a meal that started out
+    // 'manual' must be promoted to 'ai' — otherwise the source badge keeps
+    // claiming "manual" while the nutrition data was AI-edited (#106). An add or
+    // a non-empty update counts as a touch; a remove counts only when it actually
+    // deleted a row (see the 'remove' case). Metadata-only changes (set_datetime
+    // / set_meal_type) never count.
+    let foodItemsChanged = false;
 
     console.log('[Chat Apply] Received changes:', JSON.stringify(changes, null, 2));
     console.log('[Chat Apply] Meal ID:', mealId);
@@ -247,6 +257,7 @@ mealChat.post(
         case 'add':
           // For 'add', foodItem is required by schema
           console.log('[Chat Apply] Adding food item:', change.foodItem.name);
+          foodItemsChanged = true;
           await db.insert(mealFoodItems).values({
             id: uuidv4(),
             mealId,
@@ -262,10 +273,14 @@ mealChat.post(
         case 'remove': {
           // For 'remove', foodItemId is required by schema
           console.log('[Chat Apply] Removing food item ID:', change.foodItemId);
-          const deleteResult = await db.delete(mealFoodItems).where(
-            and(eq(mealFoodItems.id, change.foodItemId), eq(mealFoodItems.mealId, mealId))
-          );
+          const deleteResult = await db
+            .delete(mealFoodItems)
+            .where(and(eq(mealFoodItems.id, change.foodItemId), eq(mealFoodItems.mealId, mealId)))
+            .run();
           console.log('[Chat Apply] Delete result:', deleteResult);
+          // Only count as an AI touch when a row was actually deleted — removing
+          // an already-absent item changes nothing and must not flip the source.
+          if ((deleteResult.meta?.changes ?? 0) > 0) foodItemsChanged = true;
           break;
         }
         case 'update': {
@@ -281,6 +296,7 @@ mealChat.post(
           if (item['carbs'] !== undefined) updateData['carbs'] = item['carbs'];
 
           if (Object.keys(updateData).length > 0) {
+            foodItemsChanged = true;
             await db
               .update(mealFoodItems)
               .set(updateData)
@@ -333,7 +349,7 @@ mealChat.post(
       totalProtein: totals.protein,
       totalFat: totals.fat,
       totalCarbs: totals.carbs,
-      content: foodItems.map((i) => i.name).join(', '),
+      content: foodItems.map((i) => i.name).join(MEAL_CONTENT_DELIMITER),
       updatedAt: now,
     };
     if (newRecordedAt) {
@@ -341,6 +357,12 @@ mealChat.post(
     }
     if (newMealType) {
       mealUpdateData['mealType'] = newMealType;
+    }
+    // Promote a manual meal to 'ai' once the chat has AI-edited its food items
+    // so the analysis-source badge reflects reality (#106). Only upgrade — never
+    // downgrade an already-'ai' meal.
+    if (foodItemsChanged && meal.analysisSource !== ANALYSIS_SOURCE.ai) {
+      mealUpdateData['analysisSource'] = ANALYSIS_SOURCE.ai;
     }
 
     await db
@@ -462,7 +484,7 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
         const totalProtein = allFoodItems.reduce((sum, item) => sum + item.protein, 0);
         const totalFat = allFoodItems.reduce((sum, item) => sum + item.fat, 0);
         const totalCarbs = allFoodItems.reduce((sum, item) => sum + item.carbs, 0);
-        const contentNames = allFoodItems.map(item => item.name).join('、');
+        const contentNames = allFoodItems.map(item => item.name).join(MEAL_CONTENT_DELIMITER);
 
         await db.update(mealRecords)
           .set({
@@ -471,6 +493,9 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
             totalProtein,
             totalFat,
             totalCarbs,
+            // A photo added via chat is AI analysis → reflect that in the source.
+            analysisSource: ANALYSIS_SOURCE.ai,
+            updatedAt: new Date().toISOString(),
           })
           .where(eq(mealRecords.id, mealId));
 

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { nanoid } from 'nanoid';
-import { createMealSchema, updateMealSchema, dateRangeSchema, mealTypeSchema, mealDatesQuerySchema } from '@lifestyle-app/shared';
+import { createMealSchema, updateMealSchema, dateRangeSchema, mealTypeSchema, mealDatesQuerySchema, ANALYSIS_SOURCE, MEAL_CONTENT_DELIMITER } from '@lifestyle-app/shared';
 import { MealService } from '../services/meal';
 import { MealPhotoService, deletePhotosWithFoodItems } from '../services/meal-photo.service';
 import { PhotoStorageService } from '../services/photo-storage';
@@ -200,7 +200,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
       // Generate meal content from AI-detected food items
       const generatedContent = allFoodNames.length > 0
-        ? allFoodNames.join(', ')
+        ? allFoodNames.join(MEAL_CONTENT_DELIMITER)
         : content; // Fallback to user-provided content if no items detected
 
       // Recalculate meal totals and update content
@@ -213,7 +213,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
           totalProtein: totals.protein,
           totalFat: totals.fat,
           totalCarbs: totals.carbs,
-          analysisSource: 'ai',
+          analysisSource: ANALYSIS_SOURCE.ai,
           updatedAt: new Date().toISOString(),
         })
         .where(eq(schema.mealRecords.id, meal.id));
@@ -518,7 +518,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       const totalProtein = allFoodItems.reduce((sum, item) => sum + item.protein, 0);
       const totalFat = allFoodItems.reduce((sum, item) => sum + item.fat, 0);
       const totalCarbs = allFoodItems.reduce((sum, item) => sum + item.carbs, 0);
-      const contentNames = allFoodItems.map(item => item.name).join('、');
+      const contentNames = allFoodItems.map(item => item.name).join(MEAL_CONTENT_DELIMITER);
 
       await db.update(mealRecords)
         .set({
@@ -721,7 +721,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
           const totalProtein = allFoodItems.reduce((sum, item) => sum + item.protein, 0);
           const totalFat = allFoodItems.reduce((sum, item) => sum + item.fat, 0);
           const totalCarbs = allFoodItems.reduce((sum, item) => sum + item.carbs, 0);
-          const contentNames = allFoodItems.map(item => item.name).join('、');
+          const contentNames = allFoodItems.map(item => item.name).join(MEAL_CONTENT_DELIMITER);
 
           await db.update(mealRecords)
             .set({

--- a/packages/backend/src/services/meal-photo.service.ts
+++ b/packages/backend/src/services/meal-photo.service.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 import { eq, asc } from 'drizzle-orm';
 import type { Database } from '../db';
 import { mealPhotos, mealFoodItems, mealRecords, type MealPhoto } from '../db/schema';
-import type { NutritionTotals } from '@lifestyle-app/shared';
+import { MEAL_CONTENT_DELIMITER, type NutritionTotals } from '@lifestyle-app/shared';
 import type { PhotoStorageService } from './photo-storage';
 
 export class MealPhotoService {
@@ -131,7 +131,7 @@ export async function recalculateMealTotals(
       totalProtein: totals.protein,
       totalFat: totals.fat,
       totalCarbs: totals.carbs,
-      content: items.map((i) => i.name).join(', '),
+      content: items.map((i) => i.name).join(MEAL_CONTENT_DELIMITER),
       updatedAt: new Date().toISOString(),
     })
     .where(eq(mealRecords.id, mealId));

--- a/packages/backend/tests/unit/meal-photo.service.test.ts
+++ b/packages/backend/tests/unit/meal-photo.service.test.ts
@@ -37,6 +37,7 @@ describe('MealPhotoService', () => {
           fat: 5,
           carbs: 15,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
         {
           id: 'photo2',
@@ -49,6 +50,7 @@ describe('MealPhotoService', () => {
           fat: null,
           carbs: null,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
       ];
 
@@ -75,6 +77,7 @@ describe('MealPhotoService', () => {
           fat: 5,
           carbs: 15,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
       ];
 
@@ -91,6 +94,7 @@ describe('MealPhotoService', () => {
         fat: null,
         carbs: null,
         createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       };
 
       const mockInsert = {
@@ -121,6 +125,7 @@ describe('MealPhotoService', () => {
         fat: 5,
         carbs: 15,
         createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       }));
 
       mockDb.query.mealPhotos.findMany = vi.fn().mockResolvedValue(existingPhotos);
@@ -151,6 +156,7 @@ describe('MealPhotoService', () => {
           fat: 5,
           carbs: 15,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
         {
           id: 'photo2',
@@ -163,6 +169,7 @@ describe('MealPhotoService', () => {
           fat: 10,
           carbs: 30,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
         {
           id: 'photo3',
@@ -175,6 +182,7 @@ describe('MealPhotoService', () => {
           fat: null,
           carbs: null,
           createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         },
       ];
 

--- a/packages/frontend/src/components/exercise/StrengthInput.tsx
+++ b/packages/frontend/src/components/exercise/StrengthInput.tsx
@@ -217,6 +217,19 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
       .map(item => item.exerciseType);
   }, [customTypes, selectedMuscleGroup]);
 
+  // Autocomplete suggestions for the free-text custom-name field: every known
+  // exercise name (presets + all previously-recorded custom types, regardless of
+  // muscle group), deduplicated. Surfacing existing names as the user types
+  // curbs spelling drift (e.g. "ベンチプレス" vs "ベンチ プレス") so the same
+  // exercise stays groupable in per-type aggregates (#106).
+  const exerciseTypeSuggestions = useMemo(() => {
+    const names = new Set<string>(EXERCISE_PRESETS.map(p => p.name));
+    for (const item of customTypes) {
+      if (item.exerciseType) names.add(item.exerciseType);
+    }
+    return Array.from(names);
+  }, [customTypes]);
+
   const handleSessionSelect = useCallback((session: Session) => {
     // Take the first exercise from the session and populate the form
     const firstExercise = session.exercises[0];
@@ -339,13 +352,21 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
         )}
 
         {showCustomInput && (
-          <input
-            type="text"
-            value={customExerciseName}
-            onChange={(e) => setCustomExerciseName(e.target.value)}
-            placeholder="種目名を入力"
-            className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-          />
+          <>
+            <input
+              type="text"
+              value={customExerciseName}
+              onChange={(e) => setCustomExerciseName(e.target.value)}
+              placeholder="種目名を入力"
+              list="exercise-type-suggestions"
+              className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+            />
+            <datalist id="exercise-type-suggestions">
+              {exerciseTypeSuggestions.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+          </>
         )}
 
         {/* Last Record Badge */}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,11 @@
+// Delimiter used when deriving a meal's `content` string by concatenating its
+// food-item names. `content` is non-normalized (a denormalized display label),
+// so every derivation path must use the same separator to stay consistent
+// across photo / chat / manual flows (#106). Note: `content` is dual-purpose —
+// for AI/photo meals it is this derived join, for manual meals it is the user's
+// free-text input — so this constant only governs the derived paths.
+export const MEAL_CONTENT_DELIMITER = '、';
+
 // Meal types
 export const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
 

--- a/packages/shared/src/schemas/meal-analysis.ts
+++ b/packages/shared/src/schemas/meal-analysis.ts
@@ -6,6 +6,13 @@ export type Portion = z.infer<typeof portionSchema>;
 
 export const analysisSourceSchema = z.enum(['ai', 'manual']);
 export type AnalysisSource = z.infer<typeof analysisSourceSchema>;
+/**
+ * Canonical `meal_records.analysis_source` values, derived from the schema enum.
+ * Use these at DB write boundaries instead of bare 'ai' / 'manual' string
+ * literals so the values stay validated against the single source of truth (#106).
+ *   ANALYSIS_SOURCE.ai === 'ai', ANALYSIS_SOURCE.manual === 'manual'
+ */
+export const ANALYSIS_SOURCE = analysisSourceSchema.enum;
 
 export const chatRoleSchema = z.enum(['user', 'assistant']);
 export type ChatRole = z.infer<typeof chatRoleSchema>;

--- a/tests/unit/meal-photo-reconcile.test.ts
+++ b/tests/unit/meal-photo-reconcile.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { MEAL_CONTENT_DELIMITER } from '@lifestyle-app/shared';
 import {
   recalculateMealTotals,
   deletePhotosWithFoodItems,
@@ -43,7 +44,7 @@ describe('recalculateMealTotals (#101 SSoT)', () => {
       totalProtein: 15,
       totalFat: 8,
       totalCarbs: 30,
-      content: 'A, B',
+      content: `A${MEAL_CONTENT_DELIMITER}B`,
     });
   });
 


### PR DESCRIPTION
## 概要

DB設計レビュー由来の軽微なtech-debtチェックリスト（#106）を一括対応。ユーザー選択により**任意の boolean mode 化(項目6)を除く9項目**を1 PRにまとめた。

Closes #106

## 対応項目

### スキーマ / データモデル
- [x] **content区切り文字の統一**: 食材名連結が comma-space と読点で経路混在 → `MEAL_CONTENT_DELIMITER`(`'、'`) に一本化（全6箇所）
- [x] **analysis_source 昇格**: チャットでAIが食材を実編集したら `manual→ai` へ昇格（badgeの実態ズレ解消）。`remove` は実際に行削除した時のみカウント。死蔵していた `analysisSourceSchema` から `ANALYSIS_SOURCE` 定数を作り書込境界のリテラルを置換
- [x] **種目表記ゆれ**: 手入力欄に `datalist` 補完（プリセット＋既存customTypes）

### 型 / タイムスタンプ
- [x] **updated_at 追加**: `meal_photos` / `meal_food_items` に追加。Drizzle `$defaultFn`+`$onUpdate` で挿入時seed・更新時自動バンプ（呼出側の変更不要） / migration 0037
- [x] **主キー型混在**: TEXT uuid(外部公開ID) vs INTEGER(内部ログ/トークン) の使い分けを schema コメント化（コード変更なし）

### 索引整理 (migration 0038)
- [x] **email_delivery_logs**: `user_id`/`status`/`email_type` 単列索引を削除（INSERT専用・参照ゼロ）。cron prune用の `created_at` のみ残す
- [x] **users.email_verified**: 2値単列索引を `(email_verified, created_at)` 複合へ（cleanup cron の `WHERE` に最適化）

### cron
- [x] **password_reset 空and()除去**: 無意味な `and()` ラッパを bare `lt` に統一（機能等価）
- [x] **email_rate_limits 掃除**: 期限切れ行削除を `executeScheduledCleanup` に集約（従来は送信経路依存で長期未使用だと残存）

## 検証

**品質ゲート**: `typecheck` 緑 / `lint` 0 error / `test:unit` 246 passed / `knip` exit 0（`analysisSourceSchema` の死蔵も解消）

**実ローカルD1での挙動確認**:
- `manual → ai` 昇格（チャットで食材add）
- **no-op remove（存在しないitem削除）では昇格しない**（堅牢化の確認）
- `updated_at`: 挿入時に `$defaultFn` で設定、PATCH時に `$onUpdate` でバンプ・`created_at` は不変
- migration 0037/0038 がローカルD1に適用（DDL: updated_at NOT NULL、索引整理を `PRAGMA` で確認）
- cron で期限切れ `email_rate_limits` のみ削除（未来行は保持、ログ `Deleted 1` 確認）

**敵対的レビュー (Workflow)**: 6次元レビュー→各指摘を独立検証。確認された low 指摘3件のうち2件を反映（①no-op昇格の堅牢化、③migration 0037 のDBデフォルト未モデル化を schema へ注記）。1件（PATCH/POST/DELETE が昇格しない非対称）は却下。

## 既知のfollow-up（本PR対象外）

- `docs/db-schema.html` / `docs/db-schema-prod.sql` は**本番時点キャプチャ**であり、既に migration 0033〜0036 分もドリフト済み（PR毎更新は確立した慣習でない）。本PRの 0037/0038 分も含め、別途まとめてリフレッシュするのが妥当。

## マイグレーション注意
⚠ PR Preview ではマイグレーションが自動適用されない。スキーマ変更を含むため、preview で検証する場合は手動適用が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)