### PR TITLE
test: プレースホルダーテストをit.todoに変換しE2EのバックエンドURLハードコードを解消

### DIFF
--- a/tests/e2e/email-change.spec.ts
+++ b/tests/e2e/email-change.spec.ts
@@ -9,13 +9,14 @@
  * 5. Email is updated, user is logged out
  * 6. User logs in with new email
  *
- * TODO: Implement with Playwright
+ * TODO: Implement with Playwright (Playwright has no test.todo, so test.fixme
+ * is used to mark these unimplemented tests; they are reported as skipped)
  */
 
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test.describe('Email Change Flow', () => {
-  test('should complete full email change flow', async ({ page }) => {
+  test.fixme('should complete full email change flow', async () => {
     // TODO: Implement full email change flow
     // 1. Login as test user
     // 2. Navigate to settings
@@ -26,10 +27,9 @@ test.describe('Email Change Flow', () => {
     // 7. Verify success message
     // 8. Verify logout
     // 9. Login with new email
-    expect(true).toBe(true);
   });
 
-  test('should allow cancellation of email change', async ({ page }) => {
+  test.fixme('should allow cancellation of email change', async () => {
     // TODO: Implement cancellation flow
     // 1. Login as test user
     // 2. Request email change
@@ -37,22 +37,19 @@ test.describe('Email Change Flow', () => {
     // 4. Navigate to cancel URL
     // 5. Verify cancellation message
     // 6. Verify email unchanged
-    expect(true).toBe(true);
   });
 
-  test('should reject expired confirmation link', async ({ page }) => {
+  test.fixme('should reject expired confirmation link', async () => {
     // TODO: Implement expired token test
     // 1. Create expired email change request
     // 2. Navigate to confirmation URL
     // 3. Verify error message
-    expect(true).toBe(true);
   });
 
-  test('should prevent duplicate confirmation', async ({ page }) => {
+  test.fixme('should prevent duplicate confirmation', async () => {
     // TODO: Implement duplicate confirmation test
     // 1. Complete email change once
     // 2. Try to use same token again
     // 3. Verify error message
-    expect(true).toBe(true);
   });
 });

--- a/tests/e2e/request-id-tracing.spec.ts
+++ b/tests/e2e/request-id-tracing.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { loginAsTestUser } from '../helpers/e2e';
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8787';
+const BACKEND_URL = process.env['BACKEND_URL'] ?? 'http://localhost:8787';
 
 /**
  * Request ID Tracing Tests

--- a/tests/e2e/request-id-tracing.spec.ts
+++ b/tests/e2e/request-id-tracing.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { loginAsTestUser } from '../helpers/e2e';
 
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8787';
+
 /**
  * Request ID Tracing Tests
  *
@@ -14,7 +16,7 @@ test.describe('Request ID Tracing', () => {
 
   test('should include X-Request-ID in API responses', async ({ request }) => {
     // Make a direct API call
-    const response = await request.get('http://localhost:8787/api/health');
+    const response = await request.get(`${BACKEND_URL}/api/health`);
 
     expect(response.ok()).toBe(true);
 
@@ -32,7 +34,7 @@ test.describe('Request ID Tracing', () => {
     const testRequestId = crypto.randomUUID();
 
     // Make API call with custom Request ID
-    const response = await request.get('http://localhost:8787/api/health', {
+    const response = await request.get(`${BACKEND_URL}/api/health`, {
       headers: {
         'X-Request-ID': testRequestId,
       },
@@ -51,7 +53,7 @@ test.describe('Request ID Tracing', () => {
     const testRequestId = crypto.randomUUID();
 
     // Make an unauthorized API call to trigger an error
-    const response = await request.get('http://localhost:8787/api/dashboard', {
+    const response = await request.get(`${BACKEND_URL}/api/dashboard`, {
       headers: {
         'X-Request-ID': testRequestId,
       },

--- a/tests/integration/dashboard.test.ts
+++ b/tests/integration/dashboard.test.ts
@@ -1,127 +1,39 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { Hono } from 'hono';
+import { describe, it } from 'vitest';
 
 describe('Dashboard API Integration Tests', () => {
-  let app: Hono;
-  let authToken: string;
-  const testUser = {
-    email: 'dashboard-test@example.com',
-    password: 'password123',
-    name: 'Dashboard Tester',
-  };
-
-  beforeAll(async () => {
-    // Setup would initialize app and create test user
-    // For now, we document the expected behavior
-  });
-
-  afterAll(async () => {
-    // Cleanup test data
-  });
-
   describe('GET /api/dashboard/summary', () => {
-    it('should return 401 without authentication', async () => {
-      // const res = await app.request('/api/dashboard/summary');
-      // expect(res.status).toBe(401);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return 401 without authentication');
 
-    it('should return summary data for authenticated user', async () => {
-      // const res = await app.request('/api/dashboard/summary', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(data).toHaveProperty('weight');
-      // expect(data).toHaveProperty('meals');
-      // expect(data).toHaveProperty('exercises');
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return summary data for authenticated user');
 
-    it('should accept period query parameter', async () => {
-      // const res = await app.request('/api/dashboard/summary?period=week', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should accept period query parameter');
 
-    it('should accept custom date range', async () => {
-      // const res = await app.request(
-      //   '/api/dashboard/summary?startDate=2025-01-01&endDate=2025-01-31',
-      //   { headers: { Authorization: `Bearer ${authToken}` } }
-      // );
-      // expect(res.status).toBe(200);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should accept custom date range');
   });
 
   describe('GET /api/dashboard/trends', () => {
-    it('should return weekly trend data', async () => {
-      // const res = await app.request('/api/dashboard/trends?weeks=4', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(Array.isArray(data)).toBe(true);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return weekly trend data');
   });
 
   describe('GET /api/dashboard/goals', () => {
-    it('should return goal progress', async () => {
-      // const res = await app.request('/api/dashboard/goals', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(data).toHaveProperty('weight');
-      // expect(data).toHaveProperty('exercise');
-      // expect(data).toHaveProperty('calories');
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return goal progress');
   });
 
   describe('Data aggregation', () => {
-    beforeEach(async () => {
-      // Create test data: weights, meals, exercises
-    });
+    it.todo('should aggregate weight data correctly');
 
-    it('should aggregate weight data correctly', async () => {
-      // Create weight records and verify summary calculation
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should aggregate meal data correctly');
 
-    it('should aggregate meal data correctly', async () => {
-      // Create meal records and verify calorie summary
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should aggregate exercise data correctly');
 
-    it('should aggregate exercise data correctly', async () => {
-      // Create exercise records and verify time summary
-      expect(true).toBe(true); // Placeholder
-    });
-
-    it('should handle mixed data periods correctly', async () => {
-      // Test data from different time periods
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should handle mixed data periods correctly');
   });
 
   describe('Edge cases', () => {
-    it('should handle user with no data', async () => {
-      // New user should get empty/zero values
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should handle user with no data');
 
-    it('should handle partial data', async () => {
-      // User with only weight data, no meals or exercise
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should handle partial data');
 
-    it('should handle invalid date ranges gracefully', async () => {
-      // Start date after end date
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should handle invalid date ranges gracefully');
   });
 });

--- a/tests/integration/exercises.test.ts
+++ b/tests/integration/exercises.test.ts
@@ -1,103 +1,60 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 describe('Exercise API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('POST /api/exercises', () => {
-    it('should create an exercise record when authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should create an exercise record when authenticated');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
 
-    it('should return 400 for empty exerciseType', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for empty exerciseType');
 
-    it('should return 400 for invalid sets', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for invalid sets');
 
-    it('should return 400 for invalid reps', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for invalid reps');
 
-    it('should accept null weight for bodyweight exercises', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should accept null weight for bodyweight exercises');
   });
 
   describe('GET /api/exercises', () => {
-    it('should return all exercise records for authenticated user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return all exercise records for authenticated user');
 
-    it('should support date range query parameters', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range query parameters');
 
-    it('should support exerciseType filter query parameter', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should support exerciseType filter query parameter');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('GET /api/exercises/last/:exerciseType', () => {
-    it('should return the last record for a specific exercise type', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return the last record for a specific exercise type');
 
-    it('should return null if no records exist for the type', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return null if no records exist for the type');
   });
 
   describe('GET /api/exercises/summary', () => {
-    it('should return weekly exercise summary', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return weekly exercise summary');
 
-    it('should group by exercise type', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should group by exercise type');
   });
 
   describe('GET /api/exercises/:id', () => {
-    it('should return specific exercise record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return specific exercise record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   describe('PATCH /api/exercises/:id', () => {
-    it('should update exercise record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should update exercise record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
   });
 
   describe('DELETE /api/exercises/:id', () => {
-    it('should delete exercise record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should delete exercise record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
   });
 });

--- a/tests/integration/meal-analysis.test.ts
+++ b/tests/integration/meal-analysis.test.ts
@@ -26,183 +26,81 @@ describe('Meal Analysis API Integration Tests', () => {
   // and proper authentication setup
 
   describe('POST /api/meals/analyze', () => {
-    it('should analyze a meal photo and return food items', async () => {
-      // Test requires:
-      // - Valid session cookie
-      // - Image file upload (multipart/form-data)
-      // - AI API key configured
-      //
-      // Expected response:
-      // {
-      //   mealId: string,
-      //   photoKey: string,
-      //   foodItems: [{ id, name, portion, calories, protein, fat, carbs }],
-      //   totals: { calories, protein, fat, carbs }
-      // }
-      expect(true).toBe(true);
-    });
+    it.todo('should analyze a meal photo and return food items');
 
-    it('should return 400 for missing photo', async () => {
-      // POST /api/meals/analyze without photo
-      // Expected: 400 { error: 'invalid_request', message: '写真が必要です' }
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for missing photo');
 
-    it('should return 400 for non-image file', async () => {
-      // POST /api/meals/analyze with text file
-      // Expected: 400 { error: 'invalid_request', message: '画像ファイルを選択してください' }
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for non-image file');
 
-    it('should return 400 for file too large (>10MB)', async () => {
-      // Expected: 400 { error: 'invalid_request', message: 'ファイルサイズは10MB以下にしてください' }
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for file too large (>10MB)');
 
-    it('should return 422 for non-food image', async () => {
-      // When AI detects non-food image
-      // Expected: 422 { error: 'not_food', message: '...' }
-      expect(true).toBe(true);
-    });
+    it.todo('should return 422 for non-food image');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('POST /api/meals/create-empty', () => {
-    it('should create an empty meal for manual input', async () => {
-      // Expected: 200 { mealId: string }
-      // Meal should have:
-      // - photoKey: null
-      // - analysisSource: 'manual'
-      // - empty foodItems
-      expect(true).toBe(true);
-    });
+    it.todo('should create an empty meal for manual input');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('GET /api/meals/:mealId/food-items', () => {
-    it('should return food items for a meal', async () => {
-      // Expected: 200 { foodItems: [...] }
-      expect(true).toBe(true);
-    });
+    it.todo('should return food items for a meal');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 404 for meal belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for meal belonging to different user');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('POST /api/meals/:mealId/food-items', () => {
-    it('should add a food item to meal', async () => {
-      // Body: { name: 'サラダ', portion: 'medium', calories: 30, protein: 2, fat: 0.5, carbs: 5 }
-      // Expected: 201 { foodItem: {...}, updatedTotals: {...} }
-      expect(true).toBe(true);
-    });
+    it.todo('should add a food item to meal');
 
-    it('should validate food item data', async () => {
-      // Body with invalid data (negative calories, invalid portion)
-      // Expected: 400
-      expect(true).toBe(true);
-    });
+    it.todo('should validate food item data');
 
-    it('should recalculate meal totals after adding', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should recalculate meal totals after adding');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('PATCH /api/meals/:mealId/food-items/:foodItemId', () => {
-    it('should update a food item', async () => {
-      // Body: { calories: 100, portion: 'large' }
-      // Expected: 200 { foodItem: {...}, updatedTotals: {...} }
-      expect(true).toBe(true);
-    });
+    it.todo('should update a food item');
 
-    it('should allow partial updates', async () => {
-      // Body: { name: '白米' }
-      // Expected: 200 with only name changed
-      expect(true).toBe(true);
-    });
+    it.todo('should allow partial updates');
 
-    it('should recalculate meal totals after update', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should recalculate meal totals after update');
 
-    it('should return 404 for non-existent food item', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent food item');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('DELETE /api/meals/:mealId/food-items/:foodItemId', () => {
-    it('should delete a food item', async () => {
-      // Expected: 200 { message: '削除しました', updatedTotals: {...} }
-      expect(true).toBe(true);
-    });
+    it.todo('should delete a food item');
 
-    it('should recalculate meal totals after delete', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should recalculate meal totals after delete');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('POST /api/meals/:mealId/save', () => {
-    it('should save meal with mealType and move photo to permanent storage', async () => {
-      // Body: { mealType: 'lunch', recordedAt: '...' }
-      // Expected: 200 { meal: {...} } with permanent photoKey
-      expect(true).toBe(true);
-    });
+    it.todo('should save meal with mealType and move photo to permanent storage');
 
-    it('should validate mealType enum', async () => {
-      // Body: { mealType: 'invalid' }
-      // Expected: 400
-      expect(true).toBe(true);
-    });
+    it.todo('should validate mealType enum');
 
-    it('should use current time if recordedAt not provided', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should use current time if recordedAt not provided');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   // #97: photo serving now requires authentication AND owner verification.

--- a/tests/integration/meal-chat-photos.test.ts
+++ b/tests/integration/meal-chat-photos.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: Integration tests require full app setup with D1 and R2 bindings
 // This is a simplified version for demonstration
@@ -10,66 +10,16 @@ describe('Meal Chat Photos API Integration Tests', () => {
   // TODO: Implement full E2E tests
 
   describe('POST /api/meals/:mealId/chat/add-photo', () => {
-    it('should add photo to meal via chat', async () => {
-      // Test scenario:
-      // 1. Upload photo through chat interface
-      // 2. Verify photo is added to meal_photos table
-      // 3. Verify temporary chat message is created
-      // 4. Verify AI analysis is triggered in background
-      // 5. Verify chat message is updated with analysis results
+    it.todo('should add photo to meal via chat');
 
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
+    it.todo('should reject when meal has 10 photos');
 
-    it('should reject when meal has 10 photos', async () => {
-      // Test scenario:
-      // 1. Create meal with 10 photos
-      // 2. Attempt to upload 11th photo via chat
-      // 3. Verify request is rejected with 400 status
-      // 4. Verify error message indicates photo limit reached
+    it.todo('should reject unauthorized requests');
 
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
+    it.todo('should create acknowledgment chat message immediately');
 
-    it('should reject unauthorized requests', async () => {
-      // Test scenario:
-      // 1. Make request without auth token
-      // 2. Verify request is rejected with 401 status
+    it.todo('should handle photo upload failures gracefully');
 
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
-
-    it('should create acknowledgment chat message immediately', async () => {
-      // Test scenario:
-      // 1. Upload photo through chat
-      // 2. Verify assistant message is created with "Analyzing photo..." text
-      // 3. Verify message is returned immediately (not waiting for analysis)
-
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
-
-    it('should handle photo upload failures gracefully', async () => {
-      // Test scenario:
-      // 1. Simulate R2 upload failure
-      // 2. Verify error is returned to client
-      // 3. Verify no partial data is created (no chat message, no photo record)
-
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
-
-    it('should allow typing while photo is uploading', async () => {
-      // Test scenario:
-      // 1. Start photo upload (non-blocking)
-      // 2. Verify endpoint returns immediately with upload ID
-      // 3. Verify user can send text messages while upload is in progress
-
-      // This test requires full setup - placeholder for now
-      expect(true).toBe(true);
-    });
+    it.todo('should allow typing while photo is uploading');
   });
 });

--- a/tests/integration/meal-chat.test.ts
+++ b/tests/integration/meal-chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 /**
  * Integration tests for Meal Chat API
@@ -12,178 +12,72 @@ import { describe, it, expect } from 'vitest';
  */
 
 describe('Meal Chat API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('GET /api/meals/:mealId/chat', () => {
-    it('should return empty chat history for new meal', async () => {
-      // Expected: 200 { messages: [] }
-      expect(true).toBe(true);
-    });
+    it.todo('should return empty chat history for new meal');
 
-    it('should return chat history in chronological order', async () => {
-      // Expected: 200 { messages: [{ id, role, content, createdAt }, ...] }
-      // Messages ordered by createdAt ascending
-      expect(true).toBe(true);
-    });
+    it.todo('should return chat history in chronological order');
 
-    it('should include appliedChanges for assistant messages with changes', async () => {
-      // Expected: messages[].appliedChanges can be array of FoodItemChange
-      expect(true).toBe(true);
-    });
+    it.todo('should include appliedChanges for assistant messages with changes');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 404 for meal belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for meal belonging to different user');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('POST /api/meals/:mealId/chat', () => {
-    it('should stream chat response as SSE', async () => {
-      // Body: { message: 'カロリーを減らしたい' }
-      // Expected: text/event-stream with:
-      // - data: {"text": "..."} events
-      // - data: {"done": true, "messageId": "...", "changes": [...]} final event
-      expect(true).toBe(true);
-    });
+    it.todo('should stream chat response as SSE');
 
-    it('should save user message to chat history', async () => {
-      // After POST, GET /chat should include user message
-      expect(true).toBe(true);
-    });
+    it.todo('should save user message to chat history');
 
-    it('should save assistant response to chat history', async () => {
-      // After streaming completes, GET /chat should include assistant message
-      expect(true).toBe(true);
-    });
+    it.todo('should save assistant response to chat history');
 
-    it('should include current meal context in AI request', async () => {
-      // AI should be able to reference current food items
-      expect(true).toBe(true);
-    });
+    it.todo('should include current meal context in AI request');
 
-    it('should parse change proposals from response', async () => {
-      // Ask for changes like "ご飯を追加して"
-      // Expected: changes array in completion event
-      expect(true).toBe(true);
-    });
+    it.todo('should parse change proposals from response');
 
-    it('should handle multiple change proposals', async () => {
-      // Ask for complex changes like "ラーメンを減らしてサラダを追加"
-      // Expected: changes array with multiple items
-      expect(true).toBe(true);
-    });
+    it.todo('should handle multiple change proposals');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
 
-    it('should handle AI service errors gracefully', async () => {
-      // When AI service fails
-      // Expected: error event in stream
-      expect(true).toBe(true);
-    });
+    it.todo('should handle AI service errors gracefully');
   });
 
   describe('POST /api/meals/:mealId/chat/apply', () => {
-    it('should apply add action', async () => {
-      // Body: { changes: [{ action: 'add', foodItem: {...} }] }
-      // Expected: 200 { foodItems: [...], updatedTotals: {...} }
-      expect(true).toBe(true);
-    });
+    it.todo('should apply add action');
 
-    it('should apply remove action', async () => {
-      // Body: { changes: [{ action: 'remove', foodItemId: '...' }] }
-      // Expected: 200 with food item removed from list
-      expect(true).toBe(true);
-    });
+    it.todo('should apply remove action');
 
-    it('should apply update action', async () => {
-      // Body: { changes: [{ action: 'update', foodItemId: '...', foodItem: {...} }] }
-      // Expected: 200 with food item updated
-      expect(true).toBe(true);
-    });
+    it.todo('should apply update action');
 
-    it('should apply multiple changes in order', async () => {
-      // Body: { changes: [add, remove, update] }
-      // Expected: all changes applied
-      expect(true).toBe(true);
-    });
+    it.todo('should apply multiple changes in order');
 
-    it('should recalculate totals after applying changes', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should recalculate totals after applying changes');
 
-    it('should update meal content with food item names', async () => {
-      // After apply, meal.content should be comma-separated food names
-      expect(true).toBe(true);
-    });
+    it.todo('should update meal content with food item names');
 
-    it('should validate changes schema', async () => {
-      // Body: { changes: [{ action: 'invalid' }] }
-      // Expected: 400
-      expect(true).toBe(true);
-    });
+    it.todo('should validate changes schema');
 
-    it('should ignore remove for non-existent food item', async () => {
-      // Body: { changes: [{ action: 'remove', foodItemId: 'non-existent' }] }
-      // Expected: 200 (no error, just skip)
-      expect(true).toBe(true);
-    });
+    it.todo('should ignore remove for non-existent food item');
 
-    it('should return 404 for non-existent meal', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent meal');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
 
-    it('should apply set_meal_type action', async () => {
-      // Body: { changes: [{ action: 'set_meal_type', mealType: 'breakfast' }] }
-      // Expected: 200 { foodItems: [...], updatedTotals: {...}, mealType: 'breakfast' }
-      expect(true).toBe(true);
-    });
+    it.todo('should apply set_meal_type action');
 
-    it('should apply combined set_datetime and set_meal_type actions', async () => {
-      // Body: { changes: [
-      //   { action: 'set_datetime', recordedAt: '2026-01-02T08:00:00Z' },
-      //   { action: 'set_meal_type', mealType: 'breakfast' }
-      // ] }
-      // Expected: 200 with both recordedAt and mealType updated
-      expect(true).toBe(true);
-    });
+    it.todo('should apply combined set_datetime and set_meal_type actions');
 
-    it('should validate set_meal_type with valid mealType values only', async () => {
-      // Body: { changes: [{ action: 'set_meal_type', mealType: 'invalid' }] }
-      // Expected: 400 validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate set_meal_type with valid mealType values only');
   });
 
   describe('Chat flow integration', () => {
-    it('should complete full chat flow: send message -> get suggestions -> apply', async () => {
-      // 1. POST /api/meals/{mealId}/chat with "カロリーを減らしたい"
-      // 2. Receive streaming response with change suggestions
-      // 3. POST /api/meals/{mealId}/chat/apply with received changes
-      // 4. GET /api/meals/{mealId}/food-items to verify changes
-      // 5. GET /api/meals/{mealId}/chat to verify history
-      expect(true).toBe(true);
-    });
+    it.todo('should complete full chat flow: send message -> get suggestions -> apply');
 
-    it('should maintain conversation context across messages', async () => {
-      // Send multiple messages and verify AI remembers context
-      expect(true).toBe(true);
-    });
+    it.todo('should maintain conversation context across messages');
   });
 });

--- a/tests/integration/meals.test.ts
+++ b/tests/integration/meals.test.ts
@@ -44,27 +44,15 @@ describe('Meal API Integration Tests', () => {
       expect(data.meal.calories).toBe(350);
     });
 
-    it('should create meal record without calories', async () => {
-      // Expected: calories is optional
-      expect(true).toBe(true);
-    });
+    it.todo('should create meal record without calories');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
 
-    it('should return 400 for invalid mealType', async () => {
-      // Expected: 400 for mealType not in enum
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for invalid mealType');
 
-    it('should return 400 for empty content', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for empty content');
 
-    it('should return 400 for negative calories', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for negative calories');
 
     it.skip('should create meal with multiple photos (multipart/form-data)', async () => {
       // T053: Test multi-photo meal creation
@@ -193,75 +181,41 @@ describe('Meal API Integration Tests', () => {
   });
 
   describe('GET /api/meals', () => {
-    it('should return all meal records for authenticated user', async () => {
-      // Expected:
-      // - GET /api/meals with valid session
-      // - Response: 200 with { meals: [...] }
-      expect(true).toBe(true);
-    });
+    it.todo('should return all meal records for authenticated user');
 
-    it('should support date range query parameters', async () => {
-      // GET /api/meals?startDate=2024-01-01&endDate=2024-01-31
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range query parameters');
 
-    it('should support mealType filter', async () => {
-      // GET /api/meals?mealType=breakfast
-      expect(true).toBe(true);
-    });
+    it.todo('should support mealType filter');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('GET /api/meals/summary', () => {
-    it('should return calorie summary for date range', async () => {
-      // Expected: { totalCalories, averageCalories, count }
-      expect(true).toBe(true);
-    });
+    it.todo('should return calorie summary for date range');
   });
 
   describe('GET /api/meals/:id', () => {
-    it('should return specific meal record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return specific meal record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   describe('PATCH /api/meals/:id', () => {
-    it('should update meal record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should update meal record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   describe('DELETE /api/meals/:id', () => {
-    it('should delete meal record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should delete meal record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   // #103: the date-range filter is pushed into SQL (gte(start) + lt(nextDay(end))

--- a/tests/integration/routes/auth/password-reset.test.ts
+++ b/tests/integration/routes/auth/password-reset.test.ts
@@ -6,138 +6,46 @@
  * - POST /api/auth/password-reset/confirm
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: Integration tests require running backend server
 // These are placeholder tests that define the expected API behavior
 
 describe('Password Reset API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('POST /api/auth/password-reset/request', () => {
-    it('should validate email format', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request
-      // - Body: { email: 'invalid-email' }
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate email format');
 
-    it('should accept valid email format', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request
-      // - Body: { email: 'user@example.com' }
-      // - Response: 200 even if user doesn't exist (security: prevent email enumeration)
-      expect(true).toBe(true);
-    });
+    it.todo('should accept valid email format');
 
-    it('should require email field', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request
-      // - Body: {}
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should require email field');
 
-    it('should enforce rate limiting (10 requests per hour per IP)', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request 11 times from same IP
-      // - First 10: 200 response
-      // - 11th: 429 Too Many Requests
-      expect(true).toBe(true);
-    });
+    it.todo('should enforce rate limiting (10 requests per hour per IP)');
 
-    it('should send email with reset link if user exists', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request with existing user email
-      // - Email sent with token in URL: {FRONTEND_URL}/reset-password?token={token}
-      // - Token expires in 1 hour
-      expect(true).toBe(true);
-    });
+    it.todo('should send email with reset link if user exists');
   });
 
   describe('POST /api/auth/password-reset/confirm', () => {
-    it('should validate token format', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm
-      // - Body: { token: 'short', newPassword: 'newpassword123' }
-      // - Response: 400 with validation error (token must be 32 characters)
-      expect(true).toBe(true);
-    });
+    it.todo('should validate token format');
 
-    it('should validate password length', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm
-      // - Body: { token: '32-char-token', newPassword: 'short' }
-      // - Response: 400 with validation error (password must be at least 8 characters)
-      expect(true).toBe(true);
-    });
+    it.todo('should validate password length');
 
-    it('should require both token and newPassword', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm
-      // - Body: { token: '32-char-token' }
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should require both token and newPassword');
 
-    it('should reject expired token', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm with token older than 1 hour
-      // - Response: 400 with "トークンが期限切れです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject expired token');
 
-    it('should reject already used token', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm with same valid token twice
-      // - First request: 200 success
-      // - Second request: 400 with "トークンは既に使用済みです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject already used token');
 
-    it('should accept valid token and password, hash password, and allow login with new password', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm with valid token and new password
-      // - Response: 200 with success message
-      // - Password updated in database (hashed with bcrypt)
-      // - User can login with new password
-      expect(true).toBe(true);
-    });
+    it.todo('should accept valid token and password, hash password, and allow login with new password');
 
-    it('should mark token as used after successful password reset', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/confirm with valid token
-      // - Response: 200 success
-      // - Token's used_at field set to current timestamp
-      // - Token cannot be reused
-      expect(true).toBe(true);
-    });
+    it.todo('should mark token as used after successful password reset');
   });
 
   describe('Security tests', () => {
-    it('should always return success even if email does not exist (prevent email enumeration)', async () => {
-      // Expected behavior:
-      // - POST /api/auth/password-reset/request with non-existent email
-      // - Response: 200 with same success message as existing user
-      // - No indication whether user exists
-      expect(true).toBe(true);
-    });
+    it.todo('should always return success even if email does not exist (prevent email enumeration)');
 
-    it('should use secure token generation (32 characters, base64url, cryptographically random)', async () => {
-      // Expected behavior:
-      // - Tokens generated using Web Crypto API
-      // - 256 bits of entropy (32 bytes)
-      // - Base64url encoded (no collisions in 1000 samples)
-      expect(true).toBe(true);
-    });
+    it.todo('should use secure token generation (32 characters, base64url, cryptographically random)');
 
-    it('should implement exponential backoff for email sending (1s, 2s, 4s with max 3 retries)', async () => {
-      // Expected behavior:
-      // - Email service retries failed sends with delays: 1s → 2s → 4s
-      // - Max 3 retry attempts
-      // - Callback invoked on each retry with attempt number
-      expect(true).toBe(true);
-    });
+    it.todo('should implement exponential backoff for email sending (1s, 2s, 4s with max 3 retries)');
   });
 });

--- a/tests/integration/routes/auth/register.test.ts
+++ b/tests/integration/routes/auth/register.test.ts
@@ -6,106 +6,38 @@
  * - Email verification email sending
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: Integration tests require running backend server
 // These are placeholder tests that define the expected API behavior
 
 describe('User Registration API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('POST /api/auth/register', () => {
-    it('should create user account with valid email and password', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register
-      // - Body: { email: 'newuser@example.com', password: 'password123' }
-      // - Response: 201 with { user: { id, email, email_verified: false, ... } }
-      expect(true).toBe(true);
-    });
+    it.todo('should create user account with valid email and password');
 
-    it('should send verification email after successful registration', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register
-      // - User created with email_verified = false
-      // - Verification email sent with token in URL: {FRONTEND_URL}/verify-email?token={token}
-      // - Token expires in 24 hours
-      expect(true).toBe(true);
-    });
+    it.todo('should send verification email after successful registration');
 
-    it('should validate email format', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register with invalid email
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate email format');
 
-    it('should validate password length (minimum 8 characters)', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register with short password
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate password length (minimum 8 characters)');
 
-    it('should reject duplicate email addresses', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register with existing email
-      // - Response: 400 with "このメールアドレスは既に登録されています" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject duplicate email addresses');
 
-    it('should require both email and password fields', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register with missing fields
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should require both email and password fields');
 
-    it('should hash password before storing in database', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register
-      // - Password stored as bcrypt hash (not plaintext)
-      // - User can login with original password
-      expect(true).toBe(true);
-    });
+    it.todo('should hash password before storing in database');
 
-    it('should set email_verified to false for new users', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register
-      // - User created with email_verified = false
-      // - User must verify email before full access
-      expect(true).toBe(true);
-    });
+    it.todo('should set email_verified to false for new users');
 
-    it('should not set session cookie if email not verified (optional: depends on UX decision)', async () => {
-      // Expected behavior:
-      // - POST /api/auth/register
-      // - No session cookie set (or temporary session with limited access)
-      // - User must verify email first
-      expect(true).toBe(true);
-    });
+    it.todo('should not set session cookie if email not verified (optional: depends on UX decision)');
   });
 
   describe('Email verification flow', () => {
-    it('should generate unique verification token for each user', async () => {
-      // Expected behavior:
-      // - Multiple registrations generate different tokens
-      // - Tokens are 32 characters, base64url, cryptographically random
-      expect(true).toBe(true);
-    });
+    it.todo('should generate unique verification token for each user');
 
-    it('should store verification token with 24-hour expiration', async () => {
-      // Expected behavior:
-      // - Token inserted into email_verification_tokens table
-      // - expires_at = now + 24 hours
-      // - Token can be used within 24 hours
-      expect(true).toBe(true);
-    });
+    it.todo('should store verification token with 24-hour expiration');
 
-    it('should include user name in verification email if provided', async () => {
-      // Expected behavior:
-      // - If user provides name during registration
-      // - Email greeting includes name: "こんにちは、{name}さん"
-      expect(true).toBe(true);
-    });
+    it.todo('should include user name in verification email if provided');
   });
 });

--- a/tests/integration/routes/email/change.test.ts
+++ b/tests/integration/routes/email/change.test.ts
@@ -9,72 +9,36 @@
  * TODO: Implement actual tests with database setup
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 describe('Email Change API', () => {
   describe('POST /api/email/change/request', () => {
-    it('should request email change successfully', async () => {
-      // TODO: Create test user, authenticate, request email change
-      expect(true).toBe(true);
-    });
+    it.todo('should request email change successfully');
 
-    it('should reject same email as current', async () => {
-      // TODO: Verify error when new email === current email
-      expect(true).toBe(true);
-    });
+    it.todo('should reject same email as current');
 
-    it('should reject email already in use', async () => {
-      // TODO: Verify error when new email is already used by another user
-      expect(true).toBe(true);
-    });
+    it.todo('should reject email already in use');
 
-    it('should require authentication', async () => {
-      // TODO: Verify 401 when no session cookie
-      expect(true).toBe(true);
-    });
+    it.todo('should require authentication');
 
-    it('should validate email format', async () => {
-      // TODO: Verify 400 when invalid email format
-      expect(true).toBe(true);
-    });
+    it.todo('should validate email format');
   });
 
   describe('POST /api/email/change/confirm', () => {
-    it('should confirm email change with valid token', async () => {
-      // TODO: Request change, get token, confirm, verify email updated
-      expect(true).toBe(true);
-    });
+    it.todo('should confirm email change with valid token');
 
-    it('should reject invalid token', async () => {
-      // TODO: Verify error with non-existent token
-      expect(true).toBe(true);
-    });
+    it.todo('should reject invalid token');
 
-    it('should reject expired token', async () => {
-      // TODO: Create expired token, verify error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject expired token');
 
-    it('should reject already confirmed token', async () => {
-      // TODO: Confirm twice, verify second fails
-      expect(true).toBe(true);
-    });
+    it.todo('should reject already confirmed token');
   });
 
   describe('POST /api/email/change/cancel', () => {
-    it('should cancel email change with valid token', async () => {
-      // TODO: Request change, cancel, verify email unchanged
-      expect(true).toBe(true);
-    });
+    it.todo('should cancel email change with valid token');
 
-    it('should reject cancelling confirmed request', async () => {
-      // TODO: Confirm first, then try to cancel
-      expect(true).toBe(true);
-    });
+    it.todo('should reject cancelling confirmed request');
 
-    it('should reject invalid token', async () => {
-      // TODO: Verify error with non-existent token
-      expect(true).toBe(true);
-    });
+    it.todo('should reject invalid token');
   });
 });

--- a/tests/integration/routes/email/verify.test.ts
+++ b/tests/integration/routes/email/verify.test.ts
@@ -6,148 +6,50 @@
  * - POST /api/email/verify/resend - Resend verification email
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: Integration tests require running backend server
 // These are placeholder tests that define the expected API behavior
 
 describe('Email Verification API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('POST /api/email/verify', () => {
-    it('should verify email with valid token', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify
-      // - Body: { token: '32-char-token' }
-      // - Response: 200 with { message: 'メールアドレスを確認しました' }
-      // - User's email_verified set to true
-      // - Token marked as used
-      expect(true).toBe(true);
-    });
+    it.todo('should verify email with valid token');
 
-    it('should validate token format (32 characters)', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with short token
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate token format (32 characters)');
 
-    it('should require token field', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify without token
-      // - Response: 400 with validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should require token field');
 
-    it('should reject expired token (>24 hours)', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with token older than 24 hours
-      // - Response: 400 with "トークンが期限切れです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject expired token (>24 hours)');
 
-    it('should reject already used token', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with same token twice
-      // - First request: 200 success
-      // - Second request: 400 with "トークンは既に使用済みです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject already used token');
 
-    it('should reject invalid token', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with non-existent token
-      // - Response: 400 with "無効なトークンです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject invalid token');
 
-    it('should set email_verified to true after successful verification', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with valid token
-      // - User's email_verified column updated to true
-      // - User can now login without restrictions
-      expect(true).toBe(true);
-    });
+    it.todo('should set email_verified to true after successful verification');
 
-    it('should mark token as used after successful verification', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify with valid token
-      // - Token's used_at field set to current timestamp
-      // - Token cannot be reused
-      expect(true).toBe(true);
-    });
+    it.todo('should mark token as used after successful verification');
   });
 
   describe('POST /api/email/verify/resend', () => {
-    it('should resend verification email to authenticated user', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend with valid session
-      // - New verification token generated
-      // - Email sent with new token
-      // - Response: 200 with success message
-      expect(true).toBe(true);
-    });
+    it.todo('should resend verification email to authenticated user');
 
-    it('should require authentication', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend without session
-      // - Response: 401 Unauthorized
-      expect(true).toBe(true);
-    });
+    it.todo('should require authentication');
 
-    it('should reject if email already verified', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend for verified user
-      // - Response: 400 with "メールアドレスは既に確認済みです" error
-      expect(true).toBe(true);
-    });
+    it.todo('should reject if email already verified');
 
-    it('should invalidate old token when resending', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend
-      // - Previous unused token(s) marked as used or deleted
-      // - Only new token is valid
-      expect(true).toBe(true);
-    });
+    it.todo('should invalidate old token when resending');
 
-    it('should enforce rate limiting (max 3 resends per hour)', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend 4 times within 1 hour
-      // - First 3: 200 success
-      // - 4th: 429 Too Many Requests
-      expect(true).toBe(true);
-    });
+    it.todo('should enforce rate limiting (max 3 resends per hour)');
 
-    it('should generate new token with 24-hour expiration', async () => {
-      // Expected behavior:
-      // - POST /api/email/verify/resend
-      // - New token created with expires_at = now + 24 hours
-      // - Token different from previous token
-      expect(true).toBe(true);
-    });
+    it.todo('should generate new token with 24-hour expiration');
   });
 
   describe('Security tests', () => {
-    it('should use secure token generation (32 characters, base64url, cryptographically random)', async () => {
-      // Expected behavior:
-      // - Tokens generated using Web Crypto API
-      // - 256 bits of entropy (32 bytes)
-      // - Base64url encoded (no collisions in 1000 samples)
-      expect(true).toBe(true);
-    });
+    it.todo('should use secure token generation (32 characters, base64url, cryptographically random)');
 
-    it('should prevent token reuse after verification', async () => {
-      // Expected behavior:
-      // - Token can only be used once
-      // - used_at timestamp prevents reuse
-      expect(true).toBe(true);
-    });
+    it.todo('should prevent token reuse after verification');
 
-    it('should clean up expired tokens (handled by cron job)', async () => {
-      // Expected behavior:
-      // - Tokens older than 7 days deleted by scheduled task
-      // - Database stays clean
-      expect(true).toBe(true);
-    });
+    it.todo('should clean up expired tokens (handled by cron job)');
   });
 });

--- a/tests/integration/user-ai-usage.test.ts
+++ b/tests/integration/user-ai-usage.test.ts
@@ -1,104 +1,21 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { Hono } from 'hono';
+import { describe, it } from 'vitest';
 
 describe('User AI Usage API Integration Tests', () => {
-  let app: Hono;
-  let authToken: string;
-  const testUser = {
-    email: 'ai-usage-test@example.com',
-    password: 'password123',
-    name: 'AI Usage Tester',
-  };
-
-  beforeAll(async () => {
-    // Setup would initialize app and create test user
-    // For now, we document the expected behavior
-  });
-
-  afterAll(async () => {
-    // Cleanup test data
-  });
-
   describe('GET /api/user/ai-usage', () => {
-    it('should return 401 without authentication', async () => {
-      // const res = await app.request('/api/user/ai-usage');
-      // expect(res.status).toBe(401);
-      expect(true).toBe(true); // Placeholder - requires auth middleware testing
-    });
+    it.todo('should return 401 without authentication');
 
-    it('should return AI usage summary for authenticated user', async () => {
-      // const res = await app.request('/api/user/ai-usage', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(data).toHaveProperty('totalTokens');
-      // expect(data).toHaveProperty('monthlyTokens');
-      // expect(typeof data.totalTokens).toBe('number');
-      // expect(typeof data.monthlyTokens).toBe('number');
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return AI usage summary for authenticated user');
 
-    it('should return zero tokens for new user with no AI usage', async () => {
-      // const res = await app.request('/api/user/ai-usage', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(data.totalTokens).toBe(0);
-      // expect(data.monthlyTokens).toBe(0);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should return zero tokens for new user with no AI usage');
 
-    it('should return cumulative tokens after AI usage', async () => {
-      // First, make an AI analysis request
-      // const analysisRes = await app.request('/api/meals/analyze-text', {
-      //   method: 'POST',
-      //   headers: {
-      //     Authorization: `Bearer ${authToken}`,
-      //     'Content-Type': 'application/json',
-      //   },
-      //   body: JSON.stringify({ text: 'ご飯と味噌汁' }),
-      // });
-      // expect(analysisRes.status).toBe(200);
+    it.todo('should return cumulative tokens after AI usage');
 
-      // Then check AI usage
-      // const res = await app.request('/api/user/ai-usage', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // expect(res.status).toBe(200);
-      // const data = await res.json();
-      // expect(data.totalTokens).toBeGreaterThan(0);
-      // expect(data.monthlyTokens).toBeGreaterThan(0);
-      expect(true).toBe(true); // Placeholder - requires actual AI API call
-    });
+    it.todo('should track usage from image analysis');
 
-    it('should track usage from image analysis', async () => {
-      // Expected: POST /api/meals/analyze with image should record 'image_analysis' usage
-      // After: GET /api/user/ai-usage should show increased tokens
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should track usage from text analysis');
 
-    it('should track usage from text analysis', async () => {
-      // Expected: POST /api/meals/analyze-text should record 'text_analysis' usage
-      // After: GET /api/user/ai-usage should show increased tokens
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should track usage from chat');
 
-    it('should track usage from chat', async () => {
-      // Expected: POST /api/meals/:id/chat should record 'chat' usage
-      // After: GET /api/user/ai-usage should show increased tokens
-      expect(true).toBe(true); // Placeholder
-    });
-
-    it('should separate monthly from total tokens correctly', async () => {
-      // Expected: monthlyTokens <= totalTokens
-      // const res = await app.request('/api/user/ai-usage', {
-      //   headers: { Authorization: `Bearer ${authToken}` },
-      // });
-      // const data = await res.json();
-      // expect(data.monthlyTokens).toBeLessThanOrEqual(data.totalTokens);
-      expect(true).toBe(true); // Placeholder
-    });
+    it.todo('should separate monthly from total tokens correctly');
   });
 });

--- a/tests/integration/weights.test.ts
+++ b/tests/integration/weights.test.ts
@@ -1,100 +1,49 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: Integration tests require running backend server
 // These are placeholder tests that define the expected API behavior
 
 describe('Weight API Integration Tests', () => {
-  const API_BASE = 'http://localhost:8787';
 
   describe('POST /api/weights', () => {
-    it('should create a weight record when authenticated', async () => {
-      // Expected behavior:
-      // - POST /api/weights with valid session cookie
-      // - Body: { weight: 70.5, recordedAt: "2024-01-15T10:00:00Z" }
-      // - Response: 201 with { id, userId, weight, recordedAt, createdAt, updatedAt }
-      expect(true).toBe(true);
-    });
+    it.todo('should create a weight record when authenticated');
 
-    it('should return 401 when not authenticated', async () => {
-      // Expected: 401 Unauthorized without session cookie
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
 
-    it('should return 400 for invalid weight value', async () => {
-      // Expected: 400 Bad Request for weight < 20 or > 300
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for invalid weight value');
 
-    it('should return 400 for invalid date format', async () => {
-      // Expected: 400 Bad Request for non-ISO8601 date
-      expect(true).toBe(true);
-    });
+    it.todo('should return 400 for invalid date format');
   });
 
   describe('GET /api/weights', () => {
-    it('should return all weight records for authenticated user', async () => {
-      // Expected:
-      // - GET /api/weights with valid session
-      // - Response: 200 with { weights: [...] }
-      expect(true).toBe(true);
-    });
+    it.todo('should return all weight records for authenticated user');
 
-    it('should support date range query parameters', async () => {
-      // Expected:
-      // - GET /api/weights?startDate=2024-01-01&endDate=2024-01-31
-      // - Response: Only records within range
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range query parameters');
 
-    it('should return 401 when not authenticated', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 401 when not authenticated');
   });
 
   describe('GET /api/weights/:id', () => {
-    it('should return specific weight record', async () => {
-      // Expected: 200 with { weight: {...} }
-      expect(true).toBe(true);
-    });
+    it.todo('should return specific weight record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   describe('PATCH /api/weights/:id', () => {
-    it('should update weight record', async () => {
-      // Expected:
-      // - PATCH /api/weights/:id with { weight: 71.0 }
-      // - Response: 200 with updated record
-      expect(true).toBe(true);
-    });
+    it.todo('should update weight record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 
   describe('DELETE /api/weights/:id', () => {
-    it('should delete weight record', async () => {
-      // Expected: 204 No Content on successful deletion
-      expect(true).toBe(true);
-    });
+    it.todo('should delete weight record');
 
-    it('should return 404 for non-existent record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 404 for non-existent record');
 
-    it('should return 403 for record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return 403 for record belonging to different user');
   });
 });

--- a/tests/unit/PhotoCarousel.test.tsx
+++ b/tests/unit/PhotoCarousel.test.tsx
@@ -1,14 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Note: This test file requires @testing-library/react setup
 // Skipping for now as it's not configured in the current environment
 // E2E tests in tests/e2e/meal-history-carousel.spec.ts cover the actual UI behavior
 
 describe.skip('PhotoCarousel Component', () => {
-  it('placeholder test', () => {
-    // Placeholder to prevent empty test suite errors
-    expect(true).toBe(true);
-  });
+  it.todo('placeholder test');
 
   // TODO: Enable these tests when @testing-library/react is properly configured
   /*

--- a/tests/unit/exercise.service.test.ts
+++ b/tests/unit/exercise.service.test.ts
@@ -24,110 +24,59 @@ describe('ExerciseService', () => {
   });
 
   describe('create', () => {
-    it('should create a new exercise record with sets/reps/weight', async () => {
-      const input = {
-        exerciseType: 'ベンチプレス',
-        sets: 3,
-        reps: 10,
-        weight: 60,
-        recordedAt: new Date().toISOString(),
-      };
-      const userId = 'user-123';
+    it.todo('should create a new exercise record with sets/reps/weight');
 
-      expect(true).toBe(true);
-    });
+    it.todo('should validate sets is positive');
 
-    it('should validate sets is positive', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should validate reps is positive');
 
-    it('should validate reps is positive', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should allow null weight for bodyweight exercises');
 
-    it('should allow null weight for bodyweight exercises', async () => {
-      expect(true).toBe(true);
-    });
-
-    it('should validate exerciseType is not empty', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should validate exerciseType is not empty');
   });
 
   describe('findById', () => {
-    it('should return exercise record by id', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return exercise record by id');
 
-    it('should return null if record not found', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return null if record not found');
 
-    it('should not return record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not return record belonging to different user');
   });
 
   describe('findByUserId', () => {
-    it('should return all exercise records for user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return all exercise records for user');
 
-    it('should return records ordered by recordedAt descending', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return records ordered by recordedAt descending');
 
-    it('should support date range filtering', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range filtering');
   });
 
   describe('getWeeklySummary', () => {
-    it('should calculate total sets and reps for the week', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should calculate total sets and reps for the week');
 
-    it('should group exercises by type with sets and reps', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should group exercises by type with sets and reps');
 
-    it('should count number of exercise sessions', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should count number of exercise sessions');
   });
 
   describe('getLastByType', () => {
-    it('should return the last record for a specific exercise type', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return the last record for a specific exercise type');
 
-    it('should return null if no records exist for the type', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should return null if no records exist for the type');
   });
 
   describe('update', () => {
-    it('should update exercise record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should update exercise record');
 
-    it('should update updatedAt timestamp', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should update updatedAt timestamp');
 
-    it('should not update record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not update record belonging to different user');
   });
 
   describe('delete', () => {
-    it('should delete exercise record', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should delete exercise record');
 
-    it('should not delete record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not delete record belonging to different user');
   });
 
   describe('getMaxRMs', () => {

--- a/tests/unit/meal.service.test.ts
+++ b/tests/unit/meal.service.test.ts
@@ -24,85 +24,31 @@ describe('MealService', () => {
   });
 
   describe('create', () => {
-    it('should create a new meal record', async () => {
-      const input = {
-        mealType: 'breakfast' as const,
-        content: '卵かけご飯',
-        calories: 350,
-        recordedAt: new Date().toISOString(),
-      };
-      const userId = 'user-123';
+    it.todo('should create a new meal record');
 
-      // Expected: MealService.create(userId, input) creates a record
-      expect(true).toBe(true);
-    });
+    it.todo('should create meal record without calories');
 
-    it('should create meal record without calories', async () => {
-      const input = {
-        mealType: 'lunch' as const,
-        content: 'サラダ',
-        recordedAt: new Date().toISOString(),
-      };
+    it.todo('should validate mealType is valid enum value');
 
-      // Expected: Calories field is optional
-      expect(true).toBe(true);
-    });
-
-    it('should validate mealType is valid enum value', async () => {
-      // Expected: Only 'breakfast', 'lunch', 'dinner', 'snack' allowed
-      expect(true).toBe(true);
-    });
-
-    it('should validate content is not empty', async () => {
-      // Expected: Content must be at least 1 character
-      expect(true).toBe(true);
-    });
+    it.todo('should validate content is not empty');
   });
 
   describe('findById', () => {
-    it('should return meal record by id', async () => {
-      const mealId = 'meal-123';
-      const userId = 'user-123';
+    it.todo('should return meal record by id');
 
-      // Expected: MealService.findById(mealId, userId) returns the record
-      expect(true).toBe(true);
-    });
+    it.todo('should return null if record not found');
 
-    it('should return null if record not found', async () => {
-      expect(true).toBe(true);
-    });
-
-    it('should not return record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not return record belonging to different user');
   });
 
   describe('findByUserId', () => {
-    it('should return all meal records for user', async () => {
-      const userId = 'user-123';
+    it.todo('should return all meal records for user');
 
-      // Expected: MealService.findByUserId(userId) returns array
-      expect(true).toBe(true);
-    });
+    it.todo('should return records ordered by recordedAt descending');
 
-    it('should return records ordered by recordedAt descending', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range filtering');
 
-    it('should support date range filtering', async () => {
-      const userId = 'user-123';
-      const startDate = '2024-01-01';
-      const endDate = '2024-01-31';
-
-      expect(true).toBe(true);
-    });
-
-    it('should support filtering by mealType', async () => {
-      const userId = 'user-123';
-      const mealType = 'breakfast';
-
-      expect(true).toBe(true);
-    });
+    it.todo('should support filtering by mealType');
 
     it('fetches only the user\'s photos via a WHERE filter and groups them ordered by displayOrder (#102)', async () => {
       const userId = 'user-123';
@@ -140,46 +86,23 @@ describe('MealService', () => {
   });
 
   describe('getCalorieSummary', () => {
-    it('should calculate total calories for date range', async () => {
-      // Expected: Returns { totalCalories, averageCalories, count }
-      expect(true).toBe(true);
-    });
+    it.todo('should calculate total calories for date range');
 
-    it('should handle meals without calories', async () => {
-      // Expected: Only count meals with calories value
-      expect(true).toBe(true);
-    });
+    it.todo('should handle meals without calories');
   });
 
   describe('update', () => {
-    it('should update meal record', async () => {
-      const mealId = 'meal-123';
-      const userId = 'user-123';
-      const updates = { content: '味噌汁追加' };
+    it.todo('should update meal record');
 
-      expect(true).toBe(true);
-    });
+    it.todo('should update updatedAt timestamp');
 
-    it('should update updatedAt timestamp', async () => {
-      expect(true).toBe(true);
-    });
-
-    it('should not update record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not update record belonging to different user');
   });
 
   describe('delete', () => {
-    it('should delete meal record', async () => {
-      const mealId = 'meal-123';
-      const userId = 'user-123';
+    it.todo('should delete meal record');
 
-      expect(true).toBe(true);
-    });
-
-    it('should not delete record belonging to different user', async () => {
-      expect(true).toBe(true);
-    });
+    it.todo('should not delete record belonging to different user');
   });
 
   describe('getTodaysSummary', () => {
@@ -213,41 +136,12 @@ describe('MealService', () => {
   });
 
   describe('getMealDates', () => {
-    it('should return unique dates with meal records for a given month', async () => {
-      const userId = 'user-123';
-      const year = 2026;
-      const month = 1;
+    it.todo('should return unique dates with meal records for a given month');
 
-      // Expected: Returns array of unique date strings like ["2026-01-01", "2026-01-05"]
-      expect(true).toBe(true);
-    });
+    it.todo('should return empty array when no meals exist in the month');
 
-    it('should return empty array when no meals exist in the month', async () => {
-      const userId = 'user-123';
-      const year = 2026;
-      const month = 12;
+    it.todo('should respect timezone offset when calculating dates');
 
-      // Expected: Returns []
-      expect(true).toBe(true);
-    });
-
-    it('should respect timezone offset when calculating dates', async () => {
-      const userId = 'user-123';
-      const year = 2026;
-      const month = 1;
-      const timezoneOffset = -540; // JST (UTC+9)
-
-      // Expected: Dates are calculated in user's local timezone
-      expect(true).toBe(true);
-    });
-
-    it('should return dates sorted in ascending order', async () => {
-      const userId = 'user-123';
-      const year = 2026;
-      const month = 1;
-
-      // Expected: ["2026-01-01", "2026-01-05", "2026-01-15"] not shuffled
-      expect(true).toBe(true);
-    });
+    it.todo('should return dates sorted in ascending order');
   });
 });

--- a/tests/unit/weight.service.test.ts
+++ b/tests/unit/weight.service.test.ts
@@ -1,127 +1,40 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// Mock the database
-const mockDb = {
-  select: vi.fn().mockReturnThis(),
-  from: vi.fn().mockReturnThis(),
-  where: vi.fn().mockReturnThis(),
-  orderBy: vi.fn().mockReturnThis(),
-  limit: vi.fn().mockReturnThis(),
-  get: vi.fn(),
-  all: vi.fn(),
-  insert: vi.fn().mockReturnThis(),
-  values: vi.fn().mockReturnThis(),
-  update: vi.fn().mockReturnThis(),
-  set: vi.fn().mockReturnThis(),
-  delete: vi.fn().mockReturnThis(),
-  returning: vi.fn().mockReturnThis(),
-};
+import { describe, it } from 'vitest';
 
 // Note: These tests will be updated once WeightService is implemented
 describe('WeightService', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe('create', () => {
-    it('should create a new weight record', async () => {
-      const input = {
-        weight: 70.5,
-        recordedAt: new Date().toISOString(),
-      };
-      const userId = 'user-123';
+    it.todo('should create a new weight record');
 
-      // Expected: WeightService.create(userId, input) creates a record
-      expect(true).toBe(true); // Placeholder until service is implemented
-    });
-
-    it('should validate weight is within range', async () => {
-      const input = {
-        weight: 15, // Below minimum of 20
-        recordedAt: new Date().toISOString(),
-      };
-
-      // Expected: Should throw validation error
-      expect(true).toBe(true);
-    });
+    it.todo('should validate weight is within range');
   });
 
   describe('findById', () => {
-    it('should return weight record by id', async () => {
-      const weightId = 'weight-123';
-      const userId = 'user-123';
+    it.todo('should return weight record by id');
 
-      // Expected: WeightService.findById(weightId, userId) returns the record
-      expect(true).toBe(true);
-    });
+    it.todo('should return null if record not found');
 
-    it('should return null if record not found', async () => {
-      // Expected: Should return null for non-existent record
-      expect(true).toBe(true);
-    });
-
-    it('should not return record belonging to different user', async () => {
-      // Expected: Should throw or return null for unauthorized access
-      expect(true).toBe(true);
-    });
+    it.todo('should not return record belonging to different user');
   });
 
   describe('findByUserId', () => {
-    it('should return all weight records for user', async () => {
-      const userId = 'user-123';
+    it.todo('should return all weight records for user');
 
-      // Expected: WeightService.findByUserId(userId) returns array
-      expect(true).toBe(true);
-    });
+    it.todo('should return records ordered by recordedAt descending');
 
-    it('should return records ordered by recordedAt descending', async () => {
-      // Expected: Most recent records first
-      expect(true).toBe(true);
-    });
-
-    it('should support date range filtering', async () => {
-      const userId = 'user-123';
-      const startDate = '2024-01-01';
-      const endDate = '2024-01-31';
-
-      // Expected: Only return records within date range
-      expect(true).toBe(true);
-    });
+    it.todo('should support date range filtering');
   });
 
   describe('update', () => {
-    it('should update weight record', async () => {
-      const weightId = 'weight-123';
-      const userId = 'user-123';
-      const updates = { weight: 71.0 };
+    it.todo('should update weight record');
 
-      // Expected: WeightService.update(weightId, userId, updates) updates the record
-      expect(true).toBe(true);
-    });
+    it.todo('should update updatedAt timestamp');
 
-    it('should update updatedAt timestamp', async () => {
-      // Expected: updatedAt should be set to current time
-      expect(true).toBe(true);
-    });
-
-    it('should not update record belonging to different user', async () => {
-      // Expected: Should throw for unauthorized update
-      expect(true).toBe(true);
-    });
+    it.todo('should not update record belonging to different user');
   });
 
   describe('delete', () => {
-    it('should delete weight record', async () => {
-      const weightId = 'weight-123';
-      const userId = 'user-123';
+    it.todo('should delete weight record');
 
-      // Expected: WeightService.delete(weightId, userId) deletes the record
-      expect(true).toBe(true);
-    });
-
-    it('should not delete record belonging to different user', async () => {
-      // Expected: Should throw for unauthorized deletion
-      expect(true).toBe(true);
-    });
+    it.todo('should not delete record belonging to different user');
   });
 });


### PR DESCRIPTION
## 概要

`expect(true).toBe(true)` のみのプレースホルダーテストが多数存在し、401/400/403 等の検証を行うかのようなテスト名でCIをグリーンにしていました。これらは実質何も検証していないため、CIのグリーンが無意味になっていた問題を解消します。

Closes #128

## 変更内容

### プレースホルダーテストの `it.todo` 化（258件）

実装のないテストを `it.todo('<テスト名>')` に変換し、空のテスト本体と未使用になったセットアップ変数・import（`API_BASE`、`mockDb`、`expect`/`vi`/`beforeAll` 等）を削除しました。これにより:

- CI上で「passed」ではなく「todo」として表示され、未実装であることが可視化される
- 実際のテスト実装は別途トラッキング（既存の実装PRが進行中のファイルもあり）

| ファイル | 変換数 |
|---|---|
| tests/integration/meal-analysis.test.ts | 32 |
| tests/integration/meal-chat.test.ts | 30 |
| tests/integration/exercises.test.ts | 21 |
| tests/integration/meals.test.ts | 19 |
| tests/integration/routes/email/verify.test.ts | 17 |
| tests/integration/weights.test.ts | 16 |
| tests/integration/routes/auth/password-reset.test.ts | 15 |
| tests/integration/dashboard.test.ts | 13 |
| tests/integration/routes/auth/register.test.ts | 12 |
| tests/integration/routes/email/change.test.ts | 12 |
| tests/integration/user-ai-usage.test.ts | 8 |
| tests/integration/meal-chat-photos.test.ts | 6 |
| tests/unit/meal.service.test.ts | 22 |
| tests/unit/exercise.service.test.ts | 21 |
| tests/unit/weight.service.test.ts | 13 |
| tests/unit/PhotoCarousel.test.tsx | 1 |

実アサーションを持つテスト（meal.service.test.ts の #102 テスト、meals.test.ts / meal-analysis.test.ts の実装済み統合テスト）はそのまま維持しています。

### E2E（Playwright）

- `tests/e2e/email-change.spec.ts`: 純粋なプレースホルダー4件を `test.fixme` に変換（Playwright には `test.todo` が無いため。skipped として報告される）
- `tests/e2e/password-reset.spec.ts` / `email-verification.spec.ts` の `expect(true).toBe(true)` は実操作を伴うテスト内の条件分岐フォールバックのため対象外

### E2EのバックエンドURLハードコード解消

`tests/e2e/request-id-tracing.spec.ts` の3箇所の `http://localhost:8787` を、ファイル先頭の定数に集約:

```ts
const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8787';
```

## 確認

- `pnpm typecheck` ✅（3パッケージすべて）
- `pnpm test:unit` ✅ 190 passed | 57 todo（failureなし）
- 全todo化した統合テストファイル10本をvitestで収集・実行 ✅ 150 todo / 0 fail（バックエンド不要に）
- `pnpm lint` ✅ 新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)