### PR TITLE
fix: cronにtemp/プレフィックスR2オブジェクトの24時間経過後クリーンアップを追加

### DIFF
--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -10,6 +10,9 @@
  *    in ai_usage_totals so pruning detail does not affect the displayed total).
  * 5. Expired email_rate_limits rows (#106): previously only swept lazily on the
  *    next send from the same IP, so they lingered if email went idle.
+ * 6. Orphaned temp/ R2 objects older than 24 hours (#129): photo analysis
+ *    uploads to temp/<uuid> and /save moves them to photos/...; if the user
+ *    abandons before saving, the temp object stays forever.
  */
 
 import { drizzle } from 'drizzle-orm/d1';
@@ -23,6 +26,8 @@ const UNVERIFIED_ACCOUNT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const TOKEN_CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const EMAIL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (operational logs, recipient PII)
 const AI_USAGE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (detail; total kept in rollup)
+const TEMP_PHOTO_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours (analysis review flow is minutes)
+const R2_DELETE_BATCH_SIZE = 1000; // R2 bucket.delete() accepts up to 1000 keys per call
 
 interface CleanupResult {
   deletedUsers: number;
@@ -33,12 +38,52 @@ interface CleanupResult {
   deletedEmailLogs: number;
   deletedAiUsageRecords: number;
   deletedRateLimits: number;
+  deletedTempPhotos: number;
+}
+
+/**
+ * Delete temp/ R2 objects older than the retention window (#129).
+ *
+ * temp/<uuid> objects are created by POST /api/meals/analyze and normally
+ * moved to photos/{userId}/{mealId}/... (and deleted) by /save. If the user
+ * abandons the review flow, the object is never removed. The review flow
+ * lives for minutes, so anything past 24 hours is safe to delete — a
+ * meal_photos row may still reference the key, but such a row belongs to a
+ * meal that was never saved.
+ *
+ * Exported for unit testing.
+ */
+export async function cleanupTempPhotos(bucket: R2Bucket, now: number): Promise<number> {
+  const cutoff = now - TEMP_PHOTO_RETENTION_MS;
+
+  // Collect keys of expired temp objects, paginating with truncated/cursor.
+  const expiredKeys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const listed = await bucket.list({ prefix: 'temp/', cursor });
+    for (const object of listed.objects) {
+      if (object.uploaded.getTime() < cutoff) {
+        expiredKeys.push(object.key);
+      }
+    }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  // Batch delete (R2 supports up to 1000 keys per delete call).
+  for (let i = 0; i < expiredKeys.length; i += R2_DELETE_BATCH_SIZE) {
+    await bucket.delete(expiredKeys.slice(i, i + R2_DELETE_BATCH_SIZE));
+  }
+
+  return expiredKeys.length;
 }
 
 /**
  * Execute all scheduled cleanup tasks
  */
-export async function executeScheduledCleanup(db: D1Database): Promise<CleanupResult> {
+export async function executeScheduledCleanup(
+  db: D1Database,
+  photosBucket: R2Bucket
+): Promise<CleanupResult> {
   const orm = drizzle(db, { schema: { ...schema, ...emailSchema, ...webauthnSchema } });
   const now = Date.now();
   // Each cutoff uses the helper matching its column's storage type so the
@@ -232,6 +277,22 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     console.error('[Cleanup] Error deleting email rate-limit rows:', error);
   }
 
+  // 9. Delete temp/ R2 objects older than 24 hours (#129). These are analysis
+  //    uploads that were never saved; nothing else cleans them up. DB rows in
+  //    meal_photos that still reference such keys belong to never-saved meals
+  //    and are intentionally left to the existing record-level logic.
+  let deletedTempPhotos = 0;
+  try {
+    deletedTempPhotos = await cleanupTempPhotos(photosBucket, now);
+    console.log(
+      deletedTempPhotos > 0
+        ? `[Cleanup] Deleted ${deletedTempPhotos} orphaned temp photos from R2`
+        : '[Cleanup] No orphaned temp photos to delete'
+    );
+  } catch (error) {
+    console.error('[Cleanup] Error deleting orphaned temp photos:', error);
+  }
+
   const result = {
     deletedUsers,
     deletedPasswordResetTokens,
@@ -241,6 +302,7 @@ export async function executeScheduledCleanup(db: D1Database): Promise<CleanupRe
     deletedEmailLogs,
     deletedAiUsageRecords,
     deletedRateLimits,
+    deletedTempPhotos,
   };
 
   console.log('[Cleanup] Cleanup tasks completed:', result);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -151,7 +151,7 @@ export default {
     console.log('[Cron] Scheduled event triggered at:', new Date(event.scheduledTime).toISOString());
 
     try {
-      const result = await executeScheduledCleanup(env.DB);
+      const result = await executeScheduledCleanup(env.DB, env.PHOTOS);
       console.log('[Cron] Cleanup completed successfully:', result);
     } catch (error) {
       console.error('[Cron] Cleanup failed:', error);

--- a/tests/unit/cleanup-temp-photos.test.ts
+++ b/tests/unit/cleanup-temp-photos.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanupTempPhotos } from '../../packages/backend/src/cron/cleanup';
+
+const NOW = Date.parse('2026-06-11T02:00:00.000Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+const tempObject = (key: string, ageMs: number) => ({
+  key,
+  uploaded: new Date(NOW - ageMs),
+});
+
+// Mock R2Bucket (list/delete only; cleanupTempPhotos uses nothing else)
+const createMockR2Bucket = () => ({
+  list: vi.fn(),
+  delete: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('cleanupTempPhotos', () => {
+  let mockR2: ReturnType<typeof createMockR2Bucket>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockR2 = createMockR2Bucket();
+  });
+
+  const run = () => cleanupTempPhotos(mockR2 as unknown as R2Bucket, NOW);
+
+  it('should delete temp objects older than 24 hours', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [
+        tempObject('temp/old-1', 25 * HOUR_MS),
+        tempObject('temp/old-2', 48 * HOUR_MS),
+      ],
+      truncated: false,
+    });
+
+    const deleted = await run();
+
+    expect(deleted).toBe(2);
+    expect(mockR2.list).toHaveBeenCalledWith({ prefix: 'temp/', cursor: undefined });
+    expect(mockR2.delete).toHaveBeenCalledTimes(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['temp/old-1', 'temp/old-2']);
+  });
+
+  it('should keep temp objects younger than 24 hours', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [
+        tempObject('temp/fresh', 1 * HOUR_MS),
+        tempObject('temp/almost', 23 * HOUR_MS),
+        tempObject('temp/old', 25 * HOUR_MS),
+      ],
+      truncated: false,
+    });
+
+    const deleted = await run();
+
+    expect(deleted).toBe(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['temp/old']);
+  });
+
+  it('should not call delete when there is nothing to delete', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [tempObject('temp/fresh', 1 * HOUR_MS)],
+      truncated: false,
+    });
+
+    const deleted = await run();
+
+    expect(deleted).toBe(0);
+    expect(mockR2.delete).not.toHaveBeenCalled();
+  });
+
+  it('should paginate through truncated list results via cursor', async () => {
+    mockR2.list
+      .mockResolvedValueOnce({
+        objects: [tempObject('temp/page1-old', 30 * HOUR_MS)],
+        truncated: true,
+        cursor: 'cursor-1',
+      })
+      .mockResolvedValueOnce({
+        objects: [tempObject('temp/page2-old', 30 * HOUR_MS)],
+        truncated: false,
+      });
+
+    const deleted = await run();
+
+    expect(deleted).toBe(2);
+    expect(mockR2.list).toHaveBeenCalledTimes(2);
+    expect(mockR2.list).toHaveBeenNthCalledWith(1, { prefix: 'temp/', cursor: undefined });
+    expect(mockR2.list).toHaveBeenNthCalledWith(2, { prefix: 'temp/', cursor: 'cursor-1' });
+    expect(mockR2.delete).toHaveBeenCalledWith(['temp/page1-old', 'temp/page2-old']);
+  });
+
+  it('should split deletes into batches of 1000 keys', async () => {
+    const objects = Array.from({ length: 1500 }, (_, i) =>
+      tempObject(`temp/old-${i}`, 25 * HOUR_MS)
+    );
+    mockR2.list.mockResolvedValueOnce({ objects, truncated: false });
+
+    const deleted = await run();
+
+    expect(deleted).toBe(1500);
+    expect(mockR2.delete).toHaveBeenCalledTimes(2);
+    expect(mockR2.delete.mock.calls[0][0]).toHaveLength(1000);
+    expect(mockR2.delete.mock.calls[1][0]).toHaveLength(500);
+  });
+});


