### PR TITLE
feat: 記録データをread-onlyで公開するMCPサーバーを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,3 +168,26 @@ curl "http://localhost:8799/__scheduled?cron=0+15+*+*+*"
 Service Workerは `registerType: 'prompt'` 方式（`packages/frontend/vite.config.ts`）。新バージョンのデプロイ後、開いているタブには `PwaUpdatePrompt`（`components/ui/PwaUpdatePrompt.tsx`）が「新しいバージョンがあります」バナーを表示し、「更新」でSKIP_WAITING→リロードする。無条件の `skipWaiting()` は行わない。
 
 また、ログアウト時（明示的ログアウトと401自動ログアウトの両方）にSWの `api-cache` を削除する（`lib/clearApiCache.ts`）。キャッシュ名は vite.config.ts の `cacheName` と一致させること。
+
+## MCP Server (外部AIクライアント連携)
+
+記録データ（体重・食事・運動）を **read-only の MCPツール** として公開し、Claude Code などのMCPクライアントから自然言語で参照できる。
+
+- **エンドポイント**: `POST /api/mcp`（`packages/backend/src/routes/mcp.ts`）。`@hono/mcp` の `StreamableHTTPTransport` + `@modelcontextprotocol/sdk` の `McpServer` を使い、リクエスト毎にステートレスにサーバーを組み立てる（Workers向け）。
+- **公開ツール**: `get_latest_weight` / `get_weight_trend` / `get_daily_summary` / `get_meals`。いずれも既存サービス層（`WeightService` / `MealService` / `ExerciseService`）を認証済みユーザーにスコープして直呼びする。出力はLLM向けにトークン効率重視で要約する。
+- **認証**: 個人用Bearerトークン（`middleware/mcpAuth.ts`）。`Authorization: Bearer <token>` を `mcp_tokens` 表のSHA-256ハッシュと照合し、`c.set('user', …)` を cookie セッションの `authMiddleware` と同形で積むため下流は無改修。OAuthは使わない。
+- **トークン発行はパスキー step-up 必須**（`routes/mcp-tokens.ts`）。発行操作時に新鮮なWebAuthnアサーション（本人のパスキー）を検証してからミントする。平文トークンは発行時に1回だけ返し、以降は `prefix` のみ表示。個別失効可（`revoked_at`）。UIは設定画面「MCP連携」（`components/mcp/McpTokenManagement.tsx`）。
+- **接続方法（ヘッドレスLinuxのClaude Code等）**: 設定画面で発行 → 表示された `claude mcp add --transport http lifestyle <origin>/api/mcp --header "Authorization: Bearer <token>"` を実行。パスキーもブラウザも不要（ランタイムはトークン1本）。
+
+新規env varは不要（WebAuthnの `RP_ID` / `RP_ORIGIN` を流用）。スキーマは `mcp_tokens`（`db/schema/mcp.ts`, migration `0039`）で `passkey_credentials` に倣う（TEXT id / ISO8601 / user cascade）。
+
+ローカル疎通確認:
+```bash
+pnpm --filter @lifestyle-app/backend db:migrate:local   # 0039適用
+pnpm dev:backend                                        # localhost:8787
+# mcp_tokens に token_hash=SHA256(raw) の行を1件seedし、Accept に text/event-stream を含めて:
+curl -X POST http://localhost:8787/api/mcp \
+  -H "Authorization: Bearer <raw>" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```

--- a/packages/backend/migrations/0039_add_mcp_tokens.sql
+++ b/packages/backend/migrations/0039_add_mcp_tokens.sql
@@ -1,0 +1,22 @@
+-- Migration 0039: MCP access tokens (personal, passkey-gated issuance)
+--
+-- Long-lived bearer tokens for remote MCP clients (e.g. headless Claude Code)
+-- to authenticate to /api/mcp. Only the SHA-256 hash is stored so a leaked DB
+-- cannot be replayed; `prefix` is the first plain chars for UI display only.
+-- Individually revocable via revoked_at (no secret rotation needed).
+--
+-- Follows passkey_credentials (schema/webauthn.ts): TEXT id PK (exposed in the
+-- revoke API), TEXT ISO8601 timestamps, per-user cascade delete.
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  name TEXT,
+  prefix TEXT NOT NULL,
+  last_used_at TEXT,
+  revoked_at TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_token_hash ON mcp_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_mcp_token_user_id ON mcp_tokens(user_id);

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,8 +23,10 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.2",
+    "@hono/mcp": "^0.3.1",
     "@hono/zod-validator": "^0.2.0",
     "@lifestyle-app/shared": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@simplewebauthn/server": "^13.3.0",
     "ai": "^6.0.5",
     "bcryptjs": "^2.4.3",

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -260,3 +260,6 @@ export * from './schema/email';
 
 // WebAuthn / Passkey tables
 export * from './schema/webauthn';
+
+// MCP access tokens
+export * from './schema/mcp';

