### PR TITLE
ci: deadcode/bundle-sizeチェックでデプロイをゲートし閾値表記を30に修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            // Keep in sync with MAX_UNUSED_EXPORTS in scripts/check-deadcode-threshold.js
+            const THRESHOLD = 30;
             try {
               const report = JSON.parse(fs.readFileSync('knip-report.json', 'utf8'));
               let count = 0;
@@ -291,7 +293,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `## 🔍 Dead Code Analysis\n\n**Unused Exports**: ${count} (Threshold: 40)\n\n${count > 40 ? '❌ **FAILED**: Exceeds threshold' : '✅ **PASSED**: Within threshold'}\n\n_Current baseline: 36 unused exports. Roadmap: 40 → 30 → 20 → 10 → 0_`
+                body: `## 🔍 Dead Code Analysis\n\n**Unused Exports**: ${count} (Threshold: ${THRESHOLD})\n\n${count > THRESHOLD ? '❌ **FAILED**: Exceeds threshold' : '✅ **PASSED**: Within threshold'}\n\n_Roadmap: 40 → 30 → 20 → 10 → 0_`
               });
             } catch (error) {
               console.error('Failed to post comment:', error);
@@ -366,7 +368,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck, test]
+    needs: [lint-and-typecheck, test, deadcode-check, bundle-size-check]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 概要

Closes #127

`deadcode-check` と `bundle-size-check` に `needs:` がなく、どのジョブからも依存されていなかったため、これらが失敗してもデプロイ（`deploy-main-preview` / `deploy-production` / `deploy-pr-preview`、いずれも `needs: [build]`）が進行してしまっていた。また、deadcode-check の PRコメントが閾値40と表示していたが、実際のゲート（`scripts/check-deadcode-threshold.js` の `MAX_UNUSED_EXPORTS`）は30だった。

## 変更内容

- `build` ジョブの `needs` に `deadcode-check` と `bundle-size-check` を追加
  - `needs: [lint-and-typecheck, test]` → `needs: [lint-and-typecheck, test, deadcode-check, bundle-size-check]`
  - 両チェックは引き続き lint/test と並列実行されるため、CI全体の所要時間への影響はほぼなし。`build` を介して全デプロイジョブ（および `e2e-test`）が両チェックの成功を前提とするようになる
- PRコメントスクリプトの閾値表記を 40 → 30 に修正
  - `THRESHOLD = 30` として単一の定数にまとめ、`scripts/check-deadcode-threshold.js` の `MAX_UNUSED_EXPORTS` と同期する旨のコメントを付記（スクリプトは定数をexportしておらず、requireすると本体が実行されるためハードコードを選択）
  - 古い「Current baseline: 36 unused exports」の記述は閾値30と矛盾するため削除

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` でYAMLのパースを確認
- 依存グラフに循環がないことを確認（deadcode/bundle-size → build → deploy/e2e の一方向）

🤖 Generated with [Claude Code](https://claude.com/claude-code)