### PR TITLE
feat: 運動記録の日付をローカル日付に統一し実行中セットのフォーカス表示を追加

### DIFF
--- a/packages/backend/src/lib/localDate.ts
+++ b/packages/backend/src/lib/localDate.ts
@@ -31,3 +31,18 @@ export function nextLocalDate(localDate: string): string {
   d.setUTCDate(d.getUTCDate() + 1);
   return d.toISOString().slice(0, 10);
 }
+
+/** Sunday-through-Saturday range containing the supplied local date. */
+export function getWeekDateRange(localDate: string): { startDate: string; endDate: string } {
+  const date = new Date(`${extractLocalDate(localDate)}T00:00:00Z`);
+  const start = new Date(date);
+  start.setUTCDate(date.getUTCDate() - date.getUTCDay());
+
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  };
+}

--- a/packages/backend/src/routes/exercises.ts
+++ b/packages/backend/src/routes/exercises.ts
@@ -1,6 +1,15 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { createExerciseSetsSchema, updateExerciseSchema, dateRangeSchema, exerciseQuerySchema, maxRMQuerySchema, exerciseImportQuerySchema, recentExercisesQuerySchema } from '@lifestyle-app/shared';
+import { z } from 'zod';
+import {
+  createExerciseSetsSchema,
+  updateExerciseSchema,
+  dateRangeSchema,
+  exerciseQuerySchema,
+  maxRMQuerySchema,
+  exerciseImportQuerySchema,
+  recentExercisesQuerySchema,
+} from '@lifestyle-app/shared';
 import { ExerciseService } from '../services/exercise';
 import { authMiddleware } from '../middleware/auth';
 import type { Database } from '../db';
@@ -13,6 +22,13 @@ type Variables = {
   db: Database;
   user: { id: string; email: string };
 };
