### PR TITLE
perf: getTodaysSummary/getStats/運動集計の残存フルスキャンをDB側に降ろす

### DIFF
--- a/packages/backend/src/services/exercise.ts
+++ b/packages/backend/src/services/exercise.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, sql, gte, lt } from 'drizzle-orm';
+import { eq, desc, and, sql, gte, lt, inArray, isNotNull } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { Database } from '../db';
 import { schema } from '../db';
@@ -350,23 +350,39 @@ export class ExerciseService {
     userId: string,
     exerciseTypes?: string[]
   ): Promise<{ exerciseType: string; maxRM: number; achievedAt: string }[]> {
-    // Get all records for the user (filtered by exercise types if specified)
-    const records = await this.db
-      .select()
-      .from(schema.exerciseRecords)
-      .where(eq(schema.exerciseRecords.userId, userId))
-      .all();
+    // Push the exerciseTypes filter into the WHERE clause (inArray) so the
+    // idx_exercise_user_type_date index narrows the scan, instead of fetching
+    // the user's whole history and filtering in JS (#120). Weight-less
+    // (bodyweight) records were always skipped in JS, so exclude them in SQL
+    // too. The 1RM value itself is a JS formula (calculate1RM), so the
+    // per-record computation stays in JS — but only the relevant rows are
+    // fetched now. Empty/undefined exerciseTypes keeps the "all types"
+    // behavior (inArray with [] would match nothing, so it's guarded).
+    const conditions = [
+      eq(schema.exerciseRecords.userId, userId),
+      isNotNull(schema.exerciseRecords.weight),
+    ];
+    if (exerciseTypes && exerciseTypes.length > 0) {
+      conditions.push(inArray(schema.exerciseRecords.exerciseType, exerciseTypes));
+    }
 
-    // Filter by exercise types if specified
-    const filtered = exerciseTypes && exerciseTypes.length > 0
-      ? records.filter(r => exerciseTypes.includes(r.exerciseType))
-      : records;
+    const filtered = await this.db
+      .select({
+        exerciseType: schema.exerciseRecords.exerciseType,
+        weight: schema.exerciseRecords.weight,
+        reps: schema.exerciseRecords.reps,
+        recordedAt: schema.exerciseRecords.recordedAt,
+      })
+      .from(schema.exerciseRecords)
+      .where(and(...conditions))
+      .all();
 
     // Group by exercise type and find max 1RM for each
     const maxByType = new Map<string, { maxRM: number; achievedAt: string }>();
 
     for (const record of filtered) {
-      // Skip records without weight (bodyweight exercises)
+      // Skip records without weight (bodyweight exercises) — already excluded
+      // by the SQL filter, kept as a type guard.
       if (record.weight === null) continue;
 
       const estimated1RM = calculate1RM(record.weight, record.reps);
@@ -395,10 +411,55 @@ export class ExerciseService {
   ) {
     const limit = options?.limit ?? 10;
 
+    // Resolve the page's session dates in SQL instead of fetching the user's
+    // whole exercise history and grouping/paginating in JS (#120). Sessions
+    // are local-date groups, and recordedAt's first 10 chars are the local
+    // date, so GROUP BY substr(recorded_at, 1, 10) with ORDER BY ... DESC and
+    // LIMIT limit+1 yields exactly the page's dates plus a has-more probe.
+    // The cursor (a session date the API itself returned as nextCursor) is
+    // pushed down as lt(recordedAt, cursor): every record on or after the
+    // cursor day sorts lexicographically >= the bare "YYYY-MM-DD" cursor, so
+    // this starts the page strictly after the cursor session — same as the
+    // old slice(cursorIndex + 1). Both queries are range scans on
+    // idx_exercise_user_date.
+    const localDate = sql<string>`substr(${schema.exerciseRecords.recordedAt}, 1, 10)`;
+    const dateConditions = [eq(schema.exerciseRecords.userId, userId)];
+    if (options?.cursor) {
+      dateConditions.push(lt(schema.exerciseRecords.recordedAt, options.cursor));
+    }
+
+    const dateRows = await this.db
+      .select({ date: localDate })
+      .from(schema.exerciseRecords)
+      .where(and(...dateConditions))
+      .groupBy(localDate)
+      .orderBy(desc(localDate))
+      .limit(limit + 1)
+      .all();
+
+    const hasMore = dateRows.length > limit;
+    const pageDates = dateRows.slice(0, limit);
+
+    if (pageDates.length === 0) {
+      return { sessions: [], nextCursor: null };
+    }
+
+    // Fetch only the page's records: the [oldest, newest] date window covers
+    // exactly the pageDates (they are consecutive distinct dates), so a
+    // single index range scan replaces the previous full fetch.
+    const newestDate = pageDates[0]!.date;
+    const oldestDate = pageDates[pageDates.length - 1]!.date;
+
     const records = await this.db
       .select()
       .from(schema.exerciseRecords)
-      .where(eq(schema.exerciseRecords.userId, userId))
+      .where(
+        and(
+          eq(schema.exerciseRecords.userId, userId),
+          gte(schema.exerciseRecords.recordedAt, oldestDate),
+          lt(schema.exerciseRecords.recordedAt, nextLocalDate(newestDate))
+        )
+      )
       .orderBy(desc(schema.exerciseRecords.recordedAt))
       .all();
 
@@ -416,21 +477,10 @@ export class ExerciseService {
       sessionMap.get(dateStr)!.exercises.push(record);
     }
 
-    // Convert to array and sort by date desc
-    let sessions = Array.from(sessionMap.values())
+    // Convert to array and sort by date desc (records are already DESC, so
+    // insertion order matches; the sort is kept as a cheap invariant guard)
+    const sessions = Array.from(sessionMap.values())
       .sort((a, b) => b.date.localeCompare(a.date));
-
-    // Apply cursor pagination
-    if (options?.cursor) {
-      const cursorIndex = sessions.findIndex(s => s.date === options.cursor);
-      if (cursorIndex !== -1) {
-        sessions = sessions.slice(cursorIndex + 1);
-      }
-    }
-
-    // Apply limit
-    const hasMore = sessions.length > limit;
-    sessions = sessions.slice(0, limit);
 
     // Format sessions for response
     const formattedSessions = sessions.map(session => {

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -216,13 +216,6 @@ export class MealService {
    * we simply extract the local date using slice(0, 10).
    */
   async getTodaysSummary(userId: string, clientTodayDate?: string) {
-    // 全ての食事を取得し、今日のローカル日付でフィルタ
-    const records = await this.db
-      .select()
-      .from(schema.mealRecords)
-      .where(eq(schema.mealRecords.userId, userId))
-      .all();
-
     // クライアントから渡された「今日」の日付を使用
     // フォールバック: サーバーの日付（UTCなので不正確だが後方互換性のため）
     let todayDate: string;
@@ -233,7 +226,24 @@ export class MealService {
       todayDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     }
 
-    const todayMeals = records.filter((r) => extractLocalDate(r.recordedAt) === todayDate);
+    // Push the local-date filter into SQL so the idx_meal_user_date range scan
+    // is used instead of fetching the user's whole meal history and filtering
+    // in JS (#120). Because recordedAt is an offset-aware ISO string whose
+    // first 10 chars are the local date, gte(todayDate) + lt(nextLocalDate) is
+    // exactly equivalent to the previous extractLocalDate(...) === todayDate
+    // comparison (see lib/localDate.ts). todayDate is always "YYYY-MM-DD" here
+    // (validated by todayQuerySchema, or built from the server date fallback).
+    const todayMeals = await this.db
+      .select()
+      .from(schema.mealRecords)
+      .where(
+        and(
+          eq(schema.mealRecords.userId, userId),
+          gte(schema.mealRecords.recordedAt, todayDate),
+          lt(schema.mealRecords.recordedAt, nextLocalDate(todayDate))
+        )
+      )
+      .all();
 
     const mealsWithCalories = todayMeals.filter((m) => m.calories !== null);
     const totalCalories = mealsWithCalories.reduce((sum, m) => sum + (m.calories ?? 0), 0);

--- a/packages/backend/src/services/user.ts
+++ b/packages/backend/src/services/user.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { users, weights, meals, exercises } from '../db/schema';
 import type { Database } from '../db';
 
@@ -190,29 +190,35 @@ export class UserService {
   }
 
   async getStats(userId: string) {
+    // Count in SQL instead of fetching every row with SELECT * and using
+    // .length in JS (#120) — only a single integer per table crosses the wire.
     const weightCount = await this.db
-      .select()
+      .select({ count: sql<number>`COUNT(*)` })
       .from(weights)
       .where(eq(weights.userId, userId))
       .all();
 
     const mealCount = await this.db
-      .select()
+      .select({ count: sql<number>`COUNT(*)` })
       .from(meals)
       .where(eq(meals.userId, userId))
       .all();
 
     const exerciseCount = await this.db
-      .select()
+      .select({ count: sql<number>`COUNT(*)` })
       .from(exercises)
       .where(eq(exercises.userId, userId))
       .all();
 
+    const weightRecords = weightCount[0]?.count ?? 0;
+    const mealRecords = mealCount[0]?.count ?? 0;
+    const exerciseRecords = exerciseCount[0]?.count ?? 0;
+
     return {
-      weightRecords: weightCount.length,
-      mealRecords: mealCount.length,
-      exerciseRecords: exerciseCount.length,
-      totalRecords: weightCount.length + mealCount.length + exerciseCount.length,
+      weightRecords,
+      mealRecords,
+      exerciseRecords,
+      totalRecords: weightRecords + mealRecords + exerciseRecords,
     };
   }
 }

--- a/tests/unit/exercise.service.test.ts
+++ b/tests/unit/exercise.service.test.ts
@@ -1,4 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExerciseService } from '../../packages/backend/src/services/exercise';
+
+// Mock the database (chainable query builder)
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  groupBy: vi.fn().mockReturnThis(),
+  orderBy: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+  all: vi.fn(),
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+};
 
 describe('ExerciseService', () => {
   beforeEach(() => {
@@ -109,6 +127,93 @@ describe('ExerciseService', () => {
 
     it('should not delete record belonging to different user', async () => {
       expect(true).toBe(true);
+    });
+  });
+
+  describe('getMaxRMs', () => {
+    it('computes max 1RM per type from rows already filtered in SQL (#120)', async () => {
+      // The DB now only returns weighted rows of the requested types (the
+      // exerciseTypes/isNotNull(weight) filters live in the WHERE clause).
+      mockDb.all.mockResolvedValueOnce([
+        { exerciseType: 'ベンチプレス', weight: 100, reps: 5, recordedAt: '2026-01-10T10:00:00+09:00' },
+        { exerciseType: 'ベンチプレス', weight: 80, reps: 10, recordedAt: '2026-01-05T10:00:00+09:00' },
+        { exerciseType: 'スクワット', weight: 120, reps: 3, recordedAt: '2026-01-08T10:00:00+09:00' },
+      ]);
+
+      const service = new ExerciseService(mockDb as never);
+      const result = await service.getMaxRMs('user-123', ['ベンチプレス', 'スクワット']);
+
+      const bench = result.find((r) => r.exerciseType === 'ベンチプレス')!;
+      expect(bench.maxRM).toBeGreaterThan(100); // Epley: 100kg x 5 > 100
+      expect(bench.achievedAt).toBe('2026-01-10T10:00:00+09:00');
+      expect(result.find((r) => r.exerciseType === 'スクワット')).toBeDefined();
+
+      // Single SELECT with a WHERE filter — no JS full-scan filtering
+      expect(mockDb.all).toHaveBeenCalledTimes(1);
+      expect(mockDb.where).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array when no weighted records match', async () => {
+      mockDb.all.mockResolvedValueOnce([]);
+
+      const service = new ExerciseService(mockDb as never);
+      const result = await service.getMaxRMs('user-123');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getRecentSessions', () => {
+    it('pages by date window resolved in SQL and preserves the response shape (#120)', async () => {
+      mockDb.all
+        // 1st .all(): GROUP BY local-date page probe (limit+1 rows => hasMore)
+        .mockResolvedValueOnce([
+          { date: '2026-01-10' },
+          { date: '2026-01-08' },
+          { date: '2026-01-05' },
+        ])
+        // 2nd .all(): records inside the [oldest, newest] date window, DESC
+        .mockResolvedValueOnce([
+          { id: 'e1', userId: 'user-123', exerciseType: 'ベンチプレス', muscleGroup: '胸', setNumber: 1, reps: 10, weight: 60, variation: null, recordedAt: '2026-01-10T10:00:00+09:00' },
+          { id: 'e2', userId: 'user-123', exerciseType: 'ベンチプレス', muscleGroup: '胸', setNumber: 2, reps: 8, weight: 60, variation: null, recordedAt: '2026-01-10T10:00:00+09:00' },
+          { id: 'e3', userId: 'user-123', exerciseType: 'スクワット', muscleGroup: '脚', setNumber: 1, reps: 12, weight: 80, variation: null, recordedAt: '2026-01-08T09:00:00+09:00' },
+        ]);
+
+      const service = new ExerciseService(mockDb as never);
+      const result = await service.getRecentSessions('user-123', { limit: 2 });
+
+      // 3 date rows for limit 2 => hasMore, nextCursor = oldest page date
+      expect(result.sessions.map((s) => s.date)).toEqual(['2026-01-10', '2026-01-08']);
+      expect(result.nextCursor).toBe('2026-01-08');
+
+      const day1 = result.sessions[0]!;
+      expect(day1.exercises).toHaveLength(1);
+      expect(day1.exercises[0]!.sets.map((s) => s.setNumber)).toEqual([1, 2]);
+    });
+
+    it('returns empty page and null cursor when there are no sessions', async () => {
+      mockDb.all.mockResolvedValueOnce([]);
+
+      const service = new ExerciseService(mockDb as never);
+      const result = await service.getRecentSessions('user-123', { cursor: '2026-01-01' });
+
+      expect(result).toEqual({ sessions: [], nextCursor: null });
+      // No second query when the date page is empty
+      expect(mockDb.all).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null nextCursor on the last page', async () => {
+      mockDb.all
+        .mockResolvedValueOnce([{ date: '2026-01-10' }]) // <= limit rows => no more
+        .mockResolvedValueOnce([
+          { id: 'e1', userId: 'user-123', exerciseType: '懸垂', muscleGroup: '背中', setNumber: 1, reps: 10, weight: null, variation: null, recordedAt: '2026-01-10T10:00:00+09:00' },
+        ]);
+
+      const service = new ExerciseService(mockDb as never);
+      const result = await service.getRecentSessions('user-123', { limit: 10 });
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.nextCursor).toBeNull();
     });
   });
 });

--- a/tests/unit/meal.service.test.ts
+++ b/tests/unit/meal.service.test.ts
@@ -182,6 +182,36 @@ describe('MealService', () => {
     });
   });
 
+  describe('getTodaysSummary', () => {
+    it('filters today\'s meals via a DB-side date range instead of scanning all records (#120)', async () => {
+      const userId = 'user-123';
+      // The DB now returns only today's rows (the gte/lt local-date range is
+      // pushed into the WHERE clause and uses idx_meal_user_date).
+      mockDb.all.mockResolvedValueOnce([
+        { id: 'm1', userId, mealType: 'breakfast', content: 'a', calories: 300, totalProtein: 10, totalFat: 5, totalCarbs: 40, recordedAt: '2026-01-15T08:00:00+09:00' },
+        { id: 'm2', userId, mealType: 'lunch', content: 'b', calories: 500, totalProtein: 20, totalFat: 15, totalCarbs: 60, recordedAt: '2026-01-15T12:30:00+09:00' },
+        { id: 'm3', userId, mealType: 'snack', content: 'c', calories: null, totalProtein: null, totalFat: null, totalCarbs: null, recordedAt: '2026-01-15T15:00:00+09:00' },
+      ]);
+
+      const service = new MealService(mockDb as never);
+      const summary = await service.getTodaysSummary(userId, '2026-01-15');
+
+      expect(summary).toEqual({
+        totalCalories: 800,
+        averageCalories: 400,
+        count: 2, // only meals with calories
+        totalMeals: 3,
+        totalProtein: 30,
+        totalFat: 20,
+        totalCarbs: 100,
+      });
+
+      // Single filtered SELECT — no JS date filtering over the whole history
+      expect(mockDb.all).toHaveBeenCalledTimes(1);
+      expect(mockDb.where).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getMealDates', () => {
     it('should return unique dates with meal records for a given month', async () => {
       const userId = 'user-123';

--- a/tests/unit/user.service.test.ts
+++ b/tests/unit/user.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserService } from '../../packages/backend/src/services/user';
+
+// Mock the database (chainable query builder)
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  orderBy: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+  all: vi.fn(),
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+};
+
+describe('UserService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getStats', () => {
+    it('counts records via SQL COUNT(*) instead of fetching every row (#120)', async () => {
+      // Each .all() resolves a single COUNT(*) row, not the full record set
+      mockDb.all
+        .mockResolvedValueOnce([{ count: 12 }]) // weight_records
+        .mockResolvedValueOnce([{ count: 34 }]) // meal_records
+        .mockResolvedValueOnce([{ count: 5 }]); // exercise_records
+
+      const service = new UserService(mockDb as never);
+      const stats = await service.getStats('user-123');
+
+      expect(stats).toEqual({
+        weightRecords: 12,
+        mealRecords: 34,
+        exerciseRecords: 5,
+        totalRecords: 51,
+      });
+      expect(mockDb.all).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns zeros when the user has no records', async () => {
+      mockDb.all
+        .mockResolvedValueOnce([{ count: 0 }])
+        .mockResolvedValueOnce([{ count: 0 }])
+        .mockResolvedValueOnce([{ count: 0 }]);
+
+      const service = new UserService(mockDb as never);
+      const stats = await service.getStats('user-123');
+
+      expect(stats).toEqual({
+        weightRecords: 0,
+        mealRecords: 0,
+        exerciseRecords: 0,
+        totalRecords: 0,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 概要

3サービスに残っていた「`WHERE user_id = ?` だけで全件取得 → JSでフィルタ/集計」のフルスキャンを、すべてDB側のWHERE/集計に降ろしました（純粋なパフォーマンスリファクタで、APIレスポンスの形・値は変わりません）。

Closes #120

## 変更内容

### 1. `MealService.getTodaysSummary` (packages/backend/src/services/meal.ts)

- **Before**: ユーザーの食事記録を全件SELECTし、JSで `extractLocalDate(recordedAt) === todayDate` フィルタ。
- **After**: `findByUserId` と同じパターンで `gte(recordedAt, todayDate)` + `lt(recordedAt, nextLocalDate(todayDate))` をWHEREに降ろし。`recordedAt` はオフセット付きISO文字列で先頭10文字がローカル日付なので、この辞書順レンジは従来のJS比較と**完全に等価**（`lib/localDate.ts` の規約どおり）。
- `clientTodayDate` 未指定時のフォールバック（サーバー日付）も従来どおり同じ比較になるため、両パスとも安全にDB側へ降ろせています。
- **使用インデックス**: `idx_meal_user_date (user_id, recorded_at)` のrange scan。

### 2. `UserService.getStats` (packages/backend/src/services/user.ts)

- **Before**: weight_records / meal_records / exercise_records の3表を `SELECT *` 全件取得し `.length` でカウント。
- **After**: `SELECT COUNT(*)` ×3 に置換。返却shapeは `{ weightRecords, mealRecords, exerciseRecords, totalRecords }` のまま同一。
- 各表の `user_id` 先頭の既存インデックスでカウント可能になり、転送は1行×3だけに。

### 3. `ExerciseService.getMaxRMs` / `getRecentSessions` (packages/backend/src/services/exercise.ts)

**getMaxRMs**
- **Before**: 全件SELECT → JSで `exerciseTypes.includes()` フィルタ + `weight === null` スキップ。
- **After**: `inArray(exerciseType, exerciseTypes)`（空/未指定なら全タイプ＝従来挙動をガード）+ `isNotNull(weight)` をWHEREに降ろし、必要4カラムのみSELECT。1RM算出は共有のJS式（`calculate1RM`）なので計算自体はJSに残しています（issue記載どおり許容範囲）。
- **使用インデックス**: `idx_exercise_user_type_date (user_id, exercise_type, recorded_at)`。

**getRecentSessions**
- **Before**: 全件SELECT → JSで日付グルーピング → カーソル位置をJSで探してslice → limit。
- **After**: 2クエリ構成に変更。
  1. `GROUP BY substr(recorded_at, 1, 10)` + `ORDER BY DESC` + `LIMIT limit+1` でページ対象の日付（＋hasMore判定分）だけをSQLで解決。カーソルは `lt(recordedAt, cursor)` として降ろし（カーソル日のレコードは `"YYYY-MM-DDT..." >= "YYYY-MM-DD"` なので従来の「カーソルの次から」と同じ開始位置）。
  2. ページの `[最古日, 最新日]` を日付ウィンドウとして `gte`/`lt` の単一range scanでそのページ分のレコードのみ取得。
- グルーピング/整形ロジック・レスポンスshape（`{ sessions, nextCursor }`）・nextCursorの値は従来と同一。
- なお `substr(recorded_at,1,10)` を使い SQLite の `date()` は使っていません（`date()` はオフセット付きISOをUTC変換してしまい、ローカル日付プレフィックスとずれるため）。
- **使用インデックス**: `idx_exercise_user_date (user_id, recorded_at)`（両クエリともrange scan）。

## 既知の極小な挙動差（getRecentSessionsのみ）

旧実装では「カーソルの日付がセッション一覧に存在しない場合（ページ取得の合間にその日の記録が全削除されたレース時）」に1ページ目から再表示していましたが、新実装はカーソル日付より厳密に前のセッションを返します。カーソルはAPI自身が返した `nextCursor`（実在したセッション日付）のみが入る値であり、この縮退ケースではむしろ新挙動の方がページネーションとして正しいため、許容範囲と判断しました。それ以外のカーソル/limit/hasMoreセマンティクスは完全に同一です。

## テスト

- `pnpm typecheck`: 3パッケージすべてpass
- `pnpm test:unit`: 254 passed / 1 skipped
- 追加テスト:
  - `tests/unit/meal.service.test.ts`: getTodaysSummary（DB側レンジフィルタ前提の集計・1クエリ検証）
  - `tests/unit/exercise.service.test.ts`: getMaxRMs（SQLフィルタ済み行からの1RM集計）、getRecentSessions（日付ウィンドウ2クエリ・hasMore/nextCursor・空ページ・最終ページ）
  - `tests/unit/user.service.test.ts`: getStats（COUNT(*)×3とshape維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)