### PR TITLE
fix: エラーロギングを堅牢化（userIdをセッション由来に・formDataマスク・requestId競合解消）

### DIFF
--- a/packages/backend/src/routes/logs.ts
+++ b/packages/backend/src/routes/logs.ts
@@ -1,21 +1,70 @@
 import { Hono } from 'hono';
+import { getCookie } from 'hono/cookie';
+import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
 import { errorLogSchema } from '@lifestyle-app/shared';
+import { resolveSessionSecret, verifySessionToken } from '../middleware/auth';
 
 type Bindings = {
   DB: D1Database;
+  SESSION_SECRET?: string;
+  ENVIRONMENT?: string;
 };
 
+/**
+ * Hard cap on the request body. The Zod schema already bounds every field,
+ * but rejecting oversized bodies up front avoids parsing attacker-controlled
+ * megabyte payloads at all.
+ */
+const MAX_BODY_SIZE_BYTES = 32 * 1024;
+
+/**
+ * Error log intake.
+ *
+ * Intentionally does NOT require authentication: frontend errors can occur
+ * before login (e.g. on the login page itself). Instead of trusting a
+ * client-sent userId, the user id is derived server-side from the session
+ * cookie when one is present and valid; otherwise the entry is logged as
+ * "anonymous". Abuse is bounded by the body size cap plus strict Zod field
+ * length limits (see errorLogSchema in @lifestyle-app/shared).
+ */
 export const logs = new Hono<{ Bindings: Bindings }>()
-  .post('/error', zValidator('json', errorLogSchema), async (c) => {
-    const error = c.req.valid('json');
-    const { requestId, userId } = error;
+  .post(
+    '/error',
+    bodyLimit({
+      maxSize: MAX_BODY_SIZE_BYTES,
+      onError: (c) => c.json({ message: 'リクエストボディが大きすぎます' }, 413),
+    }),
+    zValidator('json', errorLogSchema),
+    async (c) => {
+      const error = c.req.valid('json');
+      const { requestId } = error;
 
-    // Enhanced logging with Request ID and User ID for traceability
-    const logPrefix = requestId ? `[${requestId}]` : '[NO_REQUEST_ID]';
-    const userInfo = userId ? ` [User: ${userId}]` : ' [Unauthenticated]';
+      // Optional auth: resolve the user id from the session cookie only.
+      // Never trust a client-supplied user id.
+      let userId = 'anonymous';
+      const sessionToken = getCookie(c, 'session');
+      if (sessionToken) {
+        try {
+          const secret = resolveSessionSecret(
+            c.env as { SESSION_SECRET?: string; ENVIRONMENT?: string }
+          );
+          const payload = await verifySessionToken(sessionToken, secret);
+          if (payload) {
+            userId = payload.userId;
+          }
+        } catch {
+          // Misconfigured secret (production without SESSION_SECRET):
+          // still accept the log, just without user attribution.
+        }
+      }
 
-    console.error(`${logPrefix}${userInfo} [Frontend Error]`, JSON.stringify(error, null, 2));
+      // Enhanced logging with Request ID and User ID for traceability
+      const logPrefix = requestId ? `[${requestId}]` : '[NO_REQUEST_ID]';
+      const userInfo = ` [User: ${userId}]`;
 
-    return c.json({ received: true });
-  });
+      console.error(`${logPrefix}${userInfo} [Frontend Error]`, JSON.stringify(error, null, 2));
+
+      return c.json({ received: true });
+    }
+  );

--- a/packages/frontend/src/lib/client.ts
+++ b/packages/frontend/src/lib/client.ts
@@ -1,7 +1,7 @@
 import { hc } from 'hono/client';
 import type { AppType } from '@lifestyle-app/backend';
 import { generateRequestId } from './requestId';
-import { setCurrentRequestId } from './errorLogger';
+import { setLastRequestId } from './errorLogger';
 import { useAuthStore } from '../stores/authStore';
 
 // In production (empty VITE_API_URL), use same origin
@@ -29,8 +29,10 @@ export const client = hc<AppType>(API_BASE_URL, {
     // Generate unique Request ID for this request
     const requestId = generateRequestId();
 
-    // Store requestId for error correlation
-    setCurrentRequestId(requestId);
+    // Record as the most recent request id (best-effort fallback for error
+    // correlation only — concurrent requests overwrite each other here, so
+    // errors thrown below carry their exact requestId on the Error object).
+    setLastRequestId(requestId);
 
     // Create new Headers object to properly merge headers
     const headers = new Headers(init?.headers);
@@ -58,10 +60,13 @@ export const client = hc<AppType>(API_BASE_URL, {
       return response;
     } catch (error) {
       console.error('[RPC] Fetch error:', error);
+      // Attach this request's exact id to the error so error logging
+      // (ErrorBoundary, unhandledrejection, manual logError calls) reports
+      // the right requestId even when other requests ran concurrently.
+      if (error instanceof Error) {
+        (error as Error & { requestId?: string }).requestId = requestId;
+      }
       throw error;
-    } finally {
-      // Clear requestId after request completes
-      setCurrentRequestId(undefined);
     }
   },
 });

