### PR TITLE
chore: sharedのMealRecord型から削除済み列photoKeyを除去 (#131)

### DIFF
--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -625,18 +625,12 @@ mealAnalysis.post(
       where: eq(mealRecords.id, mealId),
     });
 
-    // Get first photo key for response
-    const updatedPhotos = await photoService.getMealPhotos(mealId);
-    const firstPhoto = updatedPhotos[0];
-    const firstPhotoKey = firstPhoto ? firstPhoto.photoKey : null;
-
     return c.json({
       meal: {
         id: updatedMeal!.id,
         mealType: updatedMeal!.mealType,
         content: updatedMeal!.content,
         calories: updatedMeal!.calories,
-        photoKey: firstPhotoKey,
         totalProtein: updatedMeal!.totalProtein,
         totalFat: updatedMeal!.totalFat,
         totalCarbs: updatedMeal!.totalCarbs,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -71,7 +71,6 @@ export interface MealRecord {
   mealType: MealType;
   content: string;
   calories: number | null;
-  photoKey: string | null;
   totalProtein: number | null;
   totalFat: number | null;
   totalCarbs: number | null;


### PR DESCRIPTION
## 概要

migration 0031 で `meal_records.photo_key` 列は削除済みだが、shared の `MealRecord` 型に `photoKey: string | null` が残存していたため除去する。

Closes #131

## 変更内容

### 1. `packages/shared/src/types/index.ts`
- `MealRecord` インターフェースから `photoKey: string | null` を削除
- `firstPhotoKey` / `photos`（meal_photos 由来の拡張フィールド）はそのまま維持

### 2. `packages/backend/src/routes/meal-analysis.ts`（POST `/api/meals/:mealId/save`）
- レスポンスの `meal.photoKey: firstPhotoKey` フィールドと、そのためだけに存在していた `firstPhotoKey` 算出処理（`getMealPhotos` の再取得含む）を削除

**削除を選んだ理由**: フロントエンドでこのエンドポイントを呼ぶのは `mealAnalysisApi.saveMealAnalysis()`（`packages/frontend/src/lib/api.ts`）のみで、戻り値型は `{ meal: unknown }`。唯一の呼び出し元 `pages/Meal.tsx` も戻り値を一切参照していないため、レスポンスから除去するのが安全かつクリーンと判断した。副次的に save 時の不要な写真一覧の再クエリも1回減る。

### 残存する `photoKey` / `photo_key` について
grep で全箇所を確認した結果、残りはすべて `meal_photos` テーブル（`mealPhotos.photoKey`）や AI 解析結果（`analysisResultSchema.photoKey`）など正当な参照であり、削除済み列 `meal_records.photo_key` への参照はゼロになった。migration ファイルは履歴のため未変更。

## 検証

- `pnpm build:shared` ✅
- `pnpm typecheck` ✅（shared / backend / frontend すべて通過 — 型から外しても誰も参照していないことの実証）
- `pnpm test:unit` ✅（246 passed / 1 skipped）

🤖 Generated with [Claude Code](https://claude.com/claude-code)