### PR TITLE
feat: 健康コーチング向けMCP分析ツールを6種追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,14 @@ Service Workerは `registerType: 'prompt'` 方式（`packages/frontend/vite.conf
 記録データ（体重・食事・運動）を **read-only の MCPツール** として公開し、Claude Code などのMCPクライアントから自然言語で参照できる。
 
 - **エンドポイント**: `POST /api/mcp`（`packages/backend/src/routes/mcp.ts`）。`@hono/mcp` の `StreamableHTTPTransport` + `@modelcontextprotocol/sdk` の `McpServer` を使い、リクエスト毎にステートレスにサーバーを組み立てる（Workers向け）。
-- **公開ツール**: `get_latest_weight` / `get_weight_trend` / `get_daily_summary` / `get_meals`。いずれも既存サービス層（`WeightService` / `MealService` / `ExerciseService`）を認証済みユーザーにスコープして直呼びする。出力はLLM向けにトークン効率重視で要約する。
+- **公開ツール**: 要約系4つ（`get_latest_weight` / `get_weight_trend` / `get_daily_summary` / `get_meals`）に加え、健康コーチング向けの分析系6つ：
+  - `get_food_items` — 食事を1品ごとに分解しP/F/C・カロリー（food item単位）
+  - `get_protein_sources` — 期間のたんぱく源を食材名で集約しランキング
+  - `get_protein_gap` — たんぱく質を目標（`target` g/食, 引数必須）と比較しギャップを食事別/日別に
+  - `get_weight_moving_average` — 体重の移動平均（既定7日, 暦日トレーリング窓）＋週平均
+  - `get_nutrition_trend` — カロリー/PFCを週別・月別に集計
+  - `get_exercise_breakdown` — 運動を部位別/種目別にセット数・回数・総重量(Σreps×kg)
+  いずれも既存サービス層（`WeightService` / `MealService` / `ExerciseService`）を認証済みユーザーにスコープして直呼びする。集計の純関数は `lib/mcpAggregate.ts`（単体テスト `tests/unit/mcpAggregate.test.ts`）、food item横断取得は `MealService.getFoodItemsByUserId`。出力はLLM向けにトークン効率重視で要約する。**分析系6ツールはread-only追加のみでスキーマ変更なし**（マイグレーション不要）。
 - **認証**: 個人用Bearerトークン（`middleware/mcpAuth.ts`）。`Authorization: Bearer <token>` を `mcp_tokens` 表のSHA-256ハッシュと照合し、`c.set('user', …)` を cookie セッションの `authMiddleware` と同形で積むため下流は無改修。OAuthは使わない。
 - **トークン発行はパスキー step-up 必須**（`routes/mcp-tokens.ts`）。発行操作時に新鮮なWebAuthnアサーション（本人のパスキー）を検証してからミントする。平文トークンは発行時に1回だけ返し、以降は `prefix` のみ表示。個別失効可（`revoked_at`）。UIは設定画面「MCP連携」（`components/mcp/McpTokenManagement.tsx`）。
 - **接続方法（ヘッドレスLinuxのClaude Code等）**: 設定画面で発行 → 表示された `claude mcp add --transport http lifestyle <origin>/api/mcp --header "Authorization: Bearer <token>"` を実行。パスキーもブラウザも不要（ランタイムはトークン1本）。

--- a/packages/backend/src/lib/mcpAggregate.ts
+++ b/packages/backend/src/lib/mcpAggregate.ts
@@ -1,0 +1,327 @@
+/**
+ * Pure aggregation helpers for the coaching-oriented MCP tools.
+ *
+ * These take rows straight from the service layer and fold them into the
+ * compact, LLM-friendly shapes the MCP tools expose (protein-source ranking,
+ * protein gap vs target, weight moving average, period nutrition, exercise by
+ * muscle group). Kept side-effect-free and DB-free so they can be unit-tested
+ * in isolation. All date bucketing goes through extractJstDate so the legacy
+ * bare-UTC "Z" rows (pre-#159) land on the correct JST day, matching the
+ * display normalization in the MCP tools themselves.
+ */
+import { extractJstDate, getWeekDateRange } from './localDate';
+
+// ---- Input row shapes (subsets of the service-layer returns) ----
+
+export interface FoodItemRow {
+  mealType: string;
+  recordedAt: string;
+  name: string;
+  calories: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+}
+
+export interface MealRow {
+  mealType: string;
+  recordedAt: string;
+  calories: number | null;
+  totalProtein: number | null;
+  totalFat: number | null;
+  totalCarbs: number | null;
+}
+
+export interface WeightRow {
+  weight: number;
+  recordedAt: string;
+}
+
+export interface ExerciseRow {
+  exerciseType: string;
+  muscleGroup: string | null;
+  reps: number;
+  weight: number | null;
+  recordedAt: string;
+}
+
+// ---- Protein-source ranking (request ①) ----
+
+export interface ProteinSource {
+  name: string;
+  count: number;
+  totalProtein: number;
+  avgProtein: number;
+  totalCalories: number;
+}
+
+/**
+ * Rank food items by the total protein they contributed over the period,
+ * aggregating by (case-insensitive, trimmed) name so "蒸し鶏" logged five times
+ * collapses into one ranked row. `top` caps the returned rows.
+ */
+export function rankProteinSources(items: FoodItemRow[], top: number): ProteinSource[] {
+  const byName = new Map<string, ProteinSource>();
+  for (const item of items) {
+    const key = item.name.trim();
+    if (key === '') continue;
+    const existing = byName.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalProtein += item.protein;
+      existing.totalCalories += item.calories;
+    } else {
+      byName.set(key, {
+        name: key,
+        count: 1,
+        totalProtein: item.protein,
+        avgProtein: 0,
+        totalCalories: item.calories,
+      });
+    }
+  }
+  const ranked = [...byName.values()].map((s) => ({
+    ...s,
+    avgProtein: s.totalProtein / s.count,
+  }));
+  ranked.sort((a, b) => b.totalProtein - a.totalProtein);
+  return ranked.slice(0, top);
+}
+
+// ---- Protein gap vs target (request ②) ----
+
+export interface MealProteinGap {
+  date: string;
+  mealType: string;
+  protein: number;
+  gap: number;
+  met: boolean;
+}
+
+export interface DayProteinGap {
+  date: string;
+  mealCount: number;
+  totalProtein: number;
+  dayTarget: number;
+  gap: number;
+  mealsMetTarget: number;
+}
+
+/**
+ * Compare each meal's protein against a per-meal `target` (grams). Meals with no
+ * analyzed protein (totalProtein null) are treated as 0 — an un-analyzed meal is
+ * still a meal that fell short of the protein goal, which is the signal the user
+ * cares about. Returns per-meal gaps plus a per-day rollup whose daily target is
+ * target × (meals that day), so the day gap is the summed per-meal shortfall.
+ */
+export function proteinGap(
+  meals: MealRow[],
+  target: number
+): { byMeal: MealProteinGap[]; byDay: DayProteinGap[] } {
+  const byMeal: MealProteinGap[] = meals.map((m) => {
+    const protein = m.totalProtein ?? 0;
+    return {
+      date: extractJstDate(m.recordedAt),
+      mealType: m.mealType,
+      protein,
+      gap: protein - target,
+      met: protein >= target,
+    };
+  });
+
+  const dayMap = new Map<string, DayProteinGap>();
+  for (const meal of byMeal) {
+    const day = dayMap.get(meal.date) ?? {
+      date: meal.date,
+      mealCount: 0,
+      totalProtein: 0,
+      dayTarget: 0,
+      gap: 0,
+      mealsMetTarget: 0,
+    };
+    day.mealCount += 1;
+    day.totalProtein += meal.protein;
+    day.dayTarget += target;
+    day.gap += meal.gap;
+    if (meal.met) day.mealsMetTarget += 1;
+    dayMap.set(meal.date, day);
+  }
+  const byDay = [...dayMap.values()].sort((a, b) => a.date.localeCompare(b.date));
+
+  return { byMeal, byDay };
+}
+
+// ---- Weight moving average (request ③) ----
+
+export interface DailyWeight {
+  date: string;
+  weight: number;
+}
+
+export interface MovingAveragePoint {
+  date: string;
+  weight: number;
+  movingAvg: number;
+}
+
+/**
+ * Collapse raw weight records to one value per JST calendar day, ascending by
+ * date. When a day has several weigh-ins we keep the LATEST one (records arrive
+ * newest-first from WeightService.findByUserId, so the first seen per day wins);
+ * this matches how the app's weekly trend picks "the latest weight in the week".
+ */
+export function dailyWeightSeries(records: WeightRow[]): DailyWeight[] {
+  const seen = new Map<string, number>();
+  for (const r of records) {
+    const date = extractJstDate(r.recordedAt);
+    if (!seen.has(date)) seen.set(date, r.weight); // newest-first ⇒ first = latest
+  }
+  return [...seen.entries()]
+    .map(([date, weight]) => ({ date, weight }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Trailing simple moving average over a daily weight series (ascending by date).
+ *
+ * The daily series is already deduped to one weight per calendar day. For each
+ * day the moving average is the mean of the weigh-ins whose date falls in the
+ * `window`-day calendar span ending on that day (inclusive) — this is the
+ * "keystone" smoothing that cancels day-to-day ±1kg noise so a real trend is
+ * visible. Design choices, all tunable via `window`:
+ *   - the window is counted in CALENDAR days, not data points, so a missed
+ *     weigh-in shortens the sample rather than reaching further back in time;
+ *   - a short leading window (fewer than `window` days of history) averages
+ *     whatever days exist, so the series starts smoothing immediately.
+ */
+export function movingAverageSeries(
+  daily: DailyWeight[],
+  window: number
+): MovingAveragePoint[] {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  return daily.map((point, i) => {
+    const cutoffMs = Date.parse(`${point.date}T00:00:00Z`) - (window - 1) * DAY_MS;
+    let sum = 0;
+    let count = 0;
+    // daily is ascending, so scan backwards from i and stop once we fall out of
+    // the calendar window.
+    for (let j = i; j >= 0; j--) {
+      if (Date.parse(`${daily[j]!.date}T00:00:00Z`) < cutoffMs) break;
+      sum += daily[j]!.weight;
+      count += 1;
+    }
+    return { date: point.date, weight: point.weight, movingAvg: sum / count };
+  });
+}
+
+export interface WeeklyWeightAverage {
+  weekStart: string;
+  weekEnd: string;
+  avg: number;
+  count: number;
+}
+
+/**
+ * Calendar-week (Sun–Sat) averages of the daily weight series. Complements the
+ * moving average with a coarser, fixed-bucket view of the same smoothing intent.
+ */
+export function weeklyWeightAverages(daily: DailyWeight[]): WeeklyWeightAverage[] {
+  const buckets = new Map<string, { weekStart: string; weekEnd: string; sum: number; count: number }>();
+  for (const d of daily) {
+    const { startDate, endDate } = getWeekDateRange(d.date);
+    const bucket = buckets.get(startDate) ?? { weekStart: startDate, weekEnd: endDate, sum: 0, count: 0 };
+    bucket.sum += d.weight;
+    bucket.count += 1;
+    buckets.set(startDate, bucket);
+  }
+  return [...buckets.values()]
+    .map((b) => ({ weekStart: b.weekStart, weekEnd: b.weekEnd, avg: b.sum / b.count, count: b.count }))
+    .sort((a, b) => a.weekStart.localeCompare(b.weekStart));
+}
+
+// ---- Period nutrition aggregation (request ④) ----
+
+export type NutritionGrouping = 'week' | 'month';
+
+export interface NutritionBucket {
+  label: string;
+  days: number;
+  meals: number;
+  totalCalories: number;
+  totalProtein: number;
+  totalFat: number;
+  totalCarbs: number;
+  avgCalories: number;
+  avgProtein: number;
+}
+
+/**
+ * Bucket meals into weeks (Sun–Sat start date as label) or calendar months
+ * (YYYY-MM) and sum calories/PFC. `days` counts distinct JST dates with a meal
+ * in the bucket, so the per-day averages reflect actual logged days rather than
+ * calendar length.
+ */
+export function nutritionTrend(meals: MealRow[], groupBy: NutritionGrouping): NutritionBucket[] {
+  const buckets = new Map<
+    string,
+    { label: string; dates: Set<string>; meals: number; cal: number; p: number; f: number; c: number }
+  >();
+  for (const m of meals) {
+    const date = extractJstDate(m.recordedAt);
+    const label = groupBy === 'week' ? getWeekDateRange(date).startDate : date.slice(0, 7);
+    const b = buckets.get(label) ?? { label, dates: new Set<string>(), meals: 0, cal: 0, p: 0, f: 0, c: 0 };
+    b.dates.add(date);
+    b.meals += 1;
+    b.cal += m.calories ?? 0;
+    b.p += m.totalProtein ?? 0;
+    b.f += m.totalFat ?? 0;
+    b.c += m.totalCarbs ?? 0;
+    buckets.set(label, b);
+  }
+  return [...buckets.values()]
+    .map((b) => {
+      const days = b.dates.size;
+      return {
+        label: b.label,
+        days,
+        meals: b.meals,
+        totalCalories: b.cal,
+        totalProtein: b.p,
+        totalFat: b.f,
+        totalCarbs: b.c,
+        avgCalories: days > 0 ? b.cal / days : 0,
+        avgProtein: days > 0 ? b.p / days : 0,
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+// ---- Exercise breakdown (request ⑤) ----
+
+export type ExerciseGrouping = 'muscle' | 'type';
+
+export interface ExerciseGroup {
+  key: string;
+  sets: number;
+  reps: number;
+  volume: number;
+}
+
+/**
+ * Group exercise records by muscle group or exercise type. Each record is one
+ * set (matching ExerciseService.getSummary). `volume` is Σ(reps × weight) over
+ * sets that carry a weight — bodyweight sets (weight null) contribute reps but
+ * no volume.
+ */
+export function exerciseBreakdown(records: ExerciseRow[], groupBy: ExerciseGrouping): ExerciseGroup[] {
+  const groups = new Map<string, ExerciseGroup>();
+  for (const r of records) {
+    const key = groupBy === 'muscle' ? r.muscleGroup ?? 'other' : r.exerciseType;
+    const g = groups.get(key) ?? { key, sets: 0, reps: 0, volume: 0 };
+    g.sets += 1;
+    g.reps += r.reps;
+    g.volume += r.weight != null ? r.reps * r.weight : 0;
+    groups.set(key, g);
+  }
+  return [...groups.values()].sort((a, b) => b.sets - a.sets);
+}

--- a/packages/backend/src/routes/mcp.ts
+++ b/packages/backend/src/routes/mcp.ts
@@ -13,9 +13,18 @@ import { Hono } from 'hono';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
 import { z } from 'zod';
-import { MEAL_TYPE_LABELS } from '@lifestyle-app/shared';
+import { MEAL_TYPE_LABELS, MUSCLE_GROUP_LABELS, type MuscleGroup } from '@lifestyle-app/shared';
 import type { Database } from '../db';
 import { toJstDisplay, extractJstDate } from '../lib/localDate';
+import {
+  rankProteinSources,
+  proteinGap,
+  dailyWeightSeries,
+  movingAverageSeries,
+  weeklyWeightAverages,
+  nutritionTrend,
+  exerciseBreakdown,
+} from '../lib/mcpAggregate';
 import { mcpAuth } from '../middleware/mcpAuth';
 import { WeightService } from '../services/weight';
 import { MealService } from '../services/meal';
@@ -29,6 +38,17 @@ type Bindings = {
 function textResult(text: string) {
   return { content: [{ type: 'text' as const, text }] };
 }
+
+/** Round to 1 decimal place for display (protein/fat/carbs grams, weights). */
+const r1 = (n: number) => (Math.round(n * 10) / 10).toFixed(1);
+/** Signed 1-decimal string, e.g. +2.5 / -1.0 / ±0.0 — for gaps vs a target. */
+const signed = (n: number) => {
+  const rounded = Math.round(n * 10) / 10;
+  if (rounded === 0) return '±0.0';
+  return `${rounded > 0 ? '+' : ''}${rounded.toFixed(1)}`;
+};
+/** Human label for a meal type, falling back to the raw value. */
+const mealLabel = (t: string) => MEAL_TYPE_LABELS[t as keyof typeof MEAL_TYPE_LABELS] ?? t;
 
 /**
  * Summarize weight records into a compact, LLM-friendly string.
@@ -150,12 +170,224 @@ function buildMcpServer(db: Database, userId: string): McpServer {
         return textResult('対象期間に食事の記録はありません。');
       }
       const lines = meals.map((m) => {
-        const label =
-          MEAL_TYPE_LABELS[m.mealType as keyof typeof MEAL_TYPE_LABELS] ?? m.mealType;
         const kcal = m.calories != null ? `${m.calories}kcal` : 'カロリー未計算';
-        return `- ${toJstDisplay(m.recordedAt)} [${label}] ${m.content ?? ''} (${kcal})`;
+        return `- ${toJstDisplay(m.recordedAt)} [${mealLabel(m.mealType)}] ${m.content ?? ''} (${kcal})`;
       });
       return textResult(lines.join('\n'));
+    }
+  );
+
+  server.registerTool(
+    'get_food_items',
+    {
+      description:
+        '指定日(date)または from〜to 期間の食事を「1品ごと」に分解し、各食材の P/F/C・カロリーを返す。すべて YYYY-MM-DD。',
+      inputSchema: {
+        date: z.string().optional().describe('対象日 YYYY-MM-DD（単日指定）'),
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+      },
+    },
+    async ({ date, from, to }) => {
+      const items = await new MealService(db).getFoodItemsByUserId(userId, {
+        startDate: date ?? from,
+        endDate: date ?? to,
+      });
+      if (items.length === 0) {
+        return textResult('対象期間に食材レベルの記録はありません。');
+      }
+      const lines = items.map(
+        (it) =>
+          `- ${extractJstDate(it.recordedAt)} ${mealLabel(it.mealType)} ${it.name}: P${r1(
+            it.protein
+          )}/F${r1(it.fat)}/C${r1(it.carbs)} ${it.calories}kcal`
+      );
+      return textResult(lines.join('\n'));
+    }
+  );
+
+  server.registerTool(
+    'get_protein_sources',
+    {
+      description:
+        '指定期間に食べた食材を「たんぱく源」として名前で集約し、累計たんぱく質の多い順にランキングして返す。date 単日 or from〜to。',
+      inputSchema: {
+        date: z.string().optional().describe('対象日 YYYY-MM-DD（単日指定）'),
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+        top: z.number().int().min(1).max(50).optional().describe('上位何件を返すか（既定10）'),
+      },
+    },
+    async ({ date, from, to, top }) => {
+      const items = await new MealService(db).getFoodItemsByUserId(userId, {
+        startDate: date ?? from,
+        endDate: date ?? to,
+      });
+      const ranked = rankProteinSources(items, top ?? 10);
+      if (ranked.length === 0) {
+        return textResult('対象期間に食材レベルの記録はありません。');
+      }
+      const lines = ranked.map(
+        (s, i) =>
+          `${i + 1}. ${s.name} — 累計P${r1(s.totalProtein)}g（${s.count}回, 平均${r1(
+            s.avgProtein
+          )}g/回, 累計${s.totalCalories}kcal）`
+      );
+      return textResult(`たんぱく源ランキング（上位${ranked.length}）\n${lines.join('\n')}`);
+    }
+  );
+
+  server.registerTool(
+    'get_protein_gap',
+    {
+      description:
+        'たんぱく質の摂取量を目標(target: 1食あたりg)と比較し、不足(ギャップ)を返す。date 単日なら食事別の内訳も付く。from〜to で期間の日別集計。',
+      inputSchema: {
+        target: z.number().positive().describe('1食あたりのたんぱく質目標(g)。例: 25'),
+        date: z.string().optional().describe('対象日 YYYY-MM-DD（単日指定）'),
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+      },
+    },
+    async ({ target, date, from, to }) => {
+      const meals = await new MealService(db).findByUserId(userId, {
+        startDate: date ?? from,
+        endDate: date ?? to,
+      });
+      if (meals.length === 0) {
+        return textResult('対象期間に食事の記録はありません。');
+      }
+      const { byMeal, byDay } = proteinGap(meals, target);
+
+      // Single day: show the per-meal breakdown, then the day rollup.
+      if (date) {
+        const mealLines = byMeal.map(
+          (m) =>
+            `  - ${mealLabel(m.mealType)}: P${r1(m.protein)}（${signed(m.gap)}, ${
+              m.met ? '達成✓' : '未達'
+            }）`
+        );
+        const d = byDay[0];
+        const dayLine = d
+          ? `日合計: P${r1(d.totalProtein)} / 目標${r1(d.dayTarget)}（${signed(d.gap)}, ${d.mealCount}食中${d.mealsMetTarget}食達成）`
+          : '';
+        return textResult(
+          `【${date} たんぱく質ギャップ】目標 ${r1(target)}g/食\n食事別:\n${mealLines.join('\n')}\n${dayLine}`
+        );
+      }
+
+      // Range: per-day rollup only (keeps output bounded for long spans).
+      const lines = byDay.map(
+        (d) =>
+          `- ${d.date}: P${r1(d.totalProtein)}/目標${r1(d.dayTarget)}（${signed(d.gap)}, ${d.mealCount}食中${d.mealsMetTarget}食達成）`
+      );
+      return textResult(`たんぱく質ギャップ（目標 ${r1(target)}g/食）\n${lines.join('\n')}`);
+    }
+  );
+
+  server.registerTool(
+    'get_weight_moving_average',
+    {
+      description:
+        '体重の移動平均(既定7日)と週平均を返す。日々±1kgのノイズを均してトレンドを評価するための「要石」。from〜to 省略時は全期間。',
+      inputSchema: {
+        from: z.string().optional().describe('開始日 YYYY-MM-DD（含む）'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD（含む）'),
+        window: z.number().int().min(2).max(30).optional().describe('移動平均の窓(日数, 既定7)'),
+      },
+    },
+    async ({ from, to, window }) => {
+      const win = window ?? 7;
+      const records = await new WeightService(db).findByUserId(userId, {
+        startDate: from,
+        endDate: to,
+      });
+      const daily = dailyWeightSeries(records);
+      if (daily.length === 0) {
+        return textResult('対象期間に体重の記録はありません。');
+      }
+      const ma = movingAverageSeries(daily, win);
+      const weekly = weeklyWeightAverages(daily);
+
+      const maLines = ma.map(
+        (p) => `- ${p.date}: ${r1(p.weight)}kg（MA${r1(p.movingAvg)}）`
+      );
+      const weeklyLines = weekly.map(
+        (w) => `- ${w.weekStart}〜${w.weekEnd}: ${r1(w.avg)}kg（${w.count}日）`
+      );
+      return textResult(
+        `体重移動平均（window=${win}日, ${daily.length}日分）\n${maLines.join(
+          '\n'
+        )}\n週平均:\n${weeklyLines.join('\n')}`
+      );
+    }
+  );
+
+  server.registerTool(
+    'get_nutrition_trend',
+    {
+      description:
+        '期間のカロリー・PFCを週別または月別に集計して推移を返す。groupBy は "week"(既定) か "month"。from〜to 省略時は全期間。',
+      inputSchema: {
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+        groupBy: z.enum(['week', 'month']).optional().describe('集計単位（既定 week）'),
+      },
+    },
+    async ({ from, to, groupBy }) => {
+      const unit = groupBy ?? 'week';
+      const meals = await new MealService(db).findByUserId(userId, {
+        startDate: from,
+        endDate: to,
+      });
+      const buckets = nutritionTrend(meals, unit);
+      if (buckets.length === 0) {
+        return textResult('対象期間に食事の記録はありません。');
+      }
+      const suffix = unit === 'week' ? '週' : '';
+      const lines = buckets.map(
+        (b) =>
+          `- ${b.label}${suffix}: ${b.days}日/${b.meals}食 計${b.totalCalories}kcal（P${r1(
+            b.totalProtein
+          )} F${r1(b.totalFat)} C${r1(b.totalCarbs)}）日平均${Math.round(b.avgCalories)}kcal P${r1(
+            b.avgProtein
+          )}`
+      );
+      return textResult(`栄養集計（${unit === 'week' ? '週別' : '月別'}）\n${lines.join('\n')}`);
+    }
+  );
+
+  server.registerTool(
+    'get_exercise_breakdown',
+    {
+      description:
+        '運動記録を部位別(muscle, 既定)または種目別(type)に集計し、セット数・回数・総重量(Σreps×kg)を返す。date 単日 or from〜to。',
+      inputSchema: {
+        date: z.string().optional().describe('対象日 YYYY-MM-DD（単日指定）'),
+        from: z.string().optional().describe('開始日 YYYY-MM-DD'),
+        to: z.string().optional().describe('終了日 YYYY-MM-DD'),
+        groupBy: z.enum(['muscle', 'type']).optional().describe('集計軸（既定 muscle）'),
+      },
+    },
+    async ({ date, from, to, groupBy }) => {
+      const axis = groupBy ?? 'muscle';
+      const records = await new ExerciseService(db).findByUserId(userId, {
+        startDate: date ?? from,
+        endDate: date ?? to,
+      });
+      const groups = exerciseBreakdown(records, axis);
+      if (groups.length === 0) {
+        return textResult('対象期間に運動の記録はありません。');
+      }
+      const lines = groups.map((g) => {
+        const label =
+          axis === 'muscle'
+            ? MUSCLE_GROUP_LABELS[g.key as MuscleGroup] ?? g.key
+            : g.key;
+        const volume = g.volume > 0 ? `, 総重量${r1(g.volume)}kg` : '';
+        return `- ${label}: ${g.sets}セット/${g.reps}回${volume}`;
+      });
+      return textResult(`運動内訳（${axis === 'muscle' ? '部位別' : '種目別'}）\n${lines.join('\n')}`);
     }
   );
 

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -170,6 +170,47 @@ export class MealService {
     };
   }
 
+  /**
+   * Fetch individual food items across a date range, scoped to one user.
+   *
+   * Food items are normally read one meal at a time (by mealId), but coaching
+   * analysis needs them across a period — protein-source ranking, per-item PFC.
+   * Drive from meal_food_items and INNER JOIN meal_records so the user/date
+   * filter lives on meal_records (recordedAt is the offset-aware local-date
+   * string, filtered with the same extractLocalDate/nextLocalDate range as the
+   * other queries). Each row carries its parent meal's context (type, time).
+   */
+  async getFoodItemsByUserId(
+    userId: string,
+    options?: { startDate?: string; endDate?: string }
+  ) {
+    const conditions = [eq(schema.mealRecords.userId, userId)];
+    if (options?.startDate) {
+      conditions.push(gte(schema.mealRecords.recordedAt, extractLocalDate(options.startDate)));
+    }
+    if (options?.endDate) {
+      conditions.push(lt(schema.mealRecords.recordedAt, nextLocalDate(options.endDate)));
+    }
+
+    return this.db
+      .select({
+        mealId: schema.mealRecords.id,
+        mealType: schema.mealRecords.mealType,
+        recordedAt: schema.mealRecords.recordedAt,
+        name: schema.mealFoodItems.name,
+        portion: schema.mealFoodItems.portion,
+        calories: schema.mealFoodItems.calories,
+        protein: schema.mealFoodItems.protein,
+        fat: schema.mealFoodItems.fat,
+        carbs: schema.mealFoodItems.carbs,
+      })
+      .from(schema.mealFoodItems)
+      .innerJoin(schema.mealRecords, eq(schema.mealFoodItems.mealId, schema.mealRecords.id))
+      .where(and(...conditions))
+      .orderBy(desc(schema.mealRecords.recordedAt))
+      .all();
+  }
+
   async update(id: string, userId: string, input: UpdateMealInput) {
     await this.findById(id, userId);
 

--- a/packages/backend/tests/unit/mcpAggregate.test.ts
+++ b/packages/backend/tests/unit/mcpAggregate.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rankProteinSources,
+  proteinGap,
+  dailyWeightSeries,
+  movingAverageSeries,
+  weeklyWeightAverages,
+  nutritionTrend,
+  exerciseBreakdown,
+  type FoodItemRow,
+  type MealRow,
+  type WeightRow,
+  type ExerciseRow,
+} from '../../src/lib/mcpAggregate';
+
+const foodItem = (over: Partial<FoodItemRow>): FoodItemRow => ({
+  mealType: 'lunch',
+  recordedAt: '2026-07-17T12:00:00+09:00',
+  name: 'x',
+  calories: 100,
+  protein: 10,
+  fat: 5,
+  carbs: 20,
+  ...over,
+});
+
+const meal = (over: Partial<MealRow>): MealRow => ({
+  mealType: 'lunch',
+  recordedAt: '2026-07-17T12:00:00+09:00',
+  calories: 500,
+  totalProtein: 20,
+  totalFat: 15,
+  totalCarbs: 60,
+  ...over,
+});
+
+describe('rankProteinSources', () => {
+  it('aggregates by name and ranks by total protein desc', () => {
+    const items = [
+      foodItem({ name: '蒸し鶏', protein: 25, calories: 200 }),
+      foodItem({ name: '蒸し鶏', protein: 25, calories: 200 }),
+      foodItem({ name: 'ゆで卵', protein: 6, calories: 70 }),
+    ];
+    const ranked = rankProteinSources(items, 10);
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0]).toMatchObject({ name: '蒸し鶏', count: 2, totalProtein: 50, avgProtein: 25, totalCalories: 400 });
+    expect(ranked[1]!.name).toBe('ゆで卵');
+  });
+
+  it('trims names, skips blank, and honors the top cap', () => {
+    const items = [
+      foodItem({ name: ' 鮭 ', protein: 22 }),
+      foodItem({ name: '鮭', protein: 22 }),
+      foodItem({ name: '   ', protein: 99 }),
+      foodItem({ name: '豆腐', protein: 8 }),
+    ];
+    const ranked = rankProteinSources(items, 1);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]).toMatchObject({ name: '鮭', count: 2, totalProtein: 44 });
+  });
+});
+
+describe('proteinGap', () => {
+  it('computes per-meal gap and met flag against the per-meal target', () => {
+    const meals = [
+      meal({ mealType: 'lunch', totalProtein: 25 }),
+      meal({ mealType: 'dinner', totalProtein: 18 }),
+    ];
+    const { byMeal } = proteinGap(meals, 25);
+    expect(byMeal[0]).toMatchObject({ mealType: 'lunch', protein: 25, gap: 0, met: true });
+    expect(byMeal[1]).toMatchObject({ mealType: 'dinner', protein: 18, gap: -7, met: false });
+  });
+
+  it('treats null protein as 0 (an un-analyzed meal still missed the goal)', () => {
+    const { byMeal, byDay } = proteinGap([meal({ totalProtein: null })], 25);
+    expect(byMeal[0]).toMatchObject({ protein: 0, gap: -25, met: false });
+    expect(byDay[0]).toMatchObject({ totalProtein: 0, dayTarget: 25, gap: -25, mealsMetTarget: 0 });
+  });
+
+  it('rolls up per day with dayTarget = target × meals that day', () => {
+    const meals = [
+      meal({ recordedAt: '2026-07-17T08:00:00+09:00', totalProtein: 30 }),
+      meal({ recordedAt: '2026-07-17T19:00:00+09:00', totalProtein: 20 }),
+      meal({ recordedAt: '2026-07-18T12:00:00+09:00', totalProtein: 25 }),
+    ];
+    const { byDay } = proteinGap(meals, 25);
+    expect(byDay).toHaveLength(2);
+    expect(byDay[0]).toMatchObject({ date: '2026-07-17', mealCount: 2, totalProtein: 50, dayTarget: 50, gap: 0, mealsMetTarget: 1 });
+    expect(byDay[1]).toMatchObject({ date: '2026-07-18', mealCount: 1, dayTarget: 25, mealsMetTarget: 1 });
+  });
+
+  it('buckets a bare-UTC "Z" meal onto the correct JST day', () => {
+    // 20:00Z on 07-16 => 05:00 JST on 07-17
+    const { byDay } = proteinGap([meal({ recordedAt: '2026-07-16T20:00:00Z', totalProtein: 10 })], 25);
+    expect(byDay[0]!.date).toBe('2026-07-17');
+  });
+});
+
+describe('dailyWeightSeries', () => {
+  it('keeps the latest weigh-in per day and sorts ascending', () => {
+    // Input arrives newest-first (as WeightService.findByUserId returns it).
+    const records: WeightRow[] = [
+      { weight: 70.1, recordedAt: '2026-07-18T21:00:00+09:00' },
+      { weight: 70.5, recordedAt: '2026-07-18T07:00:00+09:00' },
+      { weight: 71.0, recordedAt: '2026-07-17T07:00:00+09:00' },
+    ];
+    const daily = dailyWeightSeries(records);
+    expect(daily).toEqual([
+      { date: '2026-07-17', weight: 71.0 },
+      { date: '2026-07-18', weight: 70.1 },
+    ]);
+  });
+});
+
+describe('movingAverageSeries', () => {
+  it('averages over the trailing calendar window, with partial leading windows', () => {
+    const daily = [
+      { date: '2026-07-01', weight: 70 },
+      { date: '2026-07-02', weight: 72 },
+      { date: '2026-07-03', weight: 71 },
+    ];
+    const ma = movingAverageSeries(daily, 3);
+    expect(ma[0]!.movingAvg).toBeCloseTo(70); // only itself
+    expect(ma[1]!.movingAvg).toBeCloseTo(71); // (70+72)/2
+    expect(ma[2]!.movingAvg).toBeCloseTo(71); // (70+72+71)/3
+  });
+
+  it('counts the window in calendar days, so a gap shortens the sample', () => {
+    // 07-01 then a 3-day gap to 07-05; with window=3 the 07-05 point only sees itself.
+    const daily = [
+      { date: '2026-07-01', weight: 70 },
+      { date: '2026-07-05', weight: 74 },
+    ];
+    const ma = movingAverageSeries(daily, 3);
+    expect(ma[1]!.movingAvg).toBeCloseTo(74);
+  });
+});
+
+describe('weeklyWeightAverages', () => {
+  it('averages within Sun–Sat weeks', () => {
+    // 2026-07-13 is a Monday; its week starts Sun 2026-07-12.
+    const daily = [
+      { date: '2026-07-13', weight: 70 },
+      { date: '2026-07-15', weight: 72 },
+    ];
+    const weekly = weeklyWeightAverages(daily);
+    expect(weekly).toHaveLength(1);
+    expect(weekly[0]).toMatchObject({ weekStart: '2026-07-12', avg: 71, count: 2 });
+  });
+});
+
+describe('nutritionTrend', () => {
+  it('buckets by month and counts distinct logged days', () => {
+    const meals = [
+      meal({ recordedAt: '2026-06-30T12:00:00+09:00', calories: 500, totalProtein: 20 }),
+      meal({ recordedAt: '2026-07-01T12:00:00+09:00', calories: 600, totalProtein: 30 }),
+      meal({ recordedAt: '2026-07-01T19:00:00+09:00', calories: 400, totalProtein: 10 }),
+    ];
+    const buckets = nutritionTrend(meals, 'month');
+    expect(buckets.map((b) => b.label)).toEqual(['2026-06', '2026-07']);
+    expect(buckets[1]).toMatchObject({ label: '2026-07', days: 1, meals: 2, totalCalories: 1000, totalProtein: 40, avgCalories: 1000 });
+  });
+
+  it('buckets by week using the Sun-start label', () => {
+    const buckets = nutritionTrend([meal({ recordedAt: '2026-07-13T12:00:00+09:00' })], 'week');
+    expect(buckets[0]!.label).toBe('2026-07-12');
+  });
+});
+
+describe('exerciseBreakdown', () => {
+  const ex = (over: Partial<ExerciseRow>): ExerciseRow => ({
+    exerciseType: 'ベンチプレス',
+    muscleGroup: 'chest',
+    reps: 10,
+    weight: 60,
+    recordedAt: '2026-07-17T20:00:00+09:00',
+    ...over,
+  });
+
+  it('groups by muscle with volume = Σ reps×weight, sorted by sets desc', () => {
+    const records = [
+      ex({ muscleGroup: 'chest', reps: 10, weight: 60 }),
+      ex({ muscleGroup: 'chest', reps: 8, weight: 60 }),
+      ex({ muscleGroup: 'legs', reps: 12, weight: 100 }),
+    ];
+    const groups = exerciseBreakdown(records, 'muscle');
+    expect(groups[0]).toMatchObject({ key: 'chest', sets: 2, reps: 18, volume: 10 * 60 + 8 * 60 });
+    expect(groups[1]).toMatchObject({ key: 'legs', sets: 1, volume: 1200 });
+  });
+
+  it('bodyweight sets (null weight) add reps but no volume; null muscle → other', () => {
+    const groups = exerciseBreakdown([ex({ muscleGroup: null, weight: null, reps: 15 })], 'muscle');
+    expect(groups[0]).toMatchObject({ key: 'other', sets: 1, reps: 15, volume: 0 });
+  });
+});


### PR DESCRIPTION
## 背景

健康相談セッションがユーザーの健康データ取得を「本番D1直アクセス」から「MCP経由(`/api/mcp`)」に切り替えた。しかし現行の要約系4ツール（`get_latest_weight`/`get_weight_trend`/`get_daily_summary`/`get_meals`）では、これまでのコーチングで行っていた食材単位・目標比較・移動平均の分析が再現できなかった。

## 追加ツール（全6, read-only）

| ツール | 対応課題 | 返すもの |
|---|---|---|
| `get_food_items` | 食材単位の内訳 | 食事を1品ごとに分解しP/F/C・カロリー |
| `get_protein_sources` | 頻出たんぱく源ランキング | 期間の食材を名前で集約し累計P順にランキング |
| `get_protein_gap` | たんぱく質ギャップ（最重要） | `target`(g/食,**引数必須**)と比較し食事別/日別のギャップ・達成率 |
| `get_weight_moving_average` | 体重の要石 | 暦日トレーリング窓の移動平均(既定7日)+週平均 |
| `get_nutrition_trend` | 期間の栄養集計 | カロリー/PFCを週別・月別に集計 |
| `get_exercise_breakdown` | 運動の内訳 | 部位別/種目別のセット数・回数・総重量(Σreps×kg) |

## 設計

- **スキーマ変更なし・マイグレーション不要**。必要なデータは既存テーブル（`meal_food_items`のper-item P/F/C、`meal_records`のper-meal `total_protein`、`exercise_records`の`muscle_group`）に全て揃っている。MCPルートへのツール追加と、集計純関数・food item横断取得メソッドの新設のみ。
- 集計ロジックは副作用なしの純関数として `lib/mcpAggregate.ts` に分離 → 単体テスト14件（`tests/unit/mcpAggregate.test.ts`）。
- 日付バケットは全て `extractJstDate` 経由なので、レガシーな bare-UTC "Z" 行（#159以前）も正しいJST日に落ちる。
- たんぱく質目標は「1食25〜30g」で個人差があるため既定を置かず `target` 引数必須（コーチング側が基準を明示）。
- 移動平均は「暦日トレーリング窓・単純平均・先頭は利用可能日で部分集計」。窓を暦日で数えるため、欠測日があるとサンプルが縮む（時間的に遡りすぎない）。窓長は `window` 引数で調整可（既定7日）。

## 検証

- `pnpm typecheck`（全3パッケージ）/ `pnpm lint`（0 error）通過
- 単体テスト14件 pass（移動平均の暦日窓・欠測、たんぱく質ギャップのnull=0扱い・日別ロールアップ、週/月バケット、部位別volume等）
- **ローカルwrangler + seedトークン + seedデータで10ツールの `tools/list` と新6ツールの `tools/call` を実HTTP経路で確認**。移動平均の欠測時の窓縮小、週平均バケット、Σreps×kgまで手計算と一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)