### PR TITLE
feat: PWAをprompt更新方式に変更し新バージョン通知バナーを追加

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,6 +37,7 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
-    "vite-plugin-pwa": "^0.17.0"
+    "vite-plugin-pwa": "^0.17.0",
+    "workbox-window": "^7.0.0"
   }
 }

--- a/packages/frontend/src/components/ui/PwaUpdatePrompt.tsx
+++ b/packages/frontend/src/components/ui/PwaUpdatePrompt.tsx
@@ -1,0 +1,50 @@
+import { useRegisterSW } from 'virtual:pwa-register/react';
+
+/**
+ * PWAの新バージョン検知バナー。
+ * registerType: 'prompt' のService Workerが新バージョンを検知すると
+ * needRefresh が true になり、画面上部に更新を促すバナーを表示する。
+ * 「更新」で新しいService Workerを有効化してリロード、「閉じる」で見送る。
+ */
+export function PwaUpdatePrompt() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW();
+
+  if (!needRefresh) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-x-4 top-4 z-50 mx-auto flex max-w-md items-center gap-3 rounded-lg border border-blue-200 bg-blue-100 px-4 py-3 text-blue-800 shadow-lg"
+      role="alert"
+    >
+      <svg className="h-5 w-5 shrink-0 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+      <p className="flex-1 text-sm font-medium">新しいバージョンがあります</p>
+      <button
+        onClick={() => updateServiceWorker(true)}
+        className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+      >
+        更新
+      </button>
+      <button
+        onClick={() => setNeedRefresh(false)}
+        className="rounded p-1 hover:bg-black/10"
+        aria-label="閉じる"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom';
 import { QueryProvider } from './providers/QueryProvider';
 import { ToastProvider } from './components/ui/Toast';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
+import { PwaUpdatePrompt } from './components/ui/PwaUpdatePrompt';
 import { router } from './router';
 import { setupGlobalErrorHandler } from './lib/errorLogger';
 import './index.css';
@@ -16,6 +17,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ErrorBoundary>
       <QueryProvider>
         <ToastProvider>
+          <PwaUpdatePrompt />
           <RouterProvider router={router} />
         </ToastProvider>
       </QueryProvider>

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {
         name: 'Health Tracker',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^0.17.0
         version: 0.17.5(vite@5.4.21)(workbox-build@7.4.0)(workbox-window@7.4.0)
+      workbox-window:
+        specifier: ^7.0.0
+        version: 7.4.0
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## 概要

PWAの更新方式を `autoUpdate` から `prompt` に変更し、新バージョン検知時に画面上部へ更新通知バナーを表示するようにした。

Closes #133

## 背景

`registerType: 'autoUpdate'` ではデプロイ後に新しいService Workerが即時有効化されるが、開いたままのタブはリロードするまで旧アセット（JS/CSS）で動作し続ける。APIスキーマが変わるデプロイ後、古いフロントエンドが新しいバックエンドに対してエラーを起こす問題があった。PWAとして長時間開きっぱなしになる利用形態のため、ユーザーに更新を明示的に促すUIが必要。

## 変更内容

- **`vite.config.ts`**: `registerType: 'autoUpdate'` → `'prompt'`
- **`src/components/ui/PwaUpdatePrompt.tsx`（新規）**: `virtual:pwa-register/react` の `useRegisterSW` を使った更新通知バナー
  - `needRefresh` が true になると画面上部に「新しいバージョンがあります」バナーを表示
  - 「更新」ボタンで `updateServiceWorker(true)` を呼び、新SWを有効化してリロード
  - 「閉じる」ボタンで見送り可能（非ブロッキング）
  - 既存Toastコンポーネントのinfoスタイル（Tailwind）に合わせたデザイン
- **`src/main.tsx`**: ルート（`ToastProvider` 配下、`RouterProvider` の隣）にバナーを配置し、全ページで表示されるように
- **`src/vite-env.d.ts`**: `vite-plugin-pwa/react` の型参照を追加
- **`package.json`**: `workbox-window` をdevDependencyに追加（`virtual:pwa-register` がランタイムで必要とするため。pnpmの厳格なnode_modules構成では明示的な依存が必要）

`offlineReady` は通知不要と判断し、特にUIは出していない（最小限の変更に留めた）。

## 動作

1. 新バージョンがデプロイされると、SWが新アセットをプリキャッシュした状態で待機（自動有効化しない）
2. 開いているタブにバナーが表示される
3. 「更新」を押すと `SKIP_WAITING` メッセージで新SWが有効化され、ページがリロードされて新アセットで動作

生成された `sw.js` を確認し、`skipWaiting()` が `SKIP_WAITING` メッセージハンドラ内のみ（無条件実行なし）であることを確認済み。

## テスト

- `pnpm build:shared && pnpm typecheck` ✅（3パッケージすべて通過）
- `pnpm lint` ✅（新規エラー・警告なし。既存の `PhotoAnalysisReview.tsx` の警告1件のみ）
- `pnpm test:unit` ✅（246 passed | 1 skipped）
- `pnpm --filter @lifestyle-app/frontend build` ✅（PWA v0.17.5 / generateSW / precache 16 entries）

🤖 Generated with [Claude Code](https://claude.com/claude-code)