### PR TITLE
fix: メール系レート制限の原子性を改善（countクランプ・resend上限の自己修正）

### DIFF
--- a/packages/backend/src/services/email/email-verification.service.ts
+++ b/packages/backend/src/services/email/email-verification.service.ts
@@ -11,7 +11,7 @@
  */
 
 import type { D1Database } from '@cloudflare/workers-types';
-import { eq, and, isNull, gt } from 'drizzle-orm';
+import { eq, and, isNull, gt, ne } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../../db/schema';
 import { generateSecureToken, hashToken } from '../token/crypto';
@@ -19,6 +19,63 @@ import { sendEmail } from './email.service';
 import { emailVerificationTemplate } from './templates/email-verification';
 
 const EMAIL_VERIFICATION_TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const RESEND_RATE_LIMIT_PER_HOUR = 3; // max tokens issued per user per hour
+const RESEND_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+type Orm = ReturnType<typeof drizzle<typeof schema>>;
+
+/**
+ * Generate a new verification token and insert its hash into the database.
+ * Only the SHA-256 hash is stored; the raw token goes in the verification
+ * link (#98).
+ */
+async function insertVerificationToken(
+  orm: Orm,
+  userId: string
+): Promise<{ token: string; tokenHash: string }> {
+  const token = await generateSecureToken();
+  const tokenHash = await hashToken(token);
+  const now = Date.now();
+
+  await orm.insert(schema.emailVerificationTokens).values({
+    userId,
+    token: tokenHash,
+    expiresAt: now + EMAIL_VERIFICATION_TOKEN_EXPIRATION_MS,
+    usedAt: null,
+    createdAt: now,
+  });
+
+  return { token, tokenHash };
+}
+
+/**
+ * Send the verification email carrying the raw token.
+ */
+async function deliverVerificationEmail(
+  db: D1Database,
+  userId: string,
+  email: string,
+  resendApiKey: string,
+  fromEmail: string,
+  frontendUrl: string,
+  token: string
+): Promise<{ success: true } | { success: false; error: string }> {
+  const verificationLink = `${frontendUrl}/verify-email?token=${token}`;
+
+  const emailResult = await sendEmail(db, resendApiKey, fromEmail, {
+    to: email,
+    subject: 'メールアドレスの確認',
+    html: emailVerificationTemplate(verificationLink, email),
+    emailType: 'email_verification',
+    userId,
+  });
+
+  if (!emailResult.success) {
+    return { success: false, error: emailResult.error || 'メール送信に失敗しました' };
+  }
+
+  return { success: true };
+}
 
 /**
  * Send verification email to newly registered user
@@ -42,36 +99,20 @@ export async function sendVerificationEmail(
   const orm = drizzle(db, { schema });
 
   try {
-    // Generate secure token. Only its SHA-256 hash is stored; the raw token
-    // goes in the verification link (#98).
-    const token = await generateSecureToken();
-    const tokenHash = await hashToken(token);
-    const now = Date.now();
-    const expiresAt = now + EMAIL_VERIFICATION_TOKEN_EXPIRATION_MS;
+    const { token } = await insertVerificationToken(orm, userId);
 
-    // Insert token hash into database
-    await orm.insert(schema.emailVerificationTokens).values({
+    const emailResult = await deliverVerificationEmail(
+      db,
       userId,
-      token: tokenHash,
-      expiresAt,
-      usedAt: null,
-      createdAt: now,
-    });
-
-    // Generate verification link (carries the raw token)
-    const verificationLink = `${frontendUrl}/verify-email?token=${token}`;
-
-    // Send email
-    const emailResult = await sendEmail(db, resendApiKey, fromEmail, {
-      to: email,
-      subject: 'メールアドレスの確認',
-      html: emailVerificationTemplate(verificationLink, email),
-      emailType: 'email_verification',
-      userId,
-    });
+      email,
+      resendApiKey,
+      fromEmail,
+      frontendUrl,
+      token
+    );
 
     if (!emailResult.success) {
-      return { success: false, error: emailResult.error || 'メール送信に失敗しました' };
+      return { success: false, error: emailResult.error };
     }
 
     return { success: true, token }; // Return token for testing
@@ -172,8 +213,18 @@ export async function resendVerificationEmail(
       return { success: false, error: 'メールアドレスは既に確認済みです' };
     }
 
-    // Check rate limit: max 3 resends per hour
-    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    // Rate limit: max 3 tokens per user per hour.
+    //
+    // A pre-insert COUNT check alone is racy (#132): two concurrent requests
+    // can both pass the check and over-issue. D1 has no interactive
+    // transactions, so instead the limit is enforced self-correctingly:
+    // insert the new token FIRST, then count tokens created in the last hour
+    // INCLUDING the new one. Every request that sees the count above the
+    // limit invalidates its own just-inserted token and bails out before any
+    // email is sent, so concurrent over-issuance corrects itself.
+    const { token, tokenHash } = await insertVerificationToken(orm, userId);
+
+    const oneHourAgo = Date.now() - RESEND_RATE_LIMIT_WINDOW_MS;
     const recentTokens = await db
       .prepare(
         `SELECT COUNT(*) as count
@@ -183,32 +234,41 @@ export async function resendVerificationEmail(
       .bind(userId, oneHourAgo)
       .first<{ count: number }>();
 
-    if (recentTokens && recentTokens.count >= 3) {
+    if (recentTokens && recentTokens.count > RESEND_RATE_LIMIT_PER_HOUR) {
+      // Over the limit: invalidate the token we just inserted. Older tokens
+      // stay valid, so a rate-limited resend does not kill previous links.
+      await orm
+        .update(schema.emailVerificationTokens)
+        .set({ usedAt: Date.now() })
+        .where(eq(schema.emailVerificationTokens.token, tokenHash));
+
       return {
         success: false,
         error: '確認メールの送信回数が上限に達しました。しばらくしてから再度お試しください',
       };
     }
 
-    // Invalidate old unused tokens for this user
+    // Within the limit: invalidate old unused tokens (the new one stays valid)
     await orm
       .update(schema.emailVerificationTokens)
       .set({ usedAt: Date.now() })
       .where(
         and(
           eq(schema.emailVerificationTokens.userId, userId),
-          isNull(schema.emailVerificationTokens.usedAt)
+          isNull(schema.emailVerificationTokens.usedAt),
+          ne(schema.emailVerificationTokens.token, tokenHash)
         )
       );
 
     // Send new verification email
-    const result = await sendVerificationEmail(
+    const result = await deliverVerificationEmail(
       db,
       userId,
       email,
       resendApiKey,
       fromEmail,
-      frontendUrl
+      frontendUrl,
+      token
     );
 
     return result.success ? { success: true } : { success: false, error: result.error };

--- a/packages/backend/src/services/rate-limit/email-rate-limit.ts
+++ b/packages/backend/src/services/rate-limit/email-rate-limit.ts
@@ -102,19 +102,27 @@ export async function incrementEmailRateLimit(
   const now = Date.now();
   const expiresAt = now + RATE_LIMIT_WINDOW_MS;
 
-  // UPSERT: Insert new record or increment existing
+  // UPSERT: Insert new record or increment existing.
+  //
+  // The count is clamped with MIN(count + 1, max) so a concurrent request
+  // slipping between check and increment can never push the value past the
+  // CHECK (count >= 0 AND count <= 10) constraint (#132). When the window has
+  // expired, the count restarts at 1 together with the expiration reset.
   await db
     .prepare(
       `INSERT INTO email_rate_limits (ip, count, expires_at)
        VALUES (?, 1, ?)
        ON CONFLICT(ip) DO UPDATE SET
-         count = count + 1,
+         count = CASE
+           WHEN expires_at < ? THEN 1
+           ELSE MIN(count + 1, ?)
+         END,
          expires_at = CASE
            WHEN expires_at < ? THEN ?
            ELSE expires_at
          END`
     )
-    .bind(ip, expiresAt, now, expiresAt)
+    .bind(ip, expiresAt, now, RATE_LIMIT_MAX, now, expiresAt)
     .run();
 }
 

--- a/tests/unit/services/email-rate-limit.test.ts
+++ b/tests/unit/services/email-rate-limit.test.ts
@@ -17,6 +17,10 @@ import {
   getClientIP,
 } from '../../../packages/backend/src/services/rate-limit/email-rate-limit';
 
+// サービスの引数型から D1Database を導出する
+// （ルートtests/からは @cloudflare/workers-types を直接importできないため）
+type ServiceD1Database = Parameters<typeof checkEmailRateLimit>[0];
+
 // Mock D1 database
 interface D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
@@ -24,11 +28,11 @@ interface D1PreparedStatement {
   run(): Promise<{ success: boolean }>;
 }
 
-interface D1Database {
+interface MockD1Database {
   prepare(query: string): D1PreparedStatement;
 }
 
-function createMockDatabase(): D1Database {
+function createMockDatabase(): MockD1Database {
   const records = new Map<
     string,
     { count: number; expires_at: number }
@@ -111,10 +115,10 @@ function createMockDatabase(): D1Database {
 }
 
 describe('Email Rate Limiting Service', () => {
-  let mockDb: D1Database;
+  let mockDb: ServiceD1Database;
 
   beforeEach(() => {
-    mockDb = createMockDatabase();
+    mockDb = createMockDatabase() as unknown as ServiceD1Database;
   });
 
   describe('checkEmailRateLimit', () => {

--- a/tests/unit/services/email-rate-limit.test.ts
+++ b/tests/unit/services/email-rate-limit.test.ts
@@ -10,7 +10,7 @@
  * - Client IP extraction from headers
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   checkEmailRateLimit,
   incrementEmailRateLimit,
@@ -69,24 +69,38 @@ function createMockDatabase(): D1Database {
         async run() {
           // INSERT or UPDATE rate limit
           if (query.includes('INSERT INTO email_rate_limits')) {
-            // bind(ip, expiresAt, now, expiresAt)
+            // bind(ip, expiresAt, now, max, now, expiresAt)
             const ip = bindings[0] as string;
             const expiresAt = bindings[1] as number;
             const now = bindings[2] as number;
+            const max = bindings[3] as number;
 
             const existing = records.get(ip);
 
+            let next: { count: number; expires_at: number };
             if (existing) {
               // ON CONFLICT DO UPDATE
-              const newExpiresAt = existing.expires_at < now ? expiresAt : existing.expires_at;
-              records.set(ip, {
-                count: existing.count + 1,
-                expires_at: newExpiresAt,
-              });
+              if (existing.expires_at < now) {
+                // Expired window: reset count together with expiration
+                next = { count: 1, expires_at: expiresAt };
+              } else {
+                // Active window: clamped increment
+                next = {
+                  count: Math.min(existing.count + 1, max),
+                  expires_at: existing.expires_at,
+                };
+              }
             } else {
               // INSERT new record with count = 1
-              records.set(ip, { count: 1, expires_at: expiresAt });
+              next = { count: 1, expires_at: expiresAt };
             }
+
+            // Emulate DDL: CHECK (count >= 0 AND count <= 10)
+            if (next.count < 0 || next.count > 10) {
+              throw new Error('D1_ERROR: CHECK constraint failed: count');
+            }
+
+            records.set(ip, next);
           }
 
           return { success: true };
@@ -190,6 +204,46 @@ describe('Email Rate Limiting Service', () => {
 
       // Expiration should remain same (within 1 second tolerance)
       expect(Math.abs(secondCheck.resetsAt - firstCheck.resetsAt)).toBeLessThan(1000);
+    });
+
+    it('should clamp count at 10 and never violate the CHECK constraint (#132)', async () => {
+      const ip = '192.168.1.8';
+
+      // 15 increments without any check in between (simulates concurrent
+      // requests that all passed the check before incrementing).
+      // With the old unconditional `count = count + 1` this would push the
+      // count past 10 and the DDL CHECK (count <= 10) would throw.
+      for (let i = 0; i < 15; i++) {
+        await expect(incrementEmailRateLimit(mockDb, ip)).resolves.toBeUndefined();
+      }
+
+      const result = await checkEmailRateLimit(mockDb, ip);
+
+      expect(result.currentCount).toBe(10); // clamped, not 15
+      expect(result.allowed).toBe(false); // still blocked at the limit
+    });
+
+    it('should reset count to 1 when incrementing after the window expired', async () => {
+      vi.useFakeTimers();
+      try {
+        const ip = '192.168.1.9';
+
+        // Fill up the window completely
+        for (let i = 0; i < 10; i++) {
+          await incrementEmailRateLimit(mockDb, ip);
+        }
+
+        // Advance past the 1-hour window, then increment WITHOUT a check
+        // in between (no DELETE cleanup ran)
+        vi.advanceTimersByTime(61 * 60 * 1000);
+        await incrementEmailRateLimit(mockDb, ip);
+
+        const result = await checkEmailRateLimit(mockDb, ip);
+        expect(result.currentCount).toBe(1); // fresh window, not 10 (clamped)
+        expect(result.allowed).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/tests/unit/services/email-verification.service.test.ts
+++ b/tests/unit/services/email-verification.service.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for email verification service (resend rate limiting, #132)
+ *
+ * Tests:
+ * - sendVerificationEmail inserts a token and sends the email
+ * - resendVerificationEmail rejects unknown / already-verified users
+ * - Resend limit is enforced self-correctingly: the token is inserted first,
+ *   then counted INCLUDING itself; over the limit the just-inserted token is
+ *   invalidated and no email is sent
+ * - Under the limit, old unused tokens are invalidated and the email is sent
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { D1Database } from '@cloudflare/workers-types';
+
+const { mockOrm, sendEmailMock, insertValuesMock, updateSetMock, updateWhereMock } = vi.hoisted(
+  () => {
+    const insertValuesMock = vi.fn().mockResolvedValue(undefined);
+    const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+    const updateSetMock = vi.fn(() => ({ where: updateWhereMock }));
+    const mockOrm = {
+      query: {
+        users: { findFirst: vi.fn() },
+        emailVerificationTokens: { findFirst: vi.fn() },
+      },
+      insert: vi.fn(() => ({ values: insertValuesMock })),
+      update: vi.fn(() => ({ set: updateSetMock })),
+    };
+    return {
+      mockOrm,
+      sendEmailMock: vi.fn(),
+      insertValuesMock,
+      updateSetMock,
+      updateWhereMock,
+    };
+  }
+);
+
+vi.mock('drizzle-orm/d1', () => ({
+  drizzle: vi.fn(() => mockOrm),
+}));
+
+vi.mock('../../../packages/backend/src/services/email/email.service', () => ({
+  sendEmail: sendEmailMock,
+}));
+
+import {
+  sendVerificationEmail,
+  resendVerificationEmail,
+} from '../../../packages/backend/src/services/email/email-verification.service';
+
+/**
+ * Raw D1 mock: only the COUNT(*) query used by the resend rate limit goes
+ * through db.prepare; everything else goes through the (mocked) drizzle ORM.
+ */
+function createMockD1(recentTokenCount: () => number): D1Database {
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn().mockReturnThis(),
+      first: vi.fn(async () => ({ count: recentTokenCount() })),
+    })),
+  } as unknown as D1Database;
+}
+
+const ARGS = ['user-1', 'user@example.com', 'api-key', 'noreply@yasedas.com', 'https://app'] as const;
+
+describe('Email Verification Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('sendVerificationEmail', () => {
+    it('should insert a token hash and send the email', async () => {
+      const db = createMockD1(() => 0);
+      sendEmailMock.mockResolvedValue({ success: true });
+
+      const result = await sendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.token).toHaveLength(32);
+      }
+
+      // Token hash (not the raw token) is stored
+      expect(insertValuesMock).toHaveBeenCalledTimes(1);
+      const inserted = insertValuesMock.mock.calls[0]?.[0] as { token: string };
+      expect(inserted.token).toMatch(/^[0-9a-f]{64}$/);
+
+      expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report failure when email delivery fails', async () => {
+      const db = createMockD1(() => 0);
+      sendEmailMock.mockResolvedValue({ success: false, error: 'delivery failed' });
+
+      const result = await sendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('delivery failed');
+      }
+    });
+  });
+
+  describe('resendVerificationEmail', () => {
+    it('should reject when user is not found', async () => {
+      const db = createMockD1(() => 0);
+      mockOrm.query.users.findFirst.mockResolvedValue(undefined);
+
+      const result = await resendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('ユーザーが見つかりません');
+      }
+      expect(insertValuesMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject when email is already verified', async () => {
+      const db = createMockD1(() => 0);
+      mockOrm.query.users.findFirst.mockResolvedValue({ id: 'user-1', emailVerified: 1 });
+
+      const result = await resendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('メールアドレスは既に確認済みです');
+      }
+      expect(insertValuesMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+    });
+
+    it('should send the email when within the limit (count including new token <= 3)', async () => {
+      // 2 existing tokens + the newly inserted one = 3 -> allowed
+      const db = createMockD1(() => 3);
+      mockOrm.query.users.findFirst.mockResolvedValue({ id: 'user-1', emailVerified: 0 });
+      sendEmailMock.mockResolvedValue({ success: true });
+
+      const result = await resendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(true);
+      expect(insertValuesMock).toHaveBeenCalledTimes(1);
+      expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+      // Old unused tokens are invalidated (usedAt set)
+      expect(updateSetMock).toHaveBeenCalledTimes(1);
+      expect(updateSetMock.mock.calls[0]?.[0]).toEqual({ usedAt: expect.any(Number) });
+    });
+
+    it('should rate limit and self-correct when count including new token exceeds 3 (#132)', async () => {
+      // 3 existing tokens + the newly inserted one = 4 -> over the limit.
+      // This is exactly the concurrent-race outcome: the token was already
+      // inserted, so the service must invalidate it and not send any email.
+      const db = createMockD1(() => 4);
+      mockOrm.query.users.findFirst.mockResolvedValue({ id: 'user-1', emailVerified: 0 });
+
+      const result = await resendVerificationEmail(db, ...ARGS);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(
+          '確認メールの送信回数が上限に達しました。しばらくしてから再度お試しください'
+        );
+      }
+
+      // Token was inserted first (insert-then-count strategy) ...
+      expect(insertValuesMock).toHaveBeenCalledTimes(1);
+      // ... and the just-inserted token was invalidated (self-correction)
+      expect(updateSetMock).toHaveBeenCalledTimes(1);
+      expect(updateSetMock.mock.calls[0]?.[0]).toEqual({ usedAt: expect.any(Number) });
+      expect(updateWhereMock).toHaveBeenCalledTimes(1);
+
+      // No email goes out for the over-limit request
+      expect(sendEmailMock).not.toHaveBeenCalled();
+    });
+
+    it('should not invalidate older tokens when rate limited', async () => {
+      const db = createMockD1(() => 4);
+      mockOrm.query.users.findFirst.mockResolvedValue({ id: 'user-1', emailVerified: 0 });
+
+      await resendVerificationEmail(db, ...ARGS);
+
+      // Exactly one update: the just-inserted token. The bulk invalidation of
+      // old unused tokens must NOT run on the rate-limited path, so previous
+      // verification links stay usable.
+      expect(mockOrm.update).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
       '@lifestyle-app/shared': path.resolve(__dirname, 'packages/shared/src'),
       '@lifestyle-app/backend': path.resolve(__dirname, 'packages/backend/src'),
       '@lifestyle-app/frontend': path.resolve(__dirname, 'packages/frontend/src'),
+      // pnpm's strict node_modules makes 'drizzle-orm/d1' unresolvable from
+      // tests/ (it is only a dependency of packages/backend), so vi.mock in
+      // unit tests would register under a different module id than the
+      // backend's own import. Pin both to the same file.
+      'drizzle-orm/d1': path.resolve(
+        __dirname,
+        'packages/backend/node_modules/drizzle-orm/d1/index.js'
+      ),
     },
   },
 });