--- a/packages/frontend/src/lib/errorLogger.ts
+++ b/packages/frontend/src/lib/errorLogger.ts
@@ -1,44 +1,97 @@
 import { api } from './client';
 import type { FieldErrors } from 'react-hook-form';
 import type { ErrorLog } from '@lifestyle-app/shared';
-import { useAuthStore } from '../stores/authStore';
+import { ERROR_LOG_LIMITS } from '@lifestyle-app/shared';
 
 /**
- * Module-scoped requestId for correlating errors with their originating request
- * Set by client.ts when making API calls, consumed by error logger
+ * Best-effort fallback: id of the most recently started API request.
+ *
+ * Concurrent requests overwrite each other here, so this is only used when
+ * an error carries no request id of its own (e.g. render errors caught by
+ * an ErrorBoundary). Errors thrown by the API client get the exact request
+ * id attached to the Error object by client.ts (see ErrorWithRequestId).
  */
-let currentRequestId: string | undefined;
+let lastRequestId: string | undefined;
 
 /**
- * Set the current request ID for error correlation
- * Called by client.ts before each API request
+ * Record the id of the most recently started API request.
+ * Called by client.ts before each API request.
  */
-export function setCurrentRequestId(requestId: string | undefined) {
-  currentRequestId = requestId;
+export function setLastRequestId(requestId: string | undefined) {
+  lastRequestId = requestId;
+}
+
+/** Error optionally tagged with the id of the request that caused it. */
+interface ErrorWithRequestId extends Error {
+  requestId?: string;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
 }
 
 /**
- * Get the current user ID from auth store
+ * Bound `extra` so it passes the backend schema's serialized-size limit.
+ * If it serializes too large, send a truncated preview instead of dropping
+ * the whole log on the floor.
  */
-function getCurrentUserId(): string | undefined {
-  const state = useAuthStore.getState();
-  return state.user?.id;
+function boundExtra(
+  extra: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (extra === undefined) return undefined;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(extra);
+  } catch {
+    return { truncated: true, preview: '[unserializable extra]' };
+  }
+  if (serialized.length <= ERROR_LOG_LIMITS.extraSerialized) {
+    return extra;
+  }
+  // Escaping can at most double the preview's length when re-serialized,
+  // so keep it well under the limit.
+  return { truncated: true, preview: serialized.slice(0, 800) };
 }
 
-export async function logError(error: Error, extra?: Record<string, unknown>) {
-  const errorLog: ErrorLog = {
-    message: error.message,
-    stack: error.stack,
-    url: window.location.href,
-    userAgent: navigator.userAgent,
-    timestamp: new Date().toISOString(),
-    requestId: currentRequestId,
-    userId: getCurrentUserId(),
-    extra,
-  };
+const SENSITIVE_KEY_PATTERN = /password|token|secret|email|credential/i;
+const MAX_FORM_VALUE_LENGTH = 100;
 
+/**
+ * Sanitize form data before it is sent to the error log endpoint:
+ * - values under sensitive-looking keys are masked
+ * - long strings are truncated
+ * - non-primitive values are omitted (unknown shape could nest secrets)
+ */
+function sanitizeFormData(
+  formData: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (formData === undefined) return undefined;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(formData)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      sanitized[key] = '[REDACTED]';
+    } else if (typeof value === 'string') {
+      sanitized[key] =
+        value.length > MAX_FORM_VALUE_LENGTH
+          ? `${value.slice(0, MAX_FORM_VALUE_LENGTH)}…[truncated]`
+          : value;
+    } else if (
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null ||
+      value === undefined
+    ) {
+      sanitized[key] = value;
+    } else {
+      sanitized[key] = '[omitted]';
+    }
+  }
+  return sanitized;
+}
+
+async function sendErrorLog(errorLog: ErrorLog, consoleLabel: string) {
   // Also log to console for local debugging
-  console.error('[Error Logger]', errorLog);
+  console.error(consoleLabel, errorLog);
 
   try {
     await api.logs.error.$post({ json: errorLog });
@@ -46,6 +99,26 @@ export async function logError(error: Error, extra?: Record<string, unknown>) {
     // Don't throw if logging fails
     console.error('[Error Logger] Failed to send error log:', e);
   }
+}
+
+export async function logError(
+  error: Error,
+  extra?: Record<string, unknown>,
+  requestId?: string
+) {
+  const errorLog: ErrorLog = {
+    message: truncate(error.message || 'Unknown error', ERROR_LOG_LIMITS.message),
+    stack: error.stack ? truncate(error.stack, ERROR_LOG_LIMITS.stack) : undefined,
+    url: truncate(window.location.href, ERROR_LOG_LIMITS.url),
+    userAgent: truncate(navigator.userAgent, ERROR_LOG_LIMITS.userAgent),
+    timestamp: new Date().toISOString(),
+    // Prefer an explicitly passed id, then the id attached to the error by
+    // the API client, and only then the racy "last request" fallback.
+    requestId: requestId ?? (error as ErrorWithRequestId).requestId ?? lastRequestId,
+    extra: boundExtra(extra),
+  };
+
+  await sendErrorLog(errorLog, '[Error Logger]');
 }
 
 // Log validation errors from react-hook-form
@@ -61,27 +134,20 @@ export async function logValidationError(
   }));
 
   const errorLog: ErrorLog = {
-    message: `Validation error in ${formName}`,
-    url: window.location.href,
-    userAgent: navigator.userAgent,
+    message: truncate(`Validation error in ${formName}`, ERROR_LOG_LIMITS.message),
+    url: truncate(window.location.href, ERROR_LOG_LIMITS.url),
+    userAgent: truncate(navigator.userAgent, ERROR_LOG_LIMITS.userAgent),
     timestamp: new Date().toISOString(),
-    requestId: currentRequestId,
-    userId: getCurrentUserId(),
-    extra: {
+    requestId: lastRequestId,
+    extra: boundExtra({
       type: 'validation',
       formName,
       errors: errorDetails,
-      formData,
-    },
+      formData: sanitizeFormData(formData),
+    }),
   };
 