+
+const weeklySummaryQuerySchema = z.object({
+  todayDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
 
 // Chain format for RPC type inference
 // All exercise routes require authentication
@@ -44,12 +60,13 @@ export const exercises = new Hono<{ Bindings: Bindings; Variables: Variables }>(
 
     return c.json({ exercises: exercisesList });
   })
-  .get('/weekly', async (c) => {
+  .get('/weekly', zValidator('query', weeklySummaryQuerySchema), async (c) => {
+    const query = c.req.valid('query');
     const db = c.get('db');
     const user = c.get('user');
 
     const exerciseService = new ExerciseService(db);
-    const summary = await exerciseService.getWeeklySummary(user.id);
+    const summary = await exerciseService.getWeeklySummary(user.id, query.todayDate);
 
     return c.json({ summary });
   })

--- a/packages/backend/src/services/exercise.ts
+++ b/packages/backend/src/services/exercise.ts
@@ -3,8 +3,14 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Database } from '../db';
 import { schema } from '../db';
 import { AppError } from '../middleware/error';
-import { extractLocalDate, nextLocalDate } from '../lib/localDate';
-import type { CreateExerciseInput, UpdateExerciseInput, ExerciseImportSummary, ExerciseRecord, RecentExerciseItem } from '@lifestyle-app/shared';
+import { extractLocalDate, getWeekDateRange, nextLocalDate } from '../lib/localDate';
+import type {
+  CreateExerciseInput,
+  UpdateExerciseInput,
+  ExerciseImportSummary,
+  ExerciseRecord,
+  RecentExerciseItem,
+} from '@lifestyle-app/shared';
 import { z } from 'zod';
 import { createExerciseSetsSchema, calculate1RM } from '@lifestyle-app/shared';
 
@@ -172,38 +178,22 @@ export class ExerciseService {
       return [];
     }
 
-    // Extract the date part (YYYY-MM-DD) from recordedAt
-    const lastDate = lastRecord.recordedAt.split('T')[0];
+    const lastDate = extractLocalDate(lastRecord.recordedAt);
+    const records = await this.findByUserId(userId, {
+      startDate: lastDate,
+      endDate: lastDate,
+      exerciseType,
+    });
 
-    // Get all records from the same date for this exercise type
-    const records = await this.db
-      .select()
-      .from(schema.exerciseRecords)
-      .where(
-        and(
-          eq(schema.exerciseRecords.userId, userId),
-          eq(schema.exerciseRecords.exerciseType, exerciseType),
-          sql`date(${schema.exerciseRecords.recordedAt}) = ${lastDate}`
-        )
-      )
-      .orderBy(schema.exerciseRecords.setNumber)
-      .all();
-
-    return records;
+    return records.sort((a, b) => a.setNumber - b.setNumber);
   }
 
-  async getWeeklySummary(userId: string) {
-    const now = new Date();
-    const startOfWeek = new Date(now);
-    startOfWeek.setDate(now.getDate() - now.getDay());
-    startOfWeek.setHours(0, 0, 0, 0);
-
-    const endOfWeek = new Date(startOfWeek);
-    endOfWeek.setDate(startOfWeek.getDate() + 7);
+  async getWeeklySummary(userId: string, todayDate = extractLocalDate(new Date().toISOString())) {
+    const { startDate, endDate } = getWeekDateRange(todayDate);
 
     const exercises = await this.findByUserId(userId, {
-      startDate: startOfWeek.toISOString(),
-      endDate: endOfWeek.toISOString(),
+      startDate,
+      endDate,
     });
 
     // Each record is now 1 set
@@ -228,8 +218,8 @@ export class ExerciseService {
       totalReps,
       count,
       byType,
-      weekStart: startOfWeek.toISOString(),
-      weekEnd: endOfWeek.toISOString(),
+      weekStart: startDate,
+      weekEnd: endDate,
     };
   }
 

--- a/packages/frontend/src/components/exercise/ExerciseList.tsx
+++ b/packages/frontend/src/components/exercise/ExerciseList.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import type { ExerciseRecord, UpdateExerciseInput } from '@lifestyle-app/shared';
 import { calculateRM } from '../../lib/exercise-utils';
+import { extractLocalDate } from '../../lib/dateValidation';
 
 interface ExerciseListProps {
   exercises: ExerciseRecord[];
@@ -38,8 +39,9 @@ export function ExerciseList({
     const groupMap = new Map<string, GroupedExercise>();
 
     for (const exercise of exercises) {
-      const date = new Date(exercise.recordedAt);
-      const dateStr = date.toISOString().split('T')[0] ?? '';
+      const dateStr = extractLocalDate(exercise.recordedAt);
+      const [year, month, day] = dateStr.split('-').map(Number);
+      const date = new Date(year!, month! - 1, day!);
       const key = `${exercise.exerciseType}|${dateStr}`;
 
       if (!groupMap.has(key)) {
@@ -52,10 +54,7 @@ export function ExerciseList({
             month: 'long',
             day: 'numeric',
           }),
-          timeLabel: date.toLocaleTimeString('ja-JP', {
-            hour: '2-digit',
-            minute: '2-digit',
-          }),
+          timeLabel: exercise.recordedAt.slice(11, 16),
           sets: [],
         };
         groupMap.set(key, group);

--- a/packages/frontend/src/components/exercise/SetRow.tsx
+++ b/packages/frontend/src/components/exercise/SetRow.tsx
@@ -13,6 +13,8 @@ interface SetRowProps {
   onRemove?: () => void;
   showVariation?: boolean;
   isRemovable?: boolean;
+  isActive?: boolean;
+  onActivate?: () => void;
 }
 
 export function SetRow({
@@ -28,15 +30,35 @@ export function SetRow({
   onRemove,
   showVariation = false,
   isRemovable = true,
+  isActive = false,
+  onActivate,
 }: SetRowProps) {
   const estimatedRM = calculateRM(weight, reps);
 
   return (
-    <div className="py-2 border-b border-gray-100 last:border-b-0">
+    <div
+      className={`py-2 pr-1 border-b border-gray-100 last:border-b-0 border-l-4 transition-colors ${
+        isActive
+          ? 'border-l-orange-500 bg-orange-50 rounded-r-md'
+          : 'border-l-transparent'
+      }`}
+    >
       <div className="flex items-center gap-2">
         {/* Set Number */}
-        <div className="w-8 text-center text-sm font-medium text-gray-500">
-          {setNumber}
+        <div className="w-8 flex justify-center">
+          <button
+            type="button"
+            onClick={onActivate}
+            aria-pressed={isActive}
+            aria-label={`セット${setNumber}を実行中にする`}
+            className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
+              isActive
+                ? 'bg-orange-600 text-white'
+                : 'text-gray-500 hover:bg-gray-200'
+            }`}
+          >
+            {setNumber}
+          </button>
         </div>
 
         {/* Reps Input */}

--- a/packages/frontend/src/components/exercise/StrengthInput.tsx
+++ b/packages/frontend/src/components/exercise/StrengthInput.tsx
@@ -65,6 +65,8 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
   const [customExerciseName, setCustomExerciseName] = useState('');
   const [sets, setSets] = useState<SetInput[]>([{ reps: 10, weight: null }]);
   const [validationError, setValidationError] = useState<string | null>(null);
+  // Index of the set currently being performed. null = 実行中のセットなし
+  const [activeSetIndex, setActiveSetIndex] = useState<number | null>(null);
 
   const actualExerciseType = showCustomInput ? customExerciseName : exerciseType;
 
@@ -118,6 +120,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
         variation: record.variation || undefined,
       }));
       setSets(newSets);
+      setActiveSetIndex(null);
     } else if (lastRecord) {
       // Fallback: copy single record to first set
       const newSets = [...sets];
@@ -140,7 +143,16 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
   const removeSet = (index: number) => {
     if (sets.length > 1) {
       setSets(sets.filter((_, i) => i !== index));
+      // 削除で後続セットの番号が繰り上がるので、追従させる
+      setActiveSetIndex((prev) => {
+        if (prev === null || prev === index) return null;
+        return prev > index ? prev - 1 : prev;
+      });
     }
+  };
+
+  const handleActivateSet = (index: number) => {
+    setActiveSetIndex((prev) => (prev === index ? null : index));
   };
 
   const updateSet = (index: number, field: keyof SetInput, value: number | string | null) => {
@@ -200,6 +212,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
     setExerciseType('');
     setCustomExerciseName('');
     setSets([{ reps: 10, weight: null }]);
+    setActiveSetIndex(null);
     setShowCustomInput(false);
     setSuccessMessage('運動を記録しました');
     setTimeout(() => setSuccessMessage(null), 3000);
@@ -256,6 +269,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
       weight: s.weight,
       variation: s.variation || undefined,
     })));
+    setActiveSetIndex(null);
 
     setSuccessMessage(`「${firstExercise.exerciseType}」のセット構成を取り込みました`);
     setTimeout(() => setSuccessMessage(null), 3000);
@@ -421,6 +435,8 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
               onMemoChange={(memo) => updateSet(index, 'memo', memo)}
               onRemove={() => removeSet(index)}
               isRemovable={sets.length > 1}
+              isActive={activeSetIndex === index}
+              onActivate={() => handleActivateSet(index)}
             />
           ))}
         </div>

--- a/packages/frontend/src/hooks/useExercises.ts
+++ b/packages/frontend/src/hooks/useExercises.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/client';
+import { getTodayDateString } from '../lib/dateValidation';
 import type {
   CreateExerciseSetsInput,
   UpdateExerciseInput,
@@ -15,6 +16,7 @@ interface UseExercisesOptions {
 
 export function useExercises(options?: UseExercisesOptions) {
   const queryClient = useQueryClient();
+  const todayDate = getTodayDateString();
 
   const exercisesQuery = useQuery({
     queryKey: ['exercises', options],
@@ -35,12 +37,14 @@ export function useExercises(options?: UseExercisesOptions) {
   });
 
   const weeklySummaryQuery = useQuery({
-    queryKey: ['exercises', 'weekly-summary'],
+    queryKey: ['exercises', 'weekly-summary', todayDate],
     queryFn: async () => {
-      const res = await api.exercises.weekly.$get();
+      const res = await api.exercises.weekly.$get({ query: { todayDate } });
       if (!res.ok) {
         const error = await res.json().catch(() => ({ message: 'Failed to fetch weekly summary' }));
-        throw new Error((error as { message?: string }).message || 'Failed to fetch weekly summary');
+        throw new Error(
+          (error as { message?: string }).message || 'Failed to fetch weekly summary'
+        );
       }
       return res.json();
     },

--- a/packages/frontend/src/lib/dateValidation.ts
+++ b/packages/frontend/src/lib/dateValidation.ts
@@ -66,12 +66,16 @@ export function toDateTimeLocal(isoString: string): string {
  * 今日の日付をYYYY-MM-DD形式で取得（ローカルタイムゾーン）
  * @returns "YYYY-MM-DD" 形式の文字列
  */
-export function getTodayDateString(): string {
-  const now = new Date();
+export function getTodayDateString(now = new Date()): string {
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
   const day = String(now.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+/** Offset-aware ISO stringに記録されたローカル日付を取得する。 */
+export function extractLocalDate(dateTime: string): string {
+  return dateTime.slice(0, 10);
 }
 
 /**

--- a/packages/frontend/src/lib/training-image-transform.ts
+++ b/packages/frontend/src/lib/training-image-transform.ts
@@ -86,9 +86,6 @@ export function transformToImageData(
  * @returns Formatted date string (e.g., "2026/01/02")
  */
 export function formatDateForImage(dateStr: string): string {
-  const date = new Date(dateStr);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const [year, month, day] = dateStr.slice(0, 10).split('-');
   return `${year}/${month}/${day}`;
 }

--- a/packages/frontend/src/pages/Exercise.tsx
+++ b/packages/frontend/src/pages/Exercise.tsx
@@ -4,12 +4,13 @@ import { StrengthInput } from '../components/exercise/StrengthInput';
 import { ExerciseList } from '../components/exercise/ExerciseList';
 import { ExerciseSummary } from '../components/exercise/ExerciseSummary';
 import { RestTimer } from '../components/exercise/RestTimer';
+import { getTodayDateString } from '../lib/dateValidation';
 
 export function Exercise() {
   const navigate = useNavigate();
 
   // Get today's date for the image generation link
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayDateString();
 
   const {
     exercises,

--- a/packages/frontend/src/pages/exercise/TrainingImagePage.tsx
+++ b/packages/frontend/src/pages/exercise/TrainingImagePage.tsx
@@ -5,6 +5,7 @@ import { useShareImage } from '../../hooks/useShareImage';
 import { TrainingImagePreview, type ColorTheme } from '../../components/exercise/TrainingImagePreview';
 import { ShareButton } from '../../components/exercise/ShareButton';
 import { SaveButton } from '../../components/exercise/SaveButton';
+import { getTodayDateString } from '../../lib/dateValidation';
 
 const colorOptions: { value: ColorTheme; label: string; bgClass: string }[] = [
   { value: 'blue', label: '青', bgClass: 'bg-blue-600' },
@@ -24,7 +25,7 @@ function TrainingImagePage() {
 
   // Get date from URL params (default to today)
   const dateParam = searchParams.get('date');
-  const date = dateParam || new Date().toISOString().split('T')[0] || '';
+  const date = dateParam || getTodayDateString();
 
   // Ref for the image preview element
   const imageRef = useRef<HTMLDivElement>(null);

--- a/tests/unit/dateValidation.test.ts
+++ b/tests/unit/dateValidation.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   validateNotFuture,
   getCurrentDateTimeLocal,
+  getTodayDateString,
+  extractLocalDate,
   toISOString,
   toDateTimeLocal,
 } from '../../packages/frontend/src/lib/dateValidation';
@@ -63,6 +65,26 @@ describe('dateValidation', () => {
       const result = getCurrentDateTimeLocal();
       expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
     });
+  });
+
+  describe('getTodayDateString', () => {
+    it('UTC文字列ではなくローカル日付のgetterを使用する', () => {
+      const now = new Date('2026-01-16T15:30:00Z');
+      vi.spyOn(now, 'getFullYear').mockReturnValue(2026);
+      vi.spyOn(now, 'getMonth').mockReturnValue(0);
+      vi.spyOn(now, 'getDate').mockReturnValue(17);
+
+      expect(getTodayDateString(now)).toBe('2026-01-17');
+    });
+  });
+
+  describe('extractLocalDate', () => {
+    it.each(['2026-01-17T00:30:00+09:00', '2026-01-17T23:30:00-05:00'])(
+      'オフセットにかかわらず記録されたローカル日付を返す: %s',
+      (recordedAt) => {
+        expect(extractLocalDate(recordedAt)).toBe('2026-01-17');
+      }
+    );
   });
 
   describe('toISOString', () => {

--- a/tests/unit/exercise.service.test.ts
+++ b/tests/unit/exercise.service.test.ts
@@ -52,7 +52,19 @@ describe('ExerciseService', () => {
   });
 
   describe('getWeeklySummary', () => {
-    it.todo('should calculate total sets and reps for the week');
+    it('queries exactly seven local dates and returns the inclusive range', async () => {
+      const service = new ExerciseService(mockDb as never);
+      const findByUserId = vi.spyOn(service, 'findByUserId').mockResolvedValue([]);
+
+      const result = await service.getWeeklySummary('user-123', '2026-01-14');
+
+      expect(findByUserId).toHaveBeenCalledWith('user-123', {
+        startDate: '2026-01-11',
+        endDate: '2026-01-17',
+      });
+      expect(result.weekStart).toBe('2026-01-11');
+      expect(result.weekEnd).toBe('2026-01-17');
+    });
 
     it.todo('should group exercises by type with sets and reps');
 
@@ -63,6 +75,29 @@ describe('ExerciseService', () => {
     it.todo('should return the last record for a specific exercise type');
 
     it.todo('should return null if no records exist for the type');
+  });
+
+  describe('getLastSessionByType', () => {
+    it.each(['2026-01-17T00:30:00+09:00', '2026-01-17T23:30:00-05:00'])(
+      'queries the local date encoded in %s',
+      async (recordedAt) => {
+        const service = new ExerciseService(mockDb as never);
+        vi.spyOn(service, 'getLastByType').mockResolvedValue({ recordedAt } as never);
+        const findByUserId = vi.spyOn(service, 'findByUserId').mockResolvedValue([
+          { id: 'set-2', setNumber: 2 },
+          { id: 'set-1', setNumber: 1 },
+        ] as never);
+
+        const result = await service.getLastSessionByType('user-123', 'スクワット');
+
+        expect(findByUserId).toHaveBeenCalledWith('user-123', {
+          startDate: '2026-01-17',
+          endDate: '2026-01-17',
+          exerciseType: 'スクワット',
+        });
+        expect(result.map((record) => record.id)).toEqual(['set-1', 'set-2']);
+      }
+    );
   });
 
   describe('update', () => {

--- a/tests/unit/localDate.test.ts
+++ b/tests/unit/localDate.test.ts
@@ -1,11 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { extractLocalDate, nextLocalDate } from '../../packages/backend/src/lib/localDate';
+import {
+  extractLocalDate,
+  getWeekDateRange,
+  nextLocalDate,
+} from '../../packages/backend/src/lib/localDate';
 
 describe('extractLocalDate', () => {
   it('takes the first 10 chars (local date) of an offset-aware ISO string', () => {
     expect(extractLocalDate('2026-01-17T08:00:00+09:00')).toBe('2026-01-17');
+    expect(extractLocalDate('2026-01-17T23:30:00-05:00')).toBe('2026-01-17');
     expect(extractLocalDate('2026-01-16T23:00:00Z')).toBe('2026-01-16');
     expect(extractLocalDate('2026-01-17')).toBe('2026-01-17');
+  });
+});
+
+describe('getWeekDateRange', () => {
+  it('returns an inclusive Sunday-through-Saturday range', () => {
+    expect(getWeekDateRange('2026-01-14')).toEqual({
+      startDate: '2026-01-11',
+      endDate: '2026-01-17',
+    });
+  });
+
+  it('keeps Sunday and Saturday in the same seven-day range', () => {
+    expect(getWeekDateRange('2026-01-11')).toEqual({
+      startDate: '2026-01-11',
+      endDate: '2026-01-17',
+    });
+    expect(getWeekDateRange('2026-01-17')).toEqual({
+      startDate: '2026-01-11',
+      endDate: '2026-01-17',
+    });
+  });
+
+  it('handles month and year boundaries', () => {
+    expect(getWeekDateRange('2026-01-01')).toEqual({
+      startDate: '2025-12-28',
+      endDate: '2026-01-03',
+    });
   });
 });
 

--- a/tests/unit/training-image-transform.test.ts
+++ b/tests/unit/training-image-transform.test.ts
@@ -152,6 +152,13 @@ describe('formatDateForImage', () => {
     expect(formatDateForImage('2026-01-02')).toBe('2026/01/02');
   });
 
+  it.each(['2026-01-17T00:30:00+09:00', '2026-01-17T23:30:00-05:00'])(
+    'should preserve the recorded local date for %s',
+    (recordedAt) => {
+      expect(formatDateForImage(recordedAt)).toBe('2026/01/17');
+    }
+  );
+
   it('should pad single digit months and days', () => {
     expect(formatDateForImage('2026-03-05')).toBe('2026/03/05');
   });


### PR DESCRIPTION
## 概要

運動画面まわりの2つの変更をまとめています。

### 1. issue #150: 運動記録の日付処理の混在を修正
運動記録でローカル日付とUTC日付が混在する問題を修正。`localDate` / `dateValidation` / `training-image-transform` とバックエンドのサービス層・ルートを整合させました。ユニットテストも追加済み。

Closes #150

### 2. 実行中セットのフォーカス表示（新機能）
筋トレ記録で「今どのセットを実行中か」が分かるように、セット番号をタップ可能なバッジにしました。選択したセットは番号のオレンジ丸バッジ・行の薄オレンジ背景・左端のオレンジバーで強調されます。再タップで解除できます。

## テスト
- `pnpm typecheck` 通過（shared/backend/frontend）
- `pnpm lint` 問題なし（既存の無関係warning 1件のみ）
- `pnpm test:unit` 231 passed / 56 todo / 2 skipped

## 備考
- DBスキーマ変更（migrations）なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)