### PR TITLE
fix: 食事タイプの時刻推測をユーザーのローカル時刻基準に修正

### DIFF
--- a/packages/backend/src/services/ai-analysis.ts
+++ b/packages/backend/src/services/ai-analysis.ts
@@ -432,12 +432,35 @@ export class AIAnalysisService {
 }
 
 /**
+ * Extract the user's local wall-clock hour (0-23) from an ISO 8601 string
+ * that carries a timezone offset (e.g. "2026-07-18T18:00:00+09:00").
+ *
+ * Why this exists: Cloudflare Workers runs in UTC, so `new Date(iso).getHours()`
+ * returns the UTC hour, not the user's local hour. For JST 18:00 that would be 9,
+ * making inferMealType() wrongly pick "breakfast". We must honor the offset that
+ * `toLocalISOString` embedded in the string instead of relying on the runtime TZ.
+ *
+ * @param isoString ISO 8601 string with an offset (falls back to UTC hour if none)
+ * @returns hour in 0-23 range
+ */
+export function getLocalHour(isoString: string): number {
+  // The user's wall-clock time is embedded directly in the string (the "18" in
+  // "2026-07-18T18:00:00+09:00"), so reading it needs no offset arithmetic and
+  // is immune to the runtime timezone.
+  const match = isoString.match(/T(\d{2}):/);
+  if (match) {
+    return parseInt(match[1]!, 10);
+  }
+  // Malformed / no time component: best-effort fallback.
+  return new Date(isoString).getUTCHours();
+}
+
+/**
  * Infer meal type from current time (T006).
  * 6-10 → breakfast, 11-14 → lunch, 17-21 → dinner, else → snack
  */
 function inferMealType(currentTime?: string): 'breakfast' | 'lunch' | 'dinner' | 'snack' {
-  const date = currentTime ? new Date(currentTime) : new Date();
-  const hour = date.getHours();
+  const hour = currentTime ? getLocalHour(currentTime) : new Date().getHours();
 
   if (hour >= 6 && hour < 10) {
     return 'breakfast';

--- a/tests/unit/ai-analysis.service.test.ts
+++ b/tests/unit/ai-analysis.service.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../packages/backend/src/lib/ai-provider', () => ({
 }));
 
 // Import service after mocks
-import { AIAnalysisService } from '../../packages/backend/src/services/ai-analysis';
+import { AIAnalysisService, getLocalHour } from '../../packages/backend/src/services/ai-analysis';
 
 describe('AIAnalysisService', () => {
   let service: AIAnalysisService;
@@ -130,4 +130,33 @@ describe('AIAnalysisService', () => {
   // - Calculating totals (tested above)
   // - Handling non-food detection
   // - Error handling for API failures
+
+  describe('getLocalHour', () => {
+    // Regression guard: Cloudflare Workers runs in UTC, so getHours() would
+    // return the UTC hour. getLocalHour must honor the offset in the string.
+    it('returns the local wall-clock hour for a JST (+09:00) evening', () => {
+      // JST 18:00 == UTC 09:00. getUTCHours() would wrongly return 9 (breakfast).
+      expect(getLocalHour('2026-07-18T18:00:00+09:00')).toBe(18);
+    });
+
+    it('returns the local hour for a JST morning', () => {
+      expect(getLocalHour('2026-07-18T08:00:00+09:00')).toBe(8);
+    });
+
+    it('honors a negative offset (America/New_York -04:00)', () => {
+      expect(getLocalHour('2026-07-18T18:00:00-04:00')).toBe(18);
+    });
+
+    it('handles a UTC (Z) string', () => {
+      expect(getLocalHour('2026-07-18T09:00:00Z')).toBe(9);
+    });
+
+    it('handles a naive (offset-less) string', () => {
+      expect(getLocalHour('2026-07-18T18:00:00')).toBe(18);
+    });
+
+    it('handles midnight boundary', () => {
+      expect(getLocalHour('2026-07-18T00:30:00+09:00')).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

食事記録の「食事タイプ (時刻から推測)」が、時刻を反映せず誤ったタイプになる不具合を修正。スクリーンショットでは JST 18:00 なのに「朝食」と表示されていた。

## 原因

`inferMealType` が `new Date(currentTime).getHours()` を使用。Cloudflare Workers は **UTC 実行**のため、`"2026-07-18T18:00:00+09:00"`（JST 18:00 = UTC 09:00）から `getHours()` が **9** を返し、`6〜10時 → breakfast` にマッチしていた。

隣接する「記録日時」は `formatDateWithOffset` でオフセットを尊重していたため正しく 18:00 表示され、非対称なバグになっていた。

## 修正

- ISO文字列に埋め込まれた壁掛け時刻を直接読む `getLocalHour(isoString)` を新設。実行環境の TZ に依存せずユーザーのローカル時刻で hour を取得する。
- `inferMealType` をこれ経由に変更。

## 動作確認

- TZ=UTC（Workers相当）で旧ロジックが hour=9 → 朝食 とバグ再現することを確認。
- 新コードを TZ=UTC で実物 import した単体テスト 12/12 パス（`getLocalHour("...T18:00:00+09:00") === 18`）。
- 回帰テスト6件を追加（JST夕方/朝、負オフセット(NY)、`Z`、naive、深夜0時境界）。
- `pnpm typecheck` 全3パッケージ成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)