### PR TITLE
fix: MCPツールの時刻表示をJSTに正規化（Z/+09:00混在に対応）

### DIFF
--- a/packages/backend/src/lib/localDate.ts
+++ b/packages/backend/src/lib/localDate.ts
@@ -32,6 +32,51 @@ export function nextLocalDate(localDate: string): string {
   return d.toISOString().slice(0, 10);
 }
 
+/** Japan Standard Time is a fixed UTC+9 (no DST) — the app's implicit local zone. */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function jstParts(iso: string): { y: number; mo: number; d: number; h: number; mi: number } | null {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  // Shift the absolute instant by +9h, then read UTC fields to get JST wall clock.
+  const t = new Date(ms + JST_OFFSET_MS);
+  return {
+    y: t.getUTCFullYear(),
+    mo: t.getUTCMonth() + 1,
+    d: t.getUTCDate(),
+    h: t.getUTCHours(),
+    mi: t.getUTCMinutes(),
+  };
+}
+
+/**
+ * Normalize any ISO timestamp to a JST wall-clock string "YYYY-MM-DD HH:mm".
+ *
+ * Most recorded_at values carry a "+09:00" offset and pass through unchanged in
+ * wall-clock terms; a few legacy rows are stored as bare UTC "Z" (pre-#159) and
+ * would otherwise display 9 hours early. Parsing to an absolute instant and
+ * re-rendering at +09:00 makes both forms consistent. Falls back to the raw
+ * input if unparseable.
+ */
+export function toJstDisplay(iso: string): string {
+  const p = jstParts(iso);
+  if (!p) return iso;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${p.y}-${pad(p.mo)}-${pad(p.d)} ${pad(p.h)}:${pad(p.mi)}`;
+}
+
+/**
+ * The JST local date (YYYY-MM-DD) of any ISO timestamp, whether it is offset-aware
+ * ("+09:00") or bare UTC ("Z"). Unlike extractLocalDate (which trusts the string's
+ * first 10 chars and is therefore wrong for "Z" rows), this converts to JST first.
+ */
+export function extractJstDate(iso: string): string {
+  const p = jstParts(iso);
+  if (!p) return iso.slice(0, 10);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${p.y}-${pad(p.mo)}-${pad(p.d)}`;
+}
+
 /** Sunday-through-Saturday range containing the supplied local date. */
 export function getWeekDateRange(localDate: string): { startDate: string; endDate: string } {
   const date = new Date(`${extractLocalDate(localDate)}T00:00:00Z`);

--- a/packages/backend/src/routes/mcp.ts
+++ b/packages/backend/src/routes/mcp.ts
@@ -15,6 +15,7 @@ import { StreamableHTTPTransport } from '@hono/mcp';
 import { z } from 'zod';
 import { MEAL_TYPE_LABELS } from '@lifestyle-app/shared';
 import type { Database } from '../db';
+import { toJstDisplay, extractJstDate } from '../lib/localDate';
 import { mcpAuth } from '../middleware/mcpAuth';
 import { WeightService } from '../services/weight';
 import { MealService } from '../services/meal';
@@ -54,10 +55,9 @@ function summarizeWeightTrend(
   const delta = latest.weight - start.weight;
   const dir = Math.abs(delta) < 0.1 ? '横ばい' : delta < 0 ? '減少' : '増加';
   const sign = delta > 0 ? '+' : '';
-  const localDate = (iso: string) => iso.slice(0, 10);
 
   return [
-    `体重推移（${localDate(start.recordedAt)}〜${localDate(latest.recordedAt)}, ${count}件）`,
+    `体重推移（${extractJstDate(start.recordedAt)}〜${extractJstDate(latest.recordedAt)}, ${count}件）`,
     `開始 ${start.weight}kg → 最新 ${latest.weight}kg（${sign}${delta.toFixed(1)}kg, ${dir}）`,
     `平均 ${avg.toFixed(1)}kg / 最小 ${min}kg / 最大 ${max}kg`,
   ].join('\n');
@@ -78,7 +78,7 @@ function buildMcpServer(db: Database, userId: string): McpServer {
     if (!latest) {
       return textResult('体重の記録はまだありません。');
     }
-    return textResult(`最新体重: ${latest.weight}kg（記録日時: ${latest.recordedAt}）`);
+    return textResult(`最新体重: ${latest.weight}kg（記録日時: ${toJstDisplay(latest.recordedAt)}）`);
     }
   );
 
@@ -153,7 +153,7 @@ function buildMcpServer(db: Database, userId: string): McpServer {
         const label =
           MEAL_TYPE_LABELS[m.mealType as keyof typeof MEAL_TYPE_LABELS] ?? m.mealType;
         const kcal = m.calories != null ? `${m.calories}kcal` : 'カロリー未計算';
-        return `- ${m.recordedAt} [${label}] ${m.content ?? ''} (${kcal})`;
+        return `- ${toJstDisplay(m.recordedAt)} [${label}] ${m.content ?? ''} (${kcal})`;
       });
       return textResult(lines.join('\n'));
     }

