### PR TITLE
fix: 写真追加時のpending写真一括再分析を削除しAI使用量チェックのバイパスを解消

### DIFF
--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -459,56 +459,6 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
         await photoService.markAnalysisFailed(photo.id);
       }
 
-      // Re-analyze all pending photos (including legacy photo if pending)
-      const allPhotos = await photoService.getMealPhotos(mealId);
-      const pendingPhotos = allPhotos.filter((p) => p.analysisStatus === 'pending');
-
-      for (const pendingPhoto of pendingPhotos) {
-        try {
-          // Get photo data from R2 using getPhotoForAnalysis
-          const photoData = await photoStorage.getPhotoForAnalysis(pendingPhoto.photoKey);
-          if (photoData) {
-            const analysisResult = await aiService.analyzeMealPhoto(
-              photoData.data,
-              photoData.mimeType
-            );
-
-            if (analysisResult.success) {
-              await photoService.updateAnalysisResult(pendingPhoto.id, analysisResult.result.totals);
-
-              // Automatically create food items from pending photo analysis
-              console.log(`[Pending Photo Analysis] Creating ${analysisResult.result.foodItems.length} food items for pending photo ${pendingPhoto.id}`);
-              for (const item of analysisResult.result.foodItems) {
-                const foodItemId = nanoid();
-                await db.insert(schema.mealFoodItems).values({
-                  id: foodItemId,
-                  mealId,
-                  photoId: pendingPhoto.id,
-                  name: item.name,
-                  portion: item.portion,
-                  calories: item.calories,
-                  protein: item.protein,
-                  fat: item.fat,
-                  carbs: item.carbs,
-                  createdAt: new Date().toISOString(),
-                });
-                console.log(`[Pending Photo Analysis] Created food item: ${foodItemId} - ${item.name}`);
-              }
-
-              if (analysisResult.usage) {
-                await aiUsageService.recordUsage(user.id, 'image_analysis', analysisResult.usage);
-              }
-            } else {
-              console.error('[Pending Photo Analysis] Analysis failed:', analysisResult.failure);
-              await photoService.markAnalysisFailed(pendingPhoto.id);
-            }
-          }
-        } catch (error) {
-          console.error(`Failed to analyze pending photo ${pendingPhoto.id}:`, error);
-          await photoService.markAnalysisFailed(pendingPhoto.id);
-        }
-      }
-
       // Update meal totals and content from all food items
       const allFoodItems = await db.query.mealFoodItems.findMany({
         where: eq(schema.mealFoodItems.mealId, mealId),


### PR DESCRIPTION
## 問題

`POST /api/meals/:id/photos` で新規写真の分析後に、その食事の `analysisStatus === 'pending'` の既存写真を**全件**再分析するループが存在していた。

- **AI使用量チェックのバイパス**: `aiUsageLimitCheck` はリクエスト冒頭で1回しか実行されないため、1回のチェックで最大10回以上のGemini呼び出しが発生し得る
- **レスポンスの遅延**: 全件再分析が同期実行されるため、写真追加のレスポンスが大幅に遅くなる
- **food item重複のリスク**: リトライ時に同じpending写真が再分析され、重複したfood itemが作成され得る

## 修正内容

`packages/backend/src/routes/meals.ts` の `POST /:id/photos` ハンドラから、pending写真の一括再分析ループ（「Re-analyze all pending photos」ブロック）を削除した。

以下は維持:
- 新規アップロード写真自体のAI分析とfood item作成
- 全food itemからの食事合計値（カロリー・PFC・content）の再計算

失敗した写真の再分析は、既存の個別エンドポイント `POST /:id/photos/:photoId/analyze`（フロントエンドの再分析ボタン）で引き続き可能。

## テスト

- `pnpm build:shared && pnpm typecheck` — 全パッケージpass
- `pnpm test:unit` — 246 passed / 1 skipped
- 削除したループの挙動をassertするテストは存在しなかったため、テスト変更なし

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)