### PR TITLE
ci: e2e.ymlにテストユーザーseedステップを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,11 @@ jobs:
           cd packages/backend
           pnpm exec wrangler d1 migrations apply DB --local
 
+      - name: Seed local test user (local DB only — never preview/production)
+        run: |
+          cd packages/backend
+          pnpm exec wrangler d1 execute DB --local --file seed/test-user.local.sql
+
       - name: Setup test environment
         run: |
           cd packages/backend


### PR DESCRIPTION
## 問題

`.github/workflows/e2e.yml` はD1マイグレーション（Run database migrations）は実行するものの、`seed/test-user.local.sql` の投入を行っていませんでした。一方 `ci.yml` では migrations の直後に seed を実行しています。

PlaywrightのglobalSetupはCIでは無効化されているため、CI上のE2E実行時に `test@example.com` が存在せず、認証に依存するE2Eテストが失敗していました。これが #109 の根本原因と考えられます。

## 修正内容

`ci.yml` と同じ形式で、「Run database migrations」ステップの直後に「Seed local test user」ステップを追加しました。

```yaml
- name: Seed local test user (local DB only — never preview/production)
  run: |
    cd packages/backend
    pnpm exec wrangler d1 execute DB --local --file seed/test-user.local.sql
```

- `packages/backend/seed/test-user.local.sql` の存在を確認済み
- YAML構文チェック済み（python3 yaml.safe_load）

Closes #123
Refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)