### PR DESCRIPTION
## 概要

Closes #129

`POST /api/meals/analyze` は写真を `temp/<uuid>` キーでR2にアップロードし、`/save` 時に `photos/{userId}/{mealId}/...` へ移動（＋temp削除）する。しかしユーザーが保存前に離脱するとtempオブジェクトが永久に残り続けていた。既存の日次cronクリーンアップ（毎日 2:00 AM UTC）はDBのみ対象で `temp/` には触れていなかったため、R2側の掃除を追加した。

## 変更内容

- **`packages/backend/src/cron/cleanup.ts`**
  - `cleanupTempPhotos(bucket, now)` を追加：`bucket.list({ prefix: 'temp/' })` でtempオブジェクトを列挙（`truncated`/`cursor` でページネーション対応）し、`uploaded` が24時間より古いものを `bucket.delete(keys[])` で一括削除（R2の上限に合わせ1000件ずつバッチ分割）
  - `executeScheduledCleanup` にタスク9として組み込み（既存タスクと同様にtry/catchで他タスクへ影響させない、`CleanupResult` に `deletedTempPhotos` を追加）
- **`packages/backend/src/index.ts`**
  - scheduledハンドラから `env.PHOTOS` を渡すようシグネチャ変更
- **`tests/unit/cleanup-temp-photos.test.ts`**（新規）
  - 24時間超のみ削除 / 24時間未満は保持 / 削除対象なしならdelete未呼出 / cursorページネーション / 1000件バッチ分割 の5ケース（既存 `photo-storage.service.test.ts` のR2モックスタイルを踏襲）

## 設計メモ

- **24時間の根拠**: 解析レビューフローは数分で完結する想定のため、24時間経過したtempオブジェクトは放棄されたものと判断できる。
- **meal_photos行の扱い**: 未保存のmealに紐づく `meal_photos` 行が `temp/` キーを参照したまま残るケースがあるが、既存cronはstaleなpending mealレコードを掃除していないため、本PRではR2オブジェクトの削除のみ行い、DB行は既存のレコード単位のロジックに委ねる（24時間経過したものは未保存のまま放棄されたmealなので、R2側を先に消しても実害はない）。DB側の掃除が必要なら別issueで対応するのが良さそう。

## テスト

- `pnpm build:shared && pnpm typecheck` ✅（shared/backend/frontend すべて通過）
- `pnpm test:unit` ✅（23 files / 251 passed、新規5テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)