### PR TITLE
docs: レビュー由来の14PRマージ後の状態にドキュメントを更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ tests/
 - **Main Preview**: mainブランチのプレビュー環境（main pushで自動デプロイ）
 - **PR Preview**: PR別のプレビュー環境（PR作成で自動デプロイ、クローズで削除）
 
-Preview環境は別のD1データベース（`health-tracker-preview-db`）を使用。
+Preview環境は別のD1データベース（`health-tracker-preview-db`）と別のR2バケット（`lifestyle-app-photos-preview`）を使用。Main PreviewとすべてのPR Previewは同一のpreview用D1/R2を共有する。
 
 **⚠ PR Previewではマイグレーションが自動実行されない。** DBスキーマ変更を含むPRをpreviewでテストするには手動適用が必要：
 ```bash
@@ -145,3 +145,26 @@ gh run list --branch main --limit 3
 - `packages/frontend/src/lib/errorLogger.ts` - エラーロギング
 - `packages/backend/src/routes/logs.ts` - ログ受信API
 - 本番ログ: Cloudflare Dashboard > Workers & Pages > lifestyle-app-backend > Logs
+
+`/api/logs/error` は未認証で受け付ける（ログイン前のエラーも拾うため）が、以下で保護されている:
+
+- ログのuserIdはクライアント送信値ではなく**セッションcookieから導出**（未ログインは `anonymous`）
+- フィールド長上限は `ERROR_LOG_LIMITS`（`packages/shared/src/schemas/log.ts`）で定義、リクエストボディは32KB上限
+- `logValidationError` のformDataはパスワード等のキーを自動マスクして送信
+
+## Scheduled Cron (Cleanup)
+
+`packages/backend/src/cron/cleanup.ts` が定期実行され、期限切れトークン類・未認証ユーザー・古いログ・レート制限行に加え、**24時間経過した `temp/` プレフィックスのR2オブジェクト**（保存されなかった分析用写真）を削除する。
+
+ローカルでの動作確認:
+```bash
+cd packages/backend
+pnpm exec wrangler dev --test-scheduled --port 8799
+curl "http://localhost:8799/__scheduled?cron=0+15+*+*+*"
+```
+
+## PWA Update Flow
+
+Service Workerは `registerType: 'prompt'` 方式（`packages/frontend/vite.config.ts`）。新バージョンのデプロイ後、開いているタブには `PwaUpdatePrompt`（`components/ui/PwaUpdatePrompt.tsx`）が「新しいバージョンがあります」バナーを表示し、「更新」でSKIP_WAITING→リロードする。無条件の `skipWaiting()` は行わない。
+
+また、ログアウト時（明示的ログアウトと401自動ログアウトの両方）にSWの `api-cache` を削除する（`lib/clearApiCache.ts`）。キャッシュ名は vite.config.ts の `cacheName` と一致させること。

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ git push origin v1.0.0
 | 本番 | health-tracker-db |
 | プレビュー | health-tracker-preview-db |
 
+プレビュー（mainプレビュー・PRプレビュー）はすべて同一のプレビュー用データベースを共有する。
+
+## R2 ストレージ（食事写真）
+
+| 環境 | バケット名 |
+|------|-----------|
+| 本番 | lifestyle-app-photos |
+| プレビュー | lifestyle-app-photos-preview |
+
+`temp/` プレフィックスの未保存写真は、cronにより24時間経過後に自動削除される。
+
 ### マイグレーション
 
 ```bash
@@ -96,6 +107,8 @@ pnpm --filter @lifestyle-app/backend exec wrangler d1 migrations apply DB --remo
 | シークレット | 説明 |
 |-------------|------|
 | GOOGLE_GENERATIVE_AI_API_KEY | Google AI API キー |
+| RESEND_API_KEY | Resend（メール送信）API キー |
+| SESSION_SECRET | セッショントークン署名用シークレット |
 
 ### GitHub Secrets
 
@@ -104,3 +117,5 @@ pnpm --filter @lifestyle-app/backend exec wrangler d1 migrations apply DB --remo
 | CLOUDFLARE_API_TOKEN | Cloudflare API トークン |
 | CLOUDFLARE_ACCOUNT_ID | Cloudflare アカウント ID |
 | GOOGLE_GENERATIVE_AI_API_KEY | Google AI API キー |
+| RESEND_API_KEY | Resend API キー |
+| SESSION_SECRET | セッショントークン署名用シークレット |


### PR DESCRIPTION
## 概要
全体レビュー（#120〜#133）由来の14PRマージで変わった運用・挙動をドキュメントに反映する。

## 変更内容

### CLAUDE.md
- **Deployment**: Preview環境がR2も分離されたこと（`lifestyle-app-photos-preview`）、全previewがD1/R2を共有することを明記（#136）
- **Error Logging**: `/api/logs/error` の保護仕様を追記 — userIdはセッションcookieから導出（未ログインは`anonymous`）、`ERROR_LOG_LIMITS`によるフィールド上限、32KBボディ上限、formDataの自動マスク（#141）
- **Scheduled Cron** セクション新設: クリーンアップ対象の一覧と `temp/` R2オブジェクトの24時間後削除（#142）、`--test-scheduled` でのローカル確認手順
- **PWA Update Flow** セクション新設: `registerType: 'prompt'` と更新バナー（#146）、ログアウト時の `api-cache` 削除（#137）

### README.md
- R2ストレージのバケット表（本番/プレビュー）を追加
- プレビューが同一DBを共有する旨を追記
- Secrets表に `RESEND_API_KEY` / `SESSION_SECRET` を追加（CIで実際に使用されているもの）

🤖 Generated with [Claude Code](https://claude.com/claude-code)