### PR DESCRIPTION
## 概要

Issue #132 で指摘されたメール系レート制限の2つの原子性問題を修正します。D1はインタラクティブトランザクションを持たないため、どちらも「競合が起きても無害になる」設計で対処しています。

Closes #132

## 修正1: `email_rate_limits` の CHECK 制約違反（countクランプ）

**問題**: DDLに `CHECK (count >= 0 AND count <= 10)` があるのに、`incrementEmailRateLimit` のUPSERTが無条件に `count = count + 1` していたため、チェックとインクリメントの間に並行リクエストが割り込むと count が 11 になり CHECK 違反の例外が伝播していた。

**修正** (`packages/backend/src/services/rate-limit/email-rate-limit.ts`):
- SET句を `MIN(count + 1, 10)` にクランプ。並行リクエストが何件割り込んでも CHECK 制約に到達しない（上限で止まりブロックは継続）。
- あわせて、ウィンドウ期限切れ時（`expires_at < now`）は `expires_at` のリセットと同時に `count` も 1 にリセットするようCASEで揃えた。これにより「期限切れ行に増分だけ走って古いcountを引き継ぐ」不整合も解消（クリーンアップのDELETEに依存しない）。
- マイグレーションファイルは変更なし（スキーマ変更不要）。

## 修正2: `resendVerificationEmail` の TOCTOU（自己修正型レート制限）

