### PR TITLE
fix: ログアウト時にService WorkerのAPIキャッシュ(api-cache)を削除

### DIFF
--- a/packages/frontend/src/lib/clearApiCache.ts
+++ b/packages/frontend/src/lib/clearApiCache.ts
@@ -1,0 +1,17 @@
+/**
+ * Service Worker (workbox) のAPIレスポンスキャッシュを削除する。
+ *
+ * 共有端末やオフライン時に、前のユーザーの /api/* レスポンスが
+ * 次のユーザーに表示されるのを防ぐため、ログアウト時に呼び出す。
+ *
+ * NOTE: 'api-cache' は vite.config.ts (workbox.runtimeCaching の cacheName)
+ * で定義されている名前と一致させる必要がある。
+ */
+export async function clearApiCache(): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  try {
+    await caches.delete('api-cache');
+  } catch {
+    // best-effort: キャッシュ削除の失敗でログアウトを妨げない
+  }
+}

--- a/packages/frontend/src/lib/client.ts
+++ b/packages/frontend/src/lib/client.ts
@@ -3,6 +3,7 @@ import type { AppType } from '@lifestyle-app/backend';
 import { generateRequestId } from './requestId';
 import { setCurrentRequestId } from './errorLogger';
 import { useAuthStore } from '../stores/authStore';
+import { clearApiCache } from './clearApiCache';
 
 // In production (empty VITE_API_URL), use same origin
 // In development, use localhost:8787
@@ -51,6 +52,9 @@ export const client = hc<AppType>(API_BASE_URL, {
         const isAuthPath = AUTH_PATHS.some(path => url.includes(path));
         if (!isAuthPath && useAuthStore.getState().isAuthenticated) {
           useAuthStore.getState().logout();
+          // 遷移前にService WorkerのAPIキャッシュ削除の完了を待つ
+          // （ナビゲーションで削除処理が中断されないように。失敗時もリダイレクトは継続）
+          await clearApiCache();
           window.location.href = '/login';
         }
       }

--- a/packages/frontend/src/stores/authStore.ts
+++ b/packages/frontend/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { User } from '@lifestyle-app/shared';
+import { clearApiCache } from '../lib/clearApiCache';
 
 interface AuthState {
   user: User | null;
@@ -26,12 +27,16 @@ export const useAuthStore = create<AuthState>()(
           isLoading: false,
         }),
       setLoading: (loading) => set({ isLoading: loading }),
-      logout: () =>
+      logout: () => {
+        // Service WorkerのAPIキャッシュを削除（前ユーザーのデータ露出防止）
+        // fire-and-forget: 失敗してもログアウトは妨げない
+        void clearApiCache();
         set({
           user: null,
           isAuthenticated: false,
           isLoading: false,
-        }),
+        });
+      },
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
## 概要

Closes #122

Service Workerが `vite.config.ts` の workbox `runtimeCaching` 設定により全 `/api/` レスポンスを `api-cache`（NetworkFirst, 24時間保持）にキャッシュしているが、ログアウト時にこのキャッシュを削除する処理が存在しなかった。

## 問題

- 共有端末やオフライン時に、前のユーザーの `/api/meals` や `/api/weights` などのレスポンスが、次にログインしたユーザーに表示される可能性がある（個人データの露出）。

## 修正内容

- `packages/frontend/src/lib/clearApiCache.ts` を新規追加
  - `caches.delete('api-cache')` をbest-effortで実行するヘルパー
  - キャッシュ名は `vite.config.ts` の `cacheName` と一致させる必要がある旨をコメントで明記
- ログアウトの全経路に組み込み:
  - **明示的ログアウト**: `authStore.ts` の `logout` アクション内で fire-and-forget 呼び出し（Layout / Settings / ConfirmEmailChange からの全ログアウトをカバー。失敗してもログアウトUXは妨げない）
  - **401自動ログアウト**: `client.ts` の401ハンドラで `/login` リダイレクト前に `await clearApiCache()`（ページ遷移で削除処理が中断されないように完了を待機）

## テスト

- `pnpm typecheck` ✅（shared / backend / frontend すべてパス）
- `pnpm test:unit` ✅（246 passed, 1 skipped）
- `pnpm lint` ✅（0 errors、警告1件はmain由来の既存のもの）

🤖 Generated with [Claude Code](https://claude.com/claude-code)