-  console.error('[Validation Error]', errorLog);
-
-  try {
-    await api.logs.error.$post({ json: errorLog });
-  } catch (e) {
-    console.error('[Error Logger] Failed to send validation error log:', e);
-  }
+  await sendErrorLog(errorLog, '[Validation Error]');
 }
 
 // Global error handler

--- a/packages/shared/src/schemas/log.ts
+++ b/packages/shared/src/schemas/log.ts
@@ -1,19 +1,45 @@
 import { z } from 'zod';
 
 /**
- * Schema for error log entries with request tracing support
+ * Field size limits for error log entries.
  *
- * Includes requestId and userId for end-to-end traceability
+ * The /api/logs/error endpoint is intentionally unauthenticated (frontend
+ * errors can happen before login), so these strict caps are the first line
+ * of defense against log-flooding abuse. The frontend truncates fields to
+ * these limits before sending (see frontend lib/errorLogger.ts).
+ */
+export const ERROR_LOG_LIMITS = {
+  message: 1000,
+  stack: 5000,
+  url: 2000,
+  userAgent: 500,
+  /** Max length of JSON.stringify(extra) */
+  extraSerialized: 2000,
+} as const;
+
+/**
+ * Schema for error log entries with request tracing support.
+ *
+ * Note: there is intentionally no `userId` field. The backend derives the
+ * user id from the (optional) session cookie instead of trusting a
+ * client-sent value.
  */
 export const errorLogSchema = z.object({
-  message: z.string().min(1, 'Message is required'),
-  stack: z.string().optional(),
-  url: z.string().url('Valid URL required'),
-  userAgent: z.string().optional(),
+  message: z.string().min(1, 'Message is required').max(ERROR_LOG_LIMITS.message),
+  stack: z.string().max(ERROR_LOG_LIMITS.stack).optional(),
+  url: z.string().url('Valid URL required').max(ERROR_LOG_LIMITS.url),
+  userAgent: z.string().max(ERROR_LOG_LIMITS.userAgent).optional(),
   timestamp: z.string().datetime('ISO 8601 timestamp required'),
   requestId: z.string().uuid('Valid UUID v4 required').optional(),
-  userId: z.string().min(1).optional(),
-  extra: z.record(z.unknown()).optional(),
+  extra: z
+    .record(z.unknown())
+    .optional()
+    .refine(
+      (value) =>
+        value === undefined ||
+        JSON.stringify(value).length <= ERROR_LOG_LIMITS.extraSerialized,
+      { message: `extra must serialize to at most ${ERROR_LOG_LIMITS.extraSerialized} characters` }
+    ),
 });
 
 /**

--- a/tests/unit/error-log-schema.test.ts
+++ b/tests/unit/error-log-schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { errorLogSchema, ERROR_LOG_LIMITS } from '../../packages/shared/src/schemas/log';
+
+const validLog = {
+  message: 'Something broke',
+  stack: 'Error: Something broke\n  at foo (app.js:1:1)',
+  url: 'https://example.com/meals',
+  userAgent: 'Mozilla/5.0',
+  timestamp: '2026-06-11T10:00:00.000Z',
+  requestId: '12345678-1234-4234-8234-123456789abc',
+  extra: { component: 'PhotoUploadButton' },
+};
+
+describe('errorLogSchema (abuse protection limits)', () => {
+  it('accepts a valid error log', () => {
+    expect(errorLogSchema.safeParse(validLog).success).toBe(true);
+  });
+
+  it('accepts a minimal anonymous error log (no requestId, no extra)', () => {
+    const result = errorLogSchema.safeParse({
+      message: 'Pre-login error',
+      url: 'https://example.com/login',
+      timestamp: '2026-06-11T10:00:00.000Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('strips a client-sent userId instead of trusting it', () => {
+    const result = errorLogSchema.safeParse({ ...validLog, userId: 'someone-else' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('userId' in result.data).toBe(false);
+    }
+  });
+
+  it(`rejects message longer than ${ERROR_LOG_LIMITS.message} chars`, () => {
+    const result = errorLogSchema.safeParse({
+      ...validLog,
+      message: 'a'.repeat(ERROR_LOG_LIMITS.message + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects stack longer than ${ERROR_LOG_LIMITS.stack} chars`, () => {
+    const result = errorLogSchema.safeParse({
+      ...validLog,
+      stack: 'a'.repeat(ERROR_LOG_LIMITS.stack + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects extra serializing to more than ${ERROR_LOG_LIMITS.extraSerialized} chars`, () => {
+    const result = errorLogSchema.safeParse({
+      ...validLog,
+      extra: { payload: 'a'.repeat(ERROR_LOG_LIMITS.extraSerialized + 1) },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts boundary-length fields', () => {
+    const result = errorLogSchema.safeParse({
+      ...validLog,
+      message: 'a'.repeat(ERROR_LOG_LIMITS.message),
+      stack: 'a'.repeat(ERROR_LOG_LIMITS.stack),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-UUID requestId', () => {
+    const result = errorLogSchema.safeParse({ ...validLog, requestId: 'not-a-uuid' });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #125 のエラーロギング全般の問題（未認証エンドポイントの濫用耐性・個人情報リーク・requestId競合）を修正します。

Closes #125

## 修正内容

### 1. `/api/logs/error` がクライアント送信の `userId` を信用していた問題（backend/src/routes/logs.ts）

ログイン前のエラーも記録できるよう**認証必須にはせず**、以下で対応:

- セッションCookieをサーバー側で検証（`verifySessionToken` を任意認証として再利用）し、有効なセッションがあればその `userId` をログに記録。無ければ `anonymous` として記録。クライアント送信の `userId` はスキーマから削除し完全に無視（旧クライアントが送ってきても strip される）
- 濫用対策として `errorLogSchema` に厳格な長さ上限を追加: `message` ≤ 1000 / `stack` ≤ 5000 / `url` ≤ 2000 / `userAgent` ≤ 500 / `extra` はシリアライズ後 ≤ 2000 文字
- Hono の `bodyLimit` ミドルウェアでリクエストボディを 32KB に制限（413 を返却）
- フロントエンド側も送信前に各フィールドを同じ上限で切り詰め、正当なエラーログがバリデーションで落ちないようにした

### 2. `logValidationError` の formData リーク（frontend/src/lib/errorLogger.ts）

`formData` をそのまま送信していたためサニタイザを追加:

- キーが `/password|token|secret|email|credential/i` にマッチする値は `[REDACTED]` にマスク
- 長い文字列値は 100 文字で切り詰め
- 形が不明なネストオブジェクト/配列は `[omitted]` に置換
- 既存の呼び出し元（StrengthInput.tsx / WeightInput.tsx）は変更不要

### 3. モジュールスコープ `currentRequestId` の競合（errorLogger.ts / client.ts）

並行APIリクエストが requestId を上書きし合い、エラーログに誤った requestId が紐づく問題:

- client.ts の fetch ラッパーが失敗時に **そのリクエストの requestId を Error オブジェクトに添付**し、`logError` はそれを優先して使用（モジュール状態に依存しない）
- `logError` に明示的な `requestId` 引数も追加
- モジュールスコープの ID は `lastRequestId`（最後に開始したリクエストのID）に改名し、クライアント経由でないエラー（レンダリングエラー等）向けのベストエフォートなフォールバックに限定。リクエスト完了時のクリア処理（競合の一因）は削除

## テスト

- `pnpm build:shared && pnpm typecheck` パス（shared/backend/frontend 全て）
- `pnpm test:unit` パス（254 passed / 1 skipped）
- 新規テスト追加: `tests/unit/error-log-schema.test.ts`（長さ上限・userId strip・境界値・UUID検証の8ケース）

🤖 Generated with [Claude Code](https://claude.com/claude-code)