--- a/packages/backend/tests/unit/localDate.test.ts
+++ b/packages/backend/tests/unit/localDate.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractLocalDate,
+  nextLocalDate,
+  toJstDisplay,
+  extractJstDate,
+} from '../../src/lib/localDate';
+
+describe('extractLocalDate / nextLocalDate', () => {
+  it('takes the first 10 chars as the local date', () => {
+    expect(extractLocalDate('2026-07-17T08:00:00+09:00')).toBe('2026-07-17');
+  });
+
+  it('nextLocalDate returns the following day', () => {
+    expect(nextLocalDate('2026-07-17')).toBe('2026-07-18');
+    expect(nextLocalDate('2026-07-31T23:59:59+09:00')).toBe('2026-08-01');
+  });
+});
+
+describe('toJstDisplay', () => {
+  it('passes an offset-aware "+09:00" timestamp through in wall-clock terms', () => {
+    expect(toJstDisplay('2026-07-19T08:43:28+09:00')).toBe('2026-07-19 08:43');
+  });
+
+  it('converts a bare-UTC "Z" timestamp to JST (+9h)', () => {
+    // 03:57 UTC -> 12:57 JST, same day
+    expect(toJstDisplay('2026-07-17T03:57:09.564Z')).toBe('2026-07-17 12:57');
+  });
+
+  it('converts a "Z" timestamp across the date boundary', () => {
+    // 20:00 UTC on 07-16 -> 05:00 JST on 07-17
+    expect(toJstDisplay('2026-07-16T20:00:00Z')).toBe('2026-07-17 05:00');
+  });
+
+  it('returns the raw input when unparseable', () => {
+    expect(toJstDisplay('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('extractJstDate', () => {
+  it('matches the string prefix for "+09:00" timestamps', () => {
+    expect(extractJstDate('2026-07-17T22:00:00+09:00')).toBe('2026-07-17');
+  });
+
+  it('converts a "Z" timestamp to the correct JST date across the boundary', () => {
+    // 20:00 UTC on 07-16 is 05:00 JST on 07-17 — extractLocalDate would wrongly say 07-16
+    expect(extractLocalDate('2026-07-16T20:00:00Z')).toBe('2026-07-16');
+    expect(extractJstDate('2026-07-16T20:00:00Z')).toBe('2026-07-17');
+  });
+});


### PR DESCRIPTION
## 背景

本番のMCPツール `get_meals` を叩いたところ、一部の食事記録の時刻が **UTC「Z」形式**（例: `2026-07-17T03:57:09.564Z`）、他は `+09:00` 形式で混在しており、Z形式のものが実時刻より **9時間早く** 表示されていた。`meal_records.recorded_at` にレガシー行（#159以前）が残っていることに由来する。

## 変更

- `lib/localDate.ts` に表示正規化ヘルパーを追加
  - `toJstDisplay(iso)` — 任意のISO（`+09:00` / `Z` 両対応）を JST 壁掛けの `YYYY-MM-DD HH:mm` に正規化
  - `extractJstDate(iso)` — 同様にJSTローカル日付へ（`extractLocalDate` はZ行で誤るため）
- `routes/mcp.ts` に適用
  - `get_latest_weight`・`get_meals` の時刻表示
  - `get_weight_trend` の日付範囲表示
- ユニットテスト追加（Z→JST変換・日付境界跨ぎ・不正入力フォールバック）

## スコープ

クエリ側のフィルタ挙動（`extractLocalDate` による範囲絞り込み）はアプリ全体の規約に関わるため**変更していない**。今回はMCPツールの**表示**正規化に限定。根本のデータ修正（Z行の +09:00 化）は別途検討。

## 確認

- `pnpm --filter @lifestyle-app/backend typecheck` クリーン
- `vitest run tests/unit/localDate.test.ts` → 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)