--- a/packages/backend/src/db/schema/mcp.ts
+++ b/packages/backend/src/db/schema/mcp.ts
@@ -1,0 +1,44 @@
+/**
+ * MCP access token schema (Drizzle ORM).
+ *
+ * Personal, long-lived bearer tokens used by remote MCP clients (e.g. a headless
+ * Claude Code) to authenticate to `/api/mcp`. Issuance is gated by a fresh
+ * passkey (WebAuthn) step-up in the web app; the token itself then carries every
+ * MCP request with no further interactive auth.
+ *
+ * Only the SHA-256 hash of the token is stored (like the email/password token
+ * family) — a leaked DB cannot be replayed. `prefix` keeps the first few plain
+ * characters purely so the UI can show which token is which. Tokens are
+ * individually revocable via `revoked_at` (no secret rotation needed).
+ *
+ * Datetime convention (#105): timestamps here are TEXT ISO8601, matching the
+ * closest analog table `passkey_credentials` (schema/webauthn.ts) — both are
+ * per-user auth rows surfaced in the settings UI with a name + last_used_at.
+ * Primary-key convention (#106): TEXT (nanoid), because the id is exposed to the
+ * client in the revoke API (`DELETE /api/mcp/tokens/:id`).
+ */
+import { sqliteTable, text, index, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import { users } from '../schema';
+
+export const mcpTokens = sqliteTable(
+  'mcp_tokens',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    tokenHash: text('token_hash').notNull().unique(),
+    name: text('name'),
+    prefix: text('prefix').notNull(),
+    lastUsedAt: text('last_used_at'),
+    revokedAt: text('revoked_at'),
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => ({
+    tokenHashIdx: uniqueIndex('idx_mcp_token_hash').on(table.tokenHash),
+    userIdIdx: index('idx_mcp_token_user_id').on(table.userId),
+  })
+);
+
+export type McpToken = typeof mcpTokens.$inferSelect;
+export type NewMcpToken = typeof mcpTokens.$inferInsert;

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -13,6 +13,8 @@ import { user } from './routes/user';
 import { logs } from './routes/logs';
 import { mealAnalysis } from './routes/meal-analysis';
 import { mealChat } from './routes/meal-chat';
+import { mcp } from './routes/mcp';
+import { mcpTokens } from './routes/mcp-tokens';
 import { emailVerify } from './routes/email/verify';
 import { emailChange } from './routes/email/change';
 import { requestContext } from './middleware/requestContext';
@@ -125,6 +127,8 @@ const routes = app
   .route('/api/exercises', exercises)
   .route('/api/dashboard', dashboard)
   .route('/api/user', user)
+  .route('/api/mcp/tokens', mcpTokens)
+  .route('/api/mcp', mcp)
   .route('/api/logs', logs)
   .route('/api/email', emailVerify)
   .route('/api/email', emailChange);

--- a/packages/backend/src/middleware/mcpAuth.ts
+++ b/packages/backend/src/middleware/mcpAuth.ts
@@ -1,0 +1,50 @@
+/**
+ * MCP bearer-token auth middleware.
+ *
+ * Remote MCP clients (e.g. a headless Claude Code) send a personal token as
+ * `Authorization: Bearer <token>`. This resolves it to the owning user and sets
+ * `c.set('user', …)` in the SAME shape as the cookie-session `authMiddleware`,
+ * so every downstream service call is scoped to that user with no changes.
+ *
+ * Fails closed with 401 + WWW-Authenticate (Bearer) on any missing/invalid
+ * token — the format MCP clients expect for an auth challenge.
+ */
+import type { Context, Next } from 'hono';
+import { eq } from 'drizzle-orm';
+import { schema } from '../db';
+import { verifyMcpToken } from '../services/mcp-token';
+
+function unauthorized(c: Context) {
+  return c.json({ message: 'MCPトークンが無効です' }, 401, {
+    'WWW-Authenticate': 'Bearer realm="mcp", error="invalid_token"',
+  });
+}
+
+export async function mcpAuth(c: Context, next: Next) {
+  const header = c.req.header('Authorization');
+  const token =
+    header && header.startsWith('Bearer ') ? header.slice('Bearer '.length).trim() : null;
+
+  if (!token) {
+    return unauthorized(c);
+  }
+
+  const db = c.get('db');
+  const userId = await verifyMcpToken(db, token);
+  if (!userId) {
+    return unauthorized(c);
+  }
+
+  const user = await db
+    .select({ id: schema.users.id, email: schema.users.email })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .get();
+
+  if (!user) {
+    return unauthorized(c);
+  }
+
+  c.set('user', user);
+  await next();
+}

--- a/packages/backend/src/routes/mcp-tokens.ts
+++ b/packages/backend/src/routes/mcp-tokens.ts
@@ -1,0 +1,160 @@
+/**
+ * MCP token management API (cookie-session authenticated).
+ *
+ * Lets the logged-in user mint, list, and revoke the personal bearer tokens
+ * that remote MCP clients use against `/api/mcp`. Minting is gated by a fresh
+ * passkey step-up: the caller must present a live WebAuthn assertion tied to
+ * their own account, so a stolen web session alone cannot create a token.
+ *
+ * The raw token is returned exactly once (from POST /) and never again — only
+ * its hash is stored (services/mcp-token).
+ */
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import {
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  AuthenticatorTransportFuture,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+import { authMiddleware } from '../middleware/auth';
+import { AppError } from '../middleware/error';
+import type { Database } from '../db';
+import {
+  saveChallenge,
+  getAndDeleteChallenge,
+  getCredentialsByUserId,
+  getCredentialByCredentialId,
+  updateCredentialCounter,
+  base64urlToUint8Array,
+} from '../services/webauthn.service';
+import { createMcpToken, listMcpTokens, revokeMcpToken } from '../services/mcp-token';
+
+type Bindings = {
+  DB: D1Database;
+  ENVIRONMENT: string;
+  SESSION_SECRET?: string;
+  RP_ID: string;
+  RP_NAME: string;
+  RP_ORIGIN: string;
+};
+
+type Variables = {
+  db: Database;
+  user: { id: string; email: string };
+};
+
+const issueSchema = z.object({
+  name: z.string().max(100).optional(),
+  // AuthenticationResponseJSON from @simplewebauthn/browser; validated by the
+  // WebAuthn ceremony below rather than by shape here.
+  response: z.any(),
+});
+
+export const mcpTokens = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  // Step 1: request a passkey challenge for the step-up before issuing a token.
+  .post('/challenge', authMiddleware, async (c) => {
+    const db = c.get('db');
+    const user = c.get('user');
+
+    const credentials = await getCredentialsByUserId(db, user.id);
+    if (credentials.length === 0) {
+      throw new AppError(
+        'トークン発行にはパスキーの登録が必要です',
+        400,
+        'NO_PASSKEY'
+      );
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: c.env.RP_ID,
+      allowCredentials: credentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports
+          ? (JSON.parse(cred.transports) as AuthenticatorTransportFuture[])
+          : undefined,
+      })),
+      userVerification: 'preferred',
+    });
+
+    await saveChallenge(db, {
+      userId: user.id,
+      challenge: options.challenge,
+      type: 'authentication',
+    });
+
+    return c.json(options);
+  })
+  // Step 2: verify the assertion and mint a token. Returns the raw token once.
+  .post('/', authMiddleware, zValidator('json', issueSchema), async (c) => {
+    const { name, response } = c.req.valid('json');
+    const db = c.get('db');
+    const user = c.get('user');
+
+    const authResponse = response as unknown as AuthenticationResponseJSON;
+    const credentialRow = await getCredentialByCredentialId(db, authResponse.id);
+    // The presented passkey must belong to the logged-in user — otherwise a
+    // stolen session could mint a token using someone else's authenticator.
+    if (!credentialRow || credentialRow.userId !== user.id) {
+      throw new AppError('パスキーの検証に失敗しました', 401, 'WEBAUTHN_AUTH_FAILED');
+    }
+
+    const verification = await verifyAuthenticationResponse({
+      response: authResponse,
+      expectedChallenge: async (challenge) => {
+        const record = await getAndDeleteChallenge(db, challenge);
+        return (
+          record !== null &&
+          record.type === 'authentication' &&
+          record.userId === user.id
+        );
+      },
+      expectedOrigin: c.env.RP_ORIGIN,
+      expectedRPID: c.env.RP_ID,
+      credential: {
+        id: credentialRow.credentialId,
+        publicKey: base64urlToUint8Array(credentialRow.publicKey) as Uint8Array<ArrayBuffer>,
+        counter: credentialRow.counter,
+        transports: credentialRow.transports
+          ? (JSON.parse(credentialRow.transports) as AuthenticatorTransportFuture[])
+          : undefined,
+      },
+    });
+
+    if (!verification.verified) {
+      throw new AppError('パスキー認証に失敗しました', 401, 'WEBAUTHN_AUTH_FAILED');
+    }
+
+    await updateCredentialCounter(
+      db,
+      credentialRow.credentialId,
+      verification.authenticationInfo.newCounter
+    );
+
+    const created = await createMcpToken(db, user.id, name);
+    return c.json(created, 201);
+  })
+  .get('/', authMiddleware, async (c) => {
+    const db = c.get('db');
+    const user = c.get('user');
+    const tokens = await listMcpTokens(db, user.id);
+    return c.json({ tokens });
+  })
+  .delete('/:id', authMiddleware, async (c) => {
+    const db = c.get('db');
+    const user = c.get('user');
+    const id = c.req.param('id');
+
+    const revoked = await revokeMcpToken(db, id, user.id);
+    if (!revoked) {
+      throw new AppError(
+        'トークンが見つからないか、既に失効済みです',
+        404,
+        'MCP_TOKEN_NOT_FOUND'
+      );
+    }
+    return c.json({ success: true });
+  });

