### PR TITLE
fix: Preview環境のR2バケットを本番から分離 (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,6 +541,9 @@ jobs:
           cd packages/backend
           # Use preview database for PR deployments
           sed -i 's/database_id = "86957e0a-04b6-4530-9b64-79ea36c64ba5"/database_id = "1c90e1fa-f2b7-4518-94b4-0ae192ff6a7b"/' wrangler.toml
+          # Use preview R2 bucket for PR deployments (PR preview deploys from
+          # top-level config via --name, so the production bucket must be swapped)
+          sed -i 's/bucket_name = "lifestyle-app-photos"/bucket_name = "lifestyle-app-photos-preview"/' wrangler.toml
 
       - name: Deploy PR Preview
         run: |

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -67,4 +67,4 @@ database_id = "1c90e1fa-f2b7-4518-94b4-0ae192ff6a7b"
 
 [[env.preview.r2_buckets]]
 binding = "PHOTOS"
-bucket_name = "lifestyle-app-photos"
+bucket_name = "lifestyle-app-photos-preview"


### PR DESCRIPTION
## 概要

Preview環境（Main Preview / PR Preview）が本番のR2バケット `lifestyle-app-photos` を共有していたため、Previewでアップロードした食事写真が本番ストレージを汚染していました。D1は `health-tracker-preview-db` で分離済みでしたが、R2は未分離でした。

Closes #124

## 変更内容

### `packages/backend/wrangler.toml`
- `[[env.preview.r2_buckets]]` の `bucket_name` を `lifestyle-app-photos` → `lifestyle-app-photos-preview` に変更（Main Preview用）

### `.github/workflows/ci.yml`
- `deploy-pr-preview` ジョブの「Patch wrangler.toml for PR preview」ステップに、R2バケット名を `lifestyle-app-photos-preview` に書き換えるsedを追加
  - PR Previewは `--env preview` ではなく `wrangler deploy --name lifestyle-tracker-pr-N` でトップレベル設定を使ってデプロイされるため、database_idと同様にバケット名もsedでの書き換えが必要

## バケット作成について

✅ `wrangler r2 bucket create lifestyle-app-photos-preview` を実行済みで、バケットは**作成成功**しています。マージ前の追加作業は不要です。

## 影響範囲

- 本番（トップレベル設定）は引き続き `lifestyle-app-photos` を使用（変更なし）
- 既存のPreview環境にアップロード済みの写真は新バケットには移行されないため、Previewで過去にアップロードした写真の参照は切れます（テストデータのため許容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)