### PR TITLE
fix: フロントエンドのアンマウント後処理・非同期タイミングの不備3件を修正

### DIFF
--- a/packages/frontend/src/components/meal/MealChat.tsx
+++ b/packages/frontend/src/components/meal/MealChat.tsx
@@ -46,6 +46,16 @@ export function MealChat({ mealId, currentFoodItems, onUpdate }: MealChatProps) 
   const [pendingChanges, setPendingChanges] = useState<ChatChange[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const photoResultTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  // Cancel pending photo-result timers on unmount
+  useEffect(() => {
+    const timers = photoResultTimersRef.current;
+    return () => {
+      timers.forEach(timer => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
 
   // Load chat history on mount
   useEffect(() => {
@@ -248,7 +258,8 @@ export function MealChat({ mealId, currentFoodItems, onUpdate }: MealChatProps) 
         const foodItems = result.foodItems;
         const updatedTotals = result.updatedTotals;
 
-        setTimeout(() => {
+        const timer = setTimeout(() => {
+          photoResultTimersRef.current.delete(timer);
           setMessages((prev) => [
             ...prev,
             {
@@ -264,6 +275,7 @@ export function MealChat({ mealId, currentFoodItems, onUpdate }: MealChatProps) 
 
           toast.success('写真を追加し、AI分析が完了しました');
         }, 2000);
+        photoResultTimersRef.current.add(timer);
       }
     } catch (error) {
       console.error('Photo upload error:', error);

--- a/packages/frontend/src/components/meal/MealEditMode.tsx
+++ b/packages/frontend/src/components/meal/MealEditMode.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { AnalysisResult } from './AnalysisResult';
 import { MealChat } from './MealChat';
 import { PhotoUploadButton } from './PhotoUploadButton';
@@ -9,6 +9,10 @@ import { validateNotFuture, toDateTimeLocal, getCurrentDateTimeLocal } from '../
 import { fromDatetimeLocal } from '../../lib/datetime';
 import { useMealPhotos } from '../../hooks/useMealPhotos';
 import type { FoodItem, NutritionTotals, MealRecord, MealType } from '@lifestyle-app/shared';
+
+// Photo analysis polling settings
+const ANALYSIS_POLL_INTERVAL_MS = 2000;
+const ANALYSIS_POLL_TIMEOUT_MS = 30000;
 
 interface MealEditModeProps {
   meal: MealRecord;
@@ -57,6 +61,15 @@ export function MealEditMode({
     uploadError,
     deleteError,
   } = useMealPhotos(meal.id);
+
+  // Track unmount to cancel photo analysis polling and avoid post-unmount setState
+  const isUnmountedRef = useRef(false);
+  useEffect(() => {
+    isUnmountedRef.current = false;
+    return () => {
+      isUnmountedRef.current = true;
+    };
+  }, []);
 
   // Notify parent of dirty state changes (T040)
   useEffect(() => {
@@ -211,20 +224,56 @@ export function MealEditMode({
     [meal.id, mealType, toast]
   );
 
+  // Poll the photo's analysis status until it completes (or fails / times out)
+  const waitForPhotoAnalysis = useCallback(
+    async (photoId: string): Promise<'complete' | 'failed' | 'timeout' | 'cancelled'> => {
+      const deadline = Date.now() + ANALYSIS_POLL_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, ANALYSIS_POLL_INTERVAL_MS));
+        if (isUnmountedRef.current) return 'cancelled';
+
+        try {
+          const { status } = await mealAnalysisApi.getPhotoStatus(meal.id, photoId);
+          if (status === 'complete') return 'complete';
+          if (status === 'failed') return 'failed';
+          // 'pending' / 'analyzing': keep polling
+        } catch (error) {
+          console.error('Failed to fetch photo analysis status:', error);
+          return 'failed';
+        }
+      }
+      return 'timeout';
+    },
+    [meal.id]
+  );
+
   // Handler for multiple photo upload (T028)
   const handlePhotoUpload = useCallback(
     async (file: File) => {
       try {
-        await uploadAsync(file);
+        const uploadResult = (await uploadAsync(file)) as { photo?: { id?: string } };
         setIsDirty(true);
         toast.success('写真をアップロードしました');
 
         // Reload food items and meal data after photo analysis completes
         if (onFoodItemsReload && onMealReload) {
-          // Wait to ensure backend processing is complete
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          // Poll analysis status instead of a fixed wait (AI analysis can take a while)
+          const photoId = uploadResult.photo?.id;
+          if (photoId) {
+            const status = await waitForPhotoAnalysis(photoId);
+            if (status === 'cancelled') return;
+            if (status === 'failed') {
+              toast.error('写真のAI分析に失敗しました');
+              return;
+            }
+            if (status === 'timeout') {
+              toast.warning('AI分析に時間がかかっています。しばらくしてから再読み込みしてください');
+              return;
+            }
+          }
 
           const updatedFoodItems = await onFoodItemsReload();
+          if (isUnmountedRef.current) return;
 
           // Force state update with new array reference
           setFoodItems([...updatedFoodItems]);
@@ -239,7 +288,7 @@ export function MealEditMode({
         toast.error('写真のアップロードに失敗しました');
       }
     },
-    [uploadAsync, toast, onFoodItemsReload, onMealReload]
+    [uploadAsync, toast, onFoodItemsReload, onMealReload, waitForPhotoAnalysis]
   );
 
   // Handler for photo deletion (T029)

--- a/packages/frontend/src/hooks/usePhotoMealFlow.ts
+++ b/packages/frontend/src/hooks/usePhotoMealFlow.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type {
   FoodItem,
@@ -72,12 +72,18 @@ export function usePhotoMealFlow(): UsePhotoMealFlowReturn {
   const [result, setResult] = useState<PhotoMealFlowResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Keep the latest preview URLs in a ref so the unmount cleanup below
+  // revokes URLs created after mount (empty deps would capture the initial array)
+  const photoPreviewUrlsRef = useRef<string[]>([]);
+  useEffect(() => {
+    photoPreviewUrlsRef.current = photoPreviewUrls;
+  }, [photoPreviewUrls]);
+
   // Cleanup preview URLs on unmount
   useEffect(() => {
     return () => {
-      photoPreviewUrls.forEach(url => URL.revokeObjectURL(url));
+      photoPreviewUrlsRef.current.forEach(url => URL.revokeObjectURL(url));
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const openSelector = useCallback(() => {


### PR DESCRIPTION
## 概要

Closes #126

フロントエンドのアンマウント後処理・非同期タイミングの不備3件を修正しました。

## 修正内容

### 1. usePhotoMealFlow: blob URLリーク (`packages/frontend/src/hooks/usePhotoMealFlow.ts`)

アンマウント時のクリーンアップが空依存配列のeffectでマウント時点の空配列をクロージャに捕捉しており、その後に作成されたプレビューURLが`revokeObjectURL`されずリークしていた。

- `photoPreviewUrlsRef`（`useRef<string[]>`）を追加し、effectで`photoPreviewUrls`の最新値を常に同期
- アンマウント時はrefから全URLをrevoke（`eslint-disable`も不要に）
- `closeSelector`/`removePhoto`/`reset`での既存のrevoke動作は変更なし（二重revokeは無害）

### 2. MealChat: アンマウント後にsetTimeoutが発火 (`packages/frontend/src/components/meal/MealChat.tsx`)

写真アップロード成功後の2秒`setTimeout`が、アンマウント後も`setMessages`/`toast`を実行していた。

- タイマーIDを`useRef<Set>`で管理（複数アップロードにも対応）し、アンマウント時に全タイマーを`clearTimeout`
- 発火時はSetから自身を削除。マウント中の挙動は従来と同一

### 3. MealEditMode: 固定1秒待ちでAI分析結果をリロード (`packages/frontend/src/components/meal/MealEditMode.tsx`)

写真アップロード後に固定1秒待ってから食材リストをリロードしていたが、AI分析は通常1秒以上かかるため古い/空のリストが表示されていた。

- `mealAnalysisApi.getPhotoStatus`を2秒間隔・最大30秒でポーリングし、`pending`/`analyzing`を抜けてからリロードする方式に変更（PhotoAnalysisReviewのポーリングパターンを踏襲）
- `failed`時は`toast.error`、タイムアウト時は`toast.warning`で通知して中断
- `isUnmountedRef`でアンマウント時にポーリングを中断し、アンマウント後のsetStateを防止

## テスト

- `pnpm typecheck`: 全3パッケージ pass
- `pnpm lint`: 新規エラー/警告なし（既存警告1件のみ: PhotoAnalysisReview.tsx の exhaustive-deps、本PR未変更ファイル）
- `pnpm test:unit`: 246 passed / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)