--- a/packages/backend/src/routes/mcp.ts
+++ b/packages/backend/src/routes/mcp.ts
@@ -1,0 +1,173 @@
+/**
+ * MCP server route (Streamable HTTP transport).
+ *
+ * Exposes the user's lifestyle data as read-only MCP tools so a remote client
+ * (e.g. a headless Claude Code) can query it in natural language. Auth is a
+ * personal bearer token (mcpAuth) — no OAuth, no per-request passkey. Each tool
+ * calls the existing service layer directly, scoped to the authenticated user.
+ *
+ * Stateless pattern (fits Cloudflare Workers): a fresh McpServer + transport is
+ * built per request, bound to that request's authenticated user via closure.
+ */
+import { Hono } from 'hono';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPTransport } from '@hono/mcp';
+import { z } from 'zod';
+import { MEAL_TYPE_LABELS } from '@lifestyle-app/shared';
+import type { Database } from '../db';
+import { mcpAuth } from '../middleware/mcpAuth';
+import { WeightService } from '../services/weight';
+import { MealService } from '../services/meal';
+import { ExerciseService } from '../services/exercise';
+
+type Bindings = {
+  DB: D1Database;
+};
+
+/** Wrap a plain string as an MCP text tool result. */
+function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+/**
+ * Summarize weight records into a compact, LLM-friendly string.
+ *
+ * The MCP consumer is an LLM, so the goal is a short, information-dense summary
+ * rather than a raw row dump — this keeps token cost low and interpretation
+ * accurate. `records` come newest-first (WeightService.findByUserId orders by
+ * recordedAt desc); each has at least { weight: number; recordedAt: string }.
+ */
+function summarizeWeightTrend(
+  records: Array<{ weight: number; recordedAt: string }>
+): string {
+  if (records.length === 0) {
+    return '対象期間に体重の記録はありません。';
+  }
+
+  const count = records.length;
+  const latest = records[0]!;
+  const start = records[count - 1]!;
+  const values = records.map((r) => r.weight);
+  const avg = values.reduce((sum, w) => sum + w, 0) / count;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const delta = latest.weight - start.weight;
+  const dir = Math.abs(delta) < 0.1 ? '横ばい' : delta < 0 ? '減少' : '増加';
+  const sign = delta > 0 ? '+' : '';
+  const localDate = (iso: string) => iso.slice(0, 10);
+
+  return [
+    `体重推移（${localDate(start.recordedAt)}〜${localDate(latest.recordedAt)}, ${count}件）`,
+    `開始 ${start.weight}kg → 最新 ${latest.weight}kg（${sign}${delta.toFixed(1)}kg, ${dir}）`,
+    `平均 ${avg.toFixed(1)}kg / 最小 ${min}kg / 最大 ${max}kg`,
+  ].join('\n');
+}
+
+/** Build a per-request MCP server whose tools are scoped to `userId`. */
+function buildMcpServer(db: Database, userId: string): McpServer {
+  const server = new McpServer({
+    name: 'lifestyle-app',
+    version: '1.0.0',
+  });
+
+  server.registerTool(
+    'get_latest_weight',
+    { description: '最新の体重記録を1件返す。' },
+    async () => {
+    const latest = await new WeightService(db).getLatest(userId);
+    if (!latest) {
+      return textResult('体重の記録はまだありません。');
+    }
+    return textResult(`最新体重: ${latest.weight}kg（記録日時: ${latest.recordedAt}）`);
+    }
+  );
+
+  server.registerTool(
+    'get_weight_trend',
+    {
+      description:
+        '指定期間の体重推移を要約して返す。from / to は YYYY-MM-DD（含む）。省略時は全期間。',
+      inputSchema: {
+        from: z.string().optional().describe('開始日 YYYY-MM-DD（含む）'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD（含む）'),
+      },
+    },
+    async ({ from, to }) => {
+      const records = await new WeightService(db).findByUserId(userId, {
+        startDate: from,
+        endDate: to,
+      });
+      return textResult(summarizeWeightTrend(records));
+    }
+  );
+
+  server.registerTool(
+    'get_daily_summary',
+    {
+      description: '指定日の体重・食事カロリー・栄養・運動をまとめて返す。date は YYYY-MM-DD。',
+      inputSchema: {
+        date: z.string().describe('対象日 YYYY-MM-DD'),
+      },
+    },
+    async ({ date }) => {
+      const range = { startDate: date, endDate: date };
+      const [meal, exercise, dayWeights] = await Promise.all([
+        new MealService(db).getCalorieSummary(userId, range),
+        new ExerciseService(db).getSummary(userId, range),
+        new WeightService(db).findByUserId(userId, range),
+      ]);
+      const weight = dayWeights[0];
+
+      const lines = [
+        `【${date} のサマリー】`,
+        `体重: ${weight ? `${weight.weight}kg` : '記録なし'}`,
+        `食事: ${meal.totalMeals}件 / 合計${meal.totalCalories}kcal（P${Math.round(
+          meal.totalProtein
+        )} F${Math.round(meal.totalFat)} C${Math.round(meal.totalCarbs)}g）`,
+        `運動: ${exercise.totalSets}セット / ${exercise.totalReps}回`,
+      ];
+      return textResult(lines.join('\n'));
+    }
+  );
+
+  server.registerTool(
+    'get_meals',
+    {
+      description:
+        '指定日（date）または from〜to 期間の食事記録を一覧で返す。すべて YYYY-MM-DD。',
+      inputSchema: {
+        date: z.string().optional().describe('対象日 YYYY-MM-DD（単日指定）'),
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+      },
+    },
+    async ({ date, from, to }) => {
+      const meals = await new MealService(db).findByUserId(userId, {
+        startDate: date ?? from,
+        endDate: date ?? to,
+      });
+      if (meals.length === 0) {
+        return textResult('対象期間に食事の記録はありません。');
+      }
+      const lines = meals.map((m) => {
+        const label =
+          MEAL_TYPE_LABELS[m.mealType as keyof typeof MEAL_TYPE_LABELS] ?? m.mealType;
+        const kcal = m.calories != null ? `${m.calories}kcal` : 'カロリー未計算';
+        return `- ${m.recordedAt} [${label}] ${m.content ?? ''} (${kcal})`;
+      });
+      return textResult(lines.join('\n'));
+    }
+  );
+
+  return server;
+}
+
+export const mcp = new Hono<{ Bindings: Bindings }>().all('/', mcpAuth, async (c) => {
+  const db = c.get('db');
+  const user = c.get('user');
+
+  const server = buildMcpServer(db, user.id);
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});

--- a/packages/backend/src/services/mcp-token.ts
+++ b/packages/backend/src/services/mcp-token.ts
@@ -1,0 +1,137 @@
+/**
+ * MCP access token service.
+ *
+ * Issues and verifies personal bearer tokens used by remote MCP clients to
+ * authenticate to `/api/mcp`. The raw token is shown to the user exactly once at
+ * creation; only its SHA-256 hash is stored (reusing services/token/crypto), so
+ * a leaked DB cannot be replayed. Tokens are individually revocable.
+ *
+ * The token carries no per-request interactive auth — issuance itself is gated
+ * by a passkey step-up in the token API route (routes/mcp-tokens.ts).
+ */
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { Database } from '../db';
+import { schema } from '../db';
+import { generateSecureToken, hashToken } from './token/crypto';
+
+/** Prefix that marks a string as an MCP token (also aids quick rejection). */
+const TOKEN_PREFIX = 'mcp_';
+/** How many leading chars of the raw token to keep in plaintext for UI display. */
+const DISPLAY_PREFIX_LEN = 12;
+
+export interface CreatedMcpToken {
+  id: string;
+  /** Plaintext token — returned only here, never stored or shown again. */
+  token: string;
+  name: string | null;
+  prefix: string;
+  createdAt: string;
+}
+
+export interface McpTokenSummary {
+  id: string;
+  name: string | null;
+  prefix: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+/** Mint a new token for `userId` and persist only its hash. */
+export async function createMcpToken(
+  db: Database,
+  userId: string,
+  name?: string | null
+): Promise<CreatedMcpToken> {
+  const raw = `${TOKEN_PREFIX}${await generateSecureToken()}`;
+  const tokenHash = await hashToken(raw);
+  const id = uuidv4();
+  const createdAt = new Date().toISOString();
+  const prefix = raw.slice(0, DISPLAY_PREFIX_LEN);
+
+  await db.insert(schema.mcpTokens).values({
+    id,
+    userId,
+    tokenHash,
+    name: name ?? null,
+    prefix,
+    lastUsedAt: null,
+    revokedAt: null,
+    createdAt,
+  });
+
+  return { id, token: raw, name: name ?? null, prefix, createdAt };
+}
+
+/**
+ * Resolve a raw bearer token to its owning userId, or null if the token is
+ * malformed, unknown, or revoked. Best-effort-updates last_used_at.
+ */
+export async function verifyMcpToken(db: Database, rawToken: string): Promise<string | null> {
+  if (!rawToken.startsWith(TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const tokenHash = await hashToken(rawToken);
+  const row = await db
+    .select()
+    .from(schema.mcpTokens)
+    .where(eq(schema.mcpTokens.tokenHash, tokenHash))
+    .get();
+
+  if (!row || row.revokedAt) {
+    return null;
+  }
+
+  await db
+    .update(schema.mcpTokens)
+    .set({ lastUsedAt: new Date().toISOString() })
+    .where(eq(schema.mcpTokens.id, row.id))
+    .run();
+
+  return row.userId;
+}
+
+/** List a user's tokens (secret hash never included), newest first. */
+export async function listMcpTokens(db: Database, userId: string): Promise<McpTokenSummary[]> {
+  const rows = await db
+    .select()
+    .from(schema.mcpTokens)
+    .where(eq(schema.mcpTokens.userId, userId))
+    .orderBy(desc(schema.mcpTokens.createdAt))
+    .all();
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    prefix: r.prefix,
+    lastUsedAt: r.lastUsedAt,
+    revokedAt: r.revokedAt,
+    createdAt: r.createdAt,
+  }));
+}
+
+/**
+ * Revoke an active token owned by `userId`. Returns false when no active token
+ * matched (unknown id, not owner, or already revoked) so the route can 404.
+ */
+export async function revokeMcpToken(
+  db: Database,
+  id: string,
+  userId: string
+): Promise<boolean> {
+  const result = await db
+    .update(schema.mcpTokens)
+    .set({ revokedAt: new Date().toISOString() })
+    .where(
+      and(
+        eq(schema.mcpTokens.id, id),
+        eq(schema.mcpTokens.userId, userId),
+        isNull(schema.mcpTokens.revokedAt)
+      )
+    )
+    .run();
+
+  return (result.meta?.changes ?? 0) > 0;
+}

--- a/packages/frontend/src/components/mcp/McpTokenManagement.tsx
+++ b/packages/frontend/src/components/mcp/McpTokenManagement.tsx
@@ -1,0 +1,240 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import type { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser';
+import { api } from '../../lib/client';
+import { useToast } from '../ui/Toast';
+
+interface IssuedToken {
+  token: string;
+  command: string;
+}
+
+/**
+ * MCP access token management.
+ *
+ * Issuing a token requires a fresh passkey step-up (the backend verifies a live
+ * WebAuthn assertion before minting). The raw token is shown exactly once, along
+ * with a ready-to-paste `claude mcp add` command; afterwards only its prefix is
+ * visible. Tokens are individually revocable.
+ */
+export function McpTokenManagement() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [newName, setNewName] = useState('');
+  const [issued, setIssued] = useState<IssuedToken | null>(null);
+  const [revokeTargetId, setRevokeTargetId] = useState<string | null>(null);
+
+  const isSupported = browserSupportsWebAuthn();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mcp', 'tokens'],
+    queryFn: async () => {
+      const res = await api.mcp.tokens.$get();
+      if (!res.ok) throw new Error('Failed to fetch MCP tokens');
+      return res.json();
+    },
+  });
+
+  const issueMutation = useMutation({
+    mutationFn: async (name?: string) => {
+      // Step-up passkey: obtain a challenge, prove a live assertion, then mint.
+      const optRes = await api.mcp.tokens.challenge.$post();
+      if (!optRes.ok) {
+        const err = (await optRes.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? 'パスキー認証の準備に失敗しました');
+      }
+      const options = (await optRes.json()) as PublicKeyCredentialRequestOptionsJSON;
+      const response = await startAuthentication({ optionsJSON: options });
+
+      const res = await api.mcp.tokens.$post({
+        json: { name, response: response as unknown as Record<string, unknown> },
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? 'トークン発行に失敗しました');
+      }
+      return res.json();
+    },
+    onSuccess: (created) => {
+      const mcpUrl = `${window.location.origin}/api/mcp`;
+      const command = `claude mcp add --transport http lifestyle ${mcpUrl} --header "Authorization: Bearer ${created.token}"`;
+      setIssued({ token: created.token, command });
+      setNewName('');
+      queryClient.invalidateQueries({ queryKey: ['mcp', 'tokens'] });
+    },
+    onError: (err) => {
+      // User-cancelled passkey prompt (NotAllowedError) is silent.
+      if (err instanceof Error && err.name === 'NotAllowedError') return;
+      toast.error(err instanceof Error ? err.message : 'トークン発行に失敗しました');
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.mcp.tokens[':id'].$delete({ param: { id } });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { message?: string };
+        throw new Error(err.message ?? '失効に失敗しました');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['mcp', 'tokens'] });
+      setRevokeTargetId(null);
+      toast.success('トークンを失効しました');
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : '失効に失敗しました');
+    },
+  });
+
+  const tokens = data?.tokens ?? [];
+
+  const copyCommand = async () => {
+    if (!issued) return;
+    try {
+      await navigator.clipboard.writeText(issued.command);
+      toast.success('コマンドをコピーしました');
+    } catch {
+      toast.error('コピーに失敗しました');
+    }
+  };
+
+  return (
+    <div className="card p-5">
+      <h2 className="mb-1 text-sm font-semibold text-gray-900">MCP連携</h2>
+      <p className="mb-3 text-xs text-gray-500">
+        アクセストークンを発行すると、Claude Code などのMCPクライアントから体重・食事・運動データを参照できます。
+      </p>
+
+      {!isSupported && (
+        <p className="mb-3 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          このブラウザはパスキー(WebAuthn)に非対応のため、トークンを発行できません。パスキー対応ブラウザで開いてください。
+        </p>
+      )}
+
+      {isLoading ? (
+        <p className="text-xs text-gray-400">読み込み中...</p>
+      ) : tokens.length === 0 ? (
+        <p className="mb-4 text-xs text-gray-500">発行済みのトークンはありません。</p>
+      ) : (
+        <ul className="mb-4 space-y-2">
+          {tokens.map((t) => {
+            const revoked = !!t.revokedAt;
+            return (
+              <li
+                key={t.id}
+                className="flex items-center justify-between rounded-lg border border-gray-100 bg-gray-50 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p
+                    className={`truncate text-sm font-medium ${
+                      revoked ? 'text-gray-400 line-through' : 'text-gray-900'
+                    }`}
+                  >
+                    {t.name || '名称未設定'}
+                    <span className="ml-2 font-mono text-[10px] text-gray-400">{t.prefix}…</span>
+                  </p>
+                  <p className="text-[10px] text-gray-400">
+                    {revoked
+                      ? `失効済み ${new Date(t.revokedAt as string).toLocaleDateString('ja-JP')}`
+                      : t.lastUsedAt
+                        ? `最終使用 ${new Date(t.lastUsedAt).toLocaleDateString('ja-JP')}`
+                        : '未使用'}
+                  </p>
+                </div>
+                {!revoked && (
+                  <button
+                    onClick={() => setRevokeTargetId(t.id)}
+                    className="ml-2 shrink-0 rounded-md border border-red-200 bg-white px-2 py-1 text-xs text-red-600 hover:bg-red-50 transition-colors"
+                  >
+                    失効
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-gray-600">新しいトークン</label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="例: headless-linux"
+            maxLength={100}
+            className="flex-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+          />
+          <button
+            onClick={() => issueMutation.mutate(newName.trim() || undefined)}
+            disabled={!isSupported || issueMutation.isPending}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {issueMutation.isPending ? 'パスキー認証中...' : 'トークンを発行'}
+          </button>
+        </div>
+      </div>
+
+      {issued && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-lg card p-6">
+            <h3 className="text-base font-semibold text-gray-900">トークンを発行しました</h3>
+            <p className="mt-2 text-sm text-amber-700">
+              このトークンは一度しか表示されません。今すぐコピーして安全な場所に保管してください。
+            </p>
+            <div className="mt-4">
+              <p className="mb-1 text-xs font-medium text-gray-600">接続コマンド (Claude Code)</p>
+              <pre className="overflow-x-auto rounded-lg bg-gray-900 p-3 text-[11px] leading-relaxed text-gray-100">
+                {issued.command}
+              </pre>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={copyCommand}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+              >
+                コマンドをコピー
+              </button>
+              <button
+                onClick={() => setIssued(null)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {revokeTargetId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-sm card p-6">
+            <h3 className="text-base font-semibold text-gray-900">このトークンを失効しますか?</h3>
+            <p className="mt-2 text-sm text-gray-500">
+              失効すると、このトークンを使っているMCPクライアントは接続できなくなります。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setRevokeTargetId(null)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => revokeTargetId && revokeMutation.mutate(revokeTargetId)}
+                disabled={revokeMutation.isPending}
+                className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {revokeMutation.isPending ? '失効中...' : '失効する'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/client';
 import { useAuthStore } from '../stores/authStore';
 import { PasskeyManagement } from '../components/auth/PasskeyManagement';
+import { McpTokenManagement } from '../components/mcp/McpTokenManagement';
 
 export function Settings() {
   const navigate = useNavigate();
@@ -188,6 +189,9 @@ export function Settings() {
 
       {/* Passkey Management */}
       <PasskeyManagement />
+
+      {/* MCP Integration */}
+      <McpTokenManagement />
 
       {/* Goals Section */}
       <div className="card p-5">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,12 +53,18 @@ importers:
       '@ai-sdk/google':
         specifier: ^3.0.2
         version: 3.0.2(zod@3.25.76)
+      '@hono/mcp':
+        specifier: ^0.3.1
+        version: 0.3.1(@modelcontextprotocol/sdk@1.29.0)(hono-rate-limiter@0.5.3)(hono@4.11.3)(zod@3.25.76)
       '@hono/zod-validator':
         specifier: ^0.2.0
         version: 0.2.2(hono@4.11.3)(zod@3.25.76)
       '@lifestyle-app/shared':
         specifier: workspace:*
         version: link:../shared
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@simplewebauthn/server':
         specifier: ^13.3.0
         version: 13.3.0
@@ -2343,6 +2349,30 @@ packages:
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
     dev: false
 
+  /@hono/mcp@0.3.1(@modelcontextprotocol/sdk@1.29.0)(hono-rate-limiter@0.5.3)(hono@4.11.3)(zod@3.25.76):
+    resolution: {integrity: sha512-EB2rTyyl27qT8KtvEysgfcLK2jhp4KBb5+XyJ5/bcKNA64usp6qyuUWja9X4QB8Rx9U/yhZHGpfI96Xa/jem4Q==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      hono: '*'
+      hono-rate-limiter: ^0.5.3
+      zod: ^3.25.0 || ^4.0.0
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      hono: 4.11.3
+      hono-rate-limiter: 0.5.3(hono@4.11.3)
+      pkce-challenge: 5.0.1
+      zod: 3.25.76
+    dev: false
+
+  /@hono/node-server@1.19.14(hono@4.12.31):
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.12.31
+    dev: false
+
   /@hono/zod-validator@0.2.2(hono@4.11.3)(zod@3.25.76):
     resolution: {integrity: sha512-dSDxaPV70Py8wuIU2QNpoVEIOSzSXZ/6/B/h4xA7eOMz7+AarKTSGV8E6QwrdcCbBLkpqfJ4Q2TmBO0eP1tCBQ==}
     peerDependencies:
@@ -2649,6 +2679,37 @@ packages:
 
   /@levischuck/tiny-cbor@0.2.11:
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+    dev: false
+
+  /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.31
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@napi-rs/wasm-runtime@1.1.1:
@@ -3638,6 +3699,14 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3683,6 +3752,17 @@ packages:
       zod: 3.25.76
     dev: false
 
+  /ajv-formats@3.0.1(ajv@8.17.1):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.17.1
+    dev: false
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -3699,7 +3779,6 @@ packages:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    dev: true
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3944,6 +4023,23 @@ packages:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
     dev: true
 
+  /body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
     dependencies:
@@ -3980,6 +4076,11 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -3991,7 +4092,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
 
   /call-bind@1.0.8:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
@@ -4009,7 +4109,6 @@ packages:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -4142,20 +4241,47 @@ packages:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
 
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+    dev: false
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+    dev: false
+
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /core-js-compat@3.47.0:
     resolution: {integrity: sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==}
     dependencies:
       browserslist: 4.28.1
     dev: true
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
 
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4164,7 +4290,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -4241,7 +4366,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -4279,6 +4403,11 @@ packages:
   /defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
     dev: true
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4469,11 +4598,14 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
 
   /ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -4494,6 +4626,11 @@ packages:
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -4568,12 +4705,10 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
@@ -4602,7 +4737,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -4804,6 +4938,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -4976,6 +5114,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
     dependencies:
@@ -4986,6 +5129,13 @@ packages:
   /eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.0.6
     dev: false
 
   /execa@8.0.1:
@@ -5008,6 +5158,55 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /express-rate-limit@8.6.0(express@5.2.1):
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
     dev: true
@@ -5024,7 +5223,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5047,7 +5245,6 @@ packages:
 
   /fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-    dev: true
 
   /fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5093,6 +5290,20 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -5137,9 +5348,19 @@ packages:
       fd-package-json: 2.0.0
     dev: true
 
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
     dev: true
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -5173,7 +5394,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
@@ -5219,7 +5439,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -5231,7 +5450,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
@@ -5346,7 +5564,6 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -5389,7 +5606,6 @@ packages:
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
@@ -5403,14 +5619,30 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /heap@0.2.7:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: true
 
+  /hono-rate-limiter@0.5.3(hono@4.11.3):
+    resolution: {integrity: sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==}
+    peerDependencies:
+      hono: ^4.10.8
+      unstorage: ^1.17.3
+    peerDependenciesMeta:
+      unstorage:
+        optional: true
+    dependencies:
+      hono: 4.11.3
+    dev: false
+
   /hono@4.11.3:
     resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
+  /hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -5442,10 +5674,28 @@ packages:
       entities: 4.5.0
     dev: false
 
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    dev: false
+
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
     dev: true
+
+  /iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
 
   /idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -5479,7 +5729,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -5489,6 +5738,16 @@ packages:
       hasown: 2.0.2
       side-channel: 1.1.0
     dev: true
+
+  /ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+    dev: false
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -5643,6 +5902,10 @@ packages:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
     dev: true
 
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
+
   /is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -5730,7 +5993,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
 
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5804,6 +6066,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5843,7 +6109,10 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: true
+
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    dev: false
 
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -6031,7 +6300,11 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: true
+
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /memoizee@0.4.17:
     resolution: {integrity: sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==}
@@ -6046,6 +6319,11 @@ packages:
       next-tick: 1.1.0
       timers-ext: 0.1.8
     dev: true
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+    dev: false
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -6063,6 +6341,18 @@ packages:
       braces: 3.0.3
       picomatch: 2.3.1
     dev: true
+
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
 
   /mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -6143,7 +6433,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -6174,6 +6463,11 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: true
@@ -6197,7 +6491,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -6207,7 +6500,6 @@ packages:
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -6260,11 +6552,17 @@ packages:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
     dev: true
 
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -6358,6 +6656,11 @@ packages:
       peberminta: 0.9.0
     dev: false
 
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -6371,7 +6674,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -6393,6 +6695,10 @@ packages:
   /path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
     dev: true
+
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -6438,6 +6744,11 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
     dev: true
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
 
   /pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -6585,6 +6896,14 @@ packages:
       react-is: 16.13.1
     dev: true
 
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -6601,6 +6920,14 @@ packages:
     engines: {node: '>=16.0.0'}
     dev: false
 
+  /qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -6610,6 +6937,21 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
     dev: true
+
+  /range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+    dev: false
 
   /react-chartjs-2@5.3.1(chart.js@4.5.1)(react@18.3.1):
     resolution: {integrity: sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==}
@@ -6769,7 +7111,6 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /resend@4.8.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==}
@@ -6883,6 +7224,19 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -6921,6 +7275,10 @@ packages:
       is-regex: 1.2.1
     dev: true
 
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
   /scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
@@ -6944,11 +7302,42 @@ packages:
     hasBin: true
     dev: true
 
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
       randombytes: 2.1.0
     dev: true
+
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6980,6 +7369,10 @@ packages:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
     dev: true
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
 
   /sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -7017,12 +7410,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7032,6 +7423,14 @@ packages:
       object-inspect: 1.13.4
     dev: true
 
+  /side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
   /side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -7040,7 +7439,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
   /side-channel-weakmap@1.0.2:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
@@ -7051,7 +7449,6 @@ packages:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    dev: true
 
   /side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
@@ -7063,6 +7460,17 @@ packages:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
     dev: true
+
+  /side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    dev: false
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -7139,6 +7547,11 @@ packages:
       as-table: 1.0.55
       get-source: 2.0.12
     dev: true
+
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -7429,6 +7842,11 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
@@ -7484,6 +7902,15 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
 
   /type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
@@ -7610,6 +8037,11 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -7647,6 +8079,11 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+    dev: false
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /vite-node@1.6.1(@types/node@20.19.27):
@@ -7861,7 +8298,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -8089,7 +8525,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -8125,6 +8560,14 @@ packages:
       mustache: 4.2.0
       stacktracey: 2.1.8
     dev: true
+
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 3.25.76
+    dev: false
 
   /zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}


### PR DESCRIPTION
## 概要

体重・食事・運動データを **read-only の MCPツール** として公開し、Claude Code などのMCPクライアントから自然言語で参照できるようにする。

## 変更点

**バックエンド**
- `POST /api/mcp`（`@hono/mcp` の Streamable HTTP、リクエスト毎ステートレス）+ read-onlyツール4本
  - `get_latest_weight` / `get_weight_trend` / `get_daily_summary` / `get_meals`
  - 既存サービス層（`WeightService` / `MealService` / `ExerciseService`）を認証済みユーザーにスコープして直呼び。出力はLLM向けにトークン効率重視で要約
- `middleware/mcpAuth.ts` — 個人用Bearerトークン。`Authorization: Bearer` を `mcp_tokens` のSHA-256ハッシュと照合し、既存 `authMiddleware` と**同形**で `user` を積むため下流は無改修。**OAuthは使わない**
- `routes/mcp-tokens.ts` — 発行/一覧/失効。**発行時にパスキー step-up（新鮮なWebAuthnアサーション検証）必須**。平文トークンは発行時1回のみ返却、個別失効可
- `db/schema/mcp.ts` + migration `0039` — `mcp_tokens` 表（`passkey_credentials` 準拠: TEXT id / ISO8601 / user cascade）

**フロントエンド**
- 設定画面「MCP連携」（`components/mcp/McpTokenManagement.tsx`）— パスキー認証→発行→`claude mcp add` コマンド生成、一覧、失効

## 認証設計

- パスキーは**トークン発行のゲート**として使用（ランタイムの毎リクエストには使わない = ヘッドレス環境で完結）
- ランタイムは静的Bearerトークン1本。ブラウザ・パスキー・OAuth不要
- 新規env varなし（WebAuthnの `RP_ID` / `RP_ORIGIN` を流用）

## 動作確認（ローカル）

- 認証: トークン無し / 不正トークン → どちらも 401
- MCP: `initialize` → serverInfo `lifestyle-app`、`tools/list` → 4ツール、`tools/call` → 実データで正しい要約を返却
- `pnpm typecheck`（全3パッケージ）・`pnpm lint`（新規ファイル0件）クリーン

## デプロイ時の注意

⚠ **PR Previewはマイグレーション自動実行されない** ため、preview D1（`0039`）への手動適用が必要。本番デプロイ時も `0039` の適用が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)