### PR TITLE
fix: update/deleteのWHERE句にuser_idを追加しSQLレベルで所有権を保証 (#130)

### DIFF
--- a/packages/backend/src/routes/meal-analysis.ts
+++ b/packages/backend/src/routes/meal-analysis.ts
@@ -181,7 +181,7 @@ mealAnalysis.post('/analyze', async (c) => {
     });
 
     // Update photo with analysis results
-    await photoService.updateAnalysisResult(mealPhoto.id, analysisResult.result.totals);
+    await photoService.updateAnalysisResult(mealPhoto.id, mealPhoto.mealId, analysisResult.result.totals);
 
     // Record AI usage
     if (analysisResult.usage) {

--- a/packages/backend/src/routes/meal-chat.ts
+++ b/packages/backend/src/routes/meal-chat.ts
@@ -449,7 +449,7 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
 
       if (analysisResult.success) {
         // Update photo with analysis results
-        await photoService.updateAnalysisResult(photo.id, analysisResult.result.totals);
+        await photoService.updateAnalysisResult(photo.id, photo.mealId, analysisResult.result.totals);
 
         // Automatically create food items from photo analysis
         console.log(`[Chat Photo] Creating ${analysisResult.result.foodItems.length} food items for photo ${photo.id}`);
@@ -531,7 +531,7 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
       } else {
         // Mark analysis as failed
         console.error('[Chat Photo] Analysis failed:', analysisResult.failure);
-        await photoService.markAnalysisFailed(photo.id);
+        await photoService.markAnalysisFailed(photo.id, photo.mealId);
 
         // Update acknowledgment message to indicate failure
         await db.update(mealChatMessages)
@@ -549,7 +549,7 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
     } catch (analysisError) {
       // Log error but don't fail the upload
       console.error('[Chat Photo] Photo analysis failed:', analysisError);
-      await photoService.markAnalysisFailed(photo.id);
+      await photoService.markAnalysisFailed(photo.id, photo.mealId);
 
       // Update acknowledgment message
       await db.update(mealChatMessages)

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -153,7 +153,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
           if (analysisResult.success) {
             // Update photo with analysis results
-            await photoService.updateAnalysisResult(mealPhoto.id, analysisResult.result.totals);
+            await photoService.updateAnalysisResult(mealPhoto.id, mealPhoto.mealId, analysisResult.result.totals);
 
             // Create food items for this photo
             console.log(`[Multi-Photo Upload] Creating ${analysisResult.result.foodItems.length} food items for photo ${mealPhoto.id}`);
@@ -423,7 +423,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
         if (analysisResult.success) {
           // Update photo with analysis results
-          await photoService.updateAnalysisResult(photo.id, analysisResult.result.totals);
+          await photoService.updateAnalysisResult(photo.id, photo.mealId, analysisResult.result.totals);
 
           // Automatically create food items from photo analysis
           console.log(`[Photo Analysis] Creating ${analysisResult.result.foodItems.length} food items for photo ${photo.id}`);
@@ -451,12 +451,12 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
         } else {
           // Mark analysis as failed
           console.error('[Photo Analysis] Analysis failed:', analysisResult.failure);
-          await photoService.markAnalysisFailed(photo.id);
+          await photoService.markAnalysisFailed(photo.id, photo.mealId);
         }
       } catch (analysisError) {
         // Log error but don't fail the upload
         console.error('Photo analysis failed:', analysisError);
-        await photoService.markAnalysisFailed(photo.id);
+        await photoService.markAnalysisFailed(photo.id, photo.mealId);
       }
 
       // Update meal totals and content from all food items
@@ -639,7 +639,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
             .where(eq(schema.mealFoodItems.photoId, photoId));
 
           // Update photo with analysis results
-          await photoService.updateAnalysisResult(photoId, analysisResult.result.totals);
+          await photoService.updateAnalysisResult(photoId, mealId, analysisResult.result.totals);
 
           // Insert new food items
           for (const item of analysisResult.result.foodItems) {

--- a/packages/backend/src/services/exercise.ts
+++ b/packages/backend/src/services/exercise.ts
@@ -301,10 +301,13 @@ export class ExerciseService {
       updateData['recordedAt'] = input.recordedAt;
     }
 
+    // Scope by userId as well (defense in depth, #130): findById above already
+    // guarantees ownership, but the SQL itself should never be able to touch
+    // another user's row.
     await this.db
       .update(schema.exerciseRecords)
       .set(updateData)
-      .where(eq(schema.exerciseRecords.id, id));
+      .where(and(eq(schema.exerciseRecords.id, id), eq(schema.exerciseRecords.userId, userId)));
 
     return this.findById(id, userId);
   }
@@ -312,7 +315,9 @@ export class ExerciseService {
   async delete(id: string, userId: string) {
     await this.findById(id, userId);
 
-    await this.db.delete(schema.exerciseRecords).where(eq(schema.exerciseRecords.id, id));
+    await this.db
+      .delete(schema.exerciseRecords)
+      .where(and(eq(schema.exerciseRecords.id, id), eq(schema.exerciseRecords.userId, userId)));
   }
 
   async getExerciseTypes(userId: string): Promise<{ exerciseType: string; muscleGroup: string | null }[]> {

--- a/packages/backend/src/services/meal-photo.service.ts
+++ b/packages/backend/src/services/meal-photo.service.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { eq, asc } from 'drizzle-orm';
+import { eq, and, asc } from 'drizzle-orm';
 import type { Database } from '../db';
 import { mealPhotos, mealFoodItems, mealRecords, type MealPhoto } from '../db/schema';
 import { MEAL_CONTENT_DELIMITER, type NutritionTotals } from '@lifestyle-app/shared';
@@ -47,8 +47,11 @@ export class MealPhotoService {
     return photo;
   }
 
+  // mealId scopes the UPDATE to the (ownership-verified) meal so the SQL can
+  // never touch another meal's photo, even if photoId were wrong (#130).
   async updateAnalysisResult(
     photoId: string,
+    mealId: string,
     result: {
       calories: number;
       protein: number;
@@ -65,7 +68,7 @@ export class MealPhotoService {
         fat: result.fat,
         carbs: result.carbs,
       })
-      .where(eq(mealPhotos.id, photoId))
+      .where(and(eq(mealPhotos.id, photoId), eq(mealPhotos.mealId, mealId)))
       .returning();
 
     if (!updated) {
@@ -75,13 +78,13 @@ export class MealPhotoService {
     return updated;
   }
 
-  async markAnalysisFailed(photoId: string): Promise<void> {
+  async markAnalysisFailed(photoId: string, mealId: string): Promise<void> {
     await this.db
       .update(mealPhotos)
       .set({
         analysisStatus: 'failed',
       })
-      .where(eq(mealPhotos.id, photoId));
+      .where(and(eq(mealPhotos.id, photoId), eq(mealPhotos.mealId, mealId)));
   }
 
   calculateTotals(photos: MealPhoto[]) {
@@ -156,8 +159,14 @@ export async function deletePhotosWithFoodItems(
     // Remove food items captured from this photo. (The FK is ON DELETE CASCADE
     // since #101, so deleting the photo row would also clear them; doing it
     // explicitly keeps the behavior correct regardless of FK enforcement.)
-    await db.delete(mealFoodItems).where(eq(mealFoodItems.photoId, photo.id));
-    await db.delete(mealPhotos).where(eq(mealPhotos.id, photo.id));
+    // Both DELETEs are additionally scoped to the (ownership-verified) mealId
+    // so the SQL can never touch another meal's rows (#130).
+    await db
+      .delete(mealFoodItems)
+      .where(and(eq(mealFoodItems.photoId, photo.id), eq(mealFoodItems.mealId, mealId)));
+    await db
+      .delete(mealPhotos)
+      .where(and(eq(mealPhotos.id, photo.id), eq(mealPhotos.mealId, mealId)));
     try {
       await photoStorage.deletePhoto(photo.photoKey);
     } catch (error) {

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -195,10 +195,13 @@ export class MealService {
       updateData['recordedAt'] = input.recordedAt;
     }
 
+    // Scope by userId as well (defense in depth, #130): findById above already
+    // guarantees ownership, but the SQL itself should never be able to touch
+    // another user's row.
     await this.db
       .update(schema.mealRecords)
       .set(updateData)
-      .where(eq(schema.mealRecords.id, id));
+      .where(and(eq(schema.mealRecords.id, id), eq(schema.mealRecords.userId, userId)));
 
     return this.findById(id, userId);
   }
@@ -206,7 +209,9 @@ export class MealService {
   async delete(id: string, userId: string) {
     await this.findById(id, userId);
 
-    await this.db.delete(schema.mealRecords).where(eq(schema.mealRecords.id, id));
+    await this.db
+      .delete(schema.mealRecords)
+      .where(and(eq(schema.mealRecords.id, id), eq(schema.mealRecords.userId, userId)));
   }
 
   /**

--- a/packages/backend/src/services/weight.ts
+++ b/packages/backend/src/services/weight.ts
@@ -96,10 +96,13 @@ export class WeightService {
       updateData['recordedAt'] = input.recordedAt;
     }
 
+    // Scope by userId as well (defense in depth, #130): findById above already
+    // guarantees ownership, but the SQL itself should never be able to touch
+    // another user's row.
     await this.db
       .update(schema.weightRecords)
       .set(updateData)
-      .where(eq(schema.weightRecords.id, id));
+      .where(and(eq(schema.weightRecords.id, id), eq(schema.weightRecords.userId, userId)));
 
     return this.findById(id, userId);
   }
@@ -108,7 +111,9 @@ export class WeightService {
     // First check if record exists and belongs to user
     await this.findById(id, userId);
 
-    await this.db.delete(schema.weightRecords).where(eq(schema.weightRecords.id, id));
+    await this.db
+      .delete(schema.weightRecords)
+      .where(and(eq(schema.weightRecords.id, id), eq(schema.weightRecords.userId, userId)));
   }
 
   async getLatest(userId: string) {


### PR DESCRIPTION
## 概要

update/delete系のクエリが `WHERE id = ?` のみで実行されており、所有権チェックがJS側の `findById` 事前チェックに依存していた問題の修正です（defense in depth）。

現状でも `findById(id, userId)` が403/404を投げるため動作上は安全ですが、SQLレベルでは他ユーザーの行に到達し得る形になっていました。本PRでは事前チェックの挙動（404/403の区別・返り値）は一切変えず、WHERE句に所有権条件を追加してSQL自体が他ユーザーの行を触れないことを保証します。

## 変更内容

### user_idでスコープ（テーブルにuser_id列があるもの）

- `packages/backend/src/services/weight.ts` — `update` / `delete`
- `packages/backend/src/services/meal.ts` — `update` / `delete`
- `packages/backend/src/services/exercise.ts` — `update` / `delete`

いずれも `WHERE id = ?` → `WHERE id = ? AND user_id = ?` に変更。

### meal_idでスコープ（meal_photos / meal_food_items はuser_id列を持たないため、所有権検証済みのmealIdで縛る）

- `packages/backend/src/services/meal-photo.service.ts`
  - `updateAnalysisResult(photoId, mealId, result)` — mealId引数を追加し `WHERE id = ? AND meal_id = ?` に
  - `markAnalysisFailed(photoId, mealId)` — 同上
  - `deletePhotosWithFoodItems` — 写真行・food items行のDELETEを引数のmealIdでスコープ
- 呼び出し側の追従: `routes/meals.ts`(8箇所), `routes/meal-analysis.ts`(1箇所), `routes/meal-chat.ts`(3箇所) — いずれも所有権検証済みのmeal由来のmealIdを渡すだけで、ロジック変更なし

### 監査して変更不要と判断したもの

- `services/user.ts` — 全update/deleteが元からuserIdでスコープ済み
- `recalculateMealTotals` — meal_recordsのPK(=mealId)指定のみで、呼び出し元が所有権検証済み。追加でスコープできる列の引数が存在しないため対象外
- `webauthn` / `auth` / `email` 系・`cron/cleanup.ts` — レコード記録系のパターン（URLのid+userIdペア）に該当しない

## テスト

- `pnpm typecheck` ✅（shared / backend / frontend すべて通過）
- `pnpm test:unit` ✅（246 passed / 1 skipped）

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)