**問題**: 「直近1時間のトークン数 COUNT(*) >= 3 チェック」→「新トークンINSERT」が別ステップで非トランザクションのため、並行リクエストが両方チェックを通過して上限超過のメールが送られ得た。

**修正** (`packages/backend/src/services/email/email-verification.service.ts`): **INSERT先行・事後カウント方式**を採用。

1. 先に新トークンをINSERTする
2. その後に「新トークンを含む」直近1時間のトークン数をCOUNTする
3. `count > 3` なら、**いま挿入した自分のトークンだけを無効化**（`used_at` を設定）してエラーを返す。メールは送信されない
4. 上限内の場合のみ、古い未使用トークンを無効化してメールを送信

**この方式を選んだ理由**: D1では条件付きの原子的操作（チェック＋INSERT）が組めず、`db.batch()` も条件分岐を含む原子性は提供しない。INSERT先行方式なら、並行リクエストが同時に走っても「上限超過を観測した各リクエストが自分のトークンを取り消して送信前に離脱する」ため、過剰発行が自己修正される。判定は `count >= 3`（挿入前）→ `count > 3`（挿入後・自分込み）に変わるだけで、上限のセマンティクスは従来と同一。

副次的な改善として、レート制限に達した場合に既存の有効な確認リンクが死なないよう、古いトークンの一括無効化を**レート制限判定の後**に移動した（従来はチェック通過後すぐ無効化していたが、無効化→送信失敗のケースで全リンクが失われていた）。挿入処理とメール送信処理は `insertVerificationToken` / `deliverVerificationEmail` のプライベートヘルパーに抽出し、`sendVerificationEmail`（サインアップ時）と共有。公開APIのシグネチャは変更なし。

## テスト

- `tests/unit/services/email-rate-limit.test.ts`
  - モックDBを新SQL（クランプ＋ウィンドウリセット）準拠に更新し、DDLの CHECK 制約違反を例外として再現するようにした
  - 追加: チェック無しで15回連続インクリメントしても例外にならず count が 10 でクランプされる
  - 追加: ウィンドウ期限切れ後のインクリメントで count が 1 にリセットされる
- `tests/unit/services/email-verification.service.test.ts`（新規）
  - 上限超過時（自分込みで count > 3）: トークン挿入→自己無効化→メール未送信を検証
  - レート制限時に古いトークンが巻き添えで無効化されないことを検証
  - 上限内の正常系、未登録ユーザー・確認済みユーザーの拒否
- `vitest.config.ts`: pnpmの厳格なnode_modules構成では `drizzle-orm/d1` が tests/ から解決できず `vi.mock` のモジュールIDがバックエンド側のimportと一致しないため、エイリアスで同一ファイルに固定

## 確認結果

- `pnpm typecheck`: 3パッケージすべて成功
- `pnpm test:unit`: 255 passed / 1 skipped
- `pnpm lint`: エラー0（既存の無関係なwarning 1件のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)