### PR TITLE
feat: 食事タブに「この1週間」評価カードを追加

### DIFF
--- a/packages/backend/src/lib/weeklyMealSummary.ts
+++ b/packages/backend/src/lib/weeklyMealSummary.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure computation for the meal tab's "この1週間" weekly evaluation card.
+ *
+ * Folds a week of meals + weights into the six coaching metrics the card shows.
+ * Kept side-effect-free / DB-free (like mcpAggregate) so it can be unit-tested
+ * directly. Day bucketing goes through extractJstDate, so legacy bare-UTC "Z"
+ * rows land on the correct JST day, matching the rest of the app.
+ *
+ * Two different calorie bases are intentional:
+ *   - metric 1 (avg calories) uses the LOGGED `calories` (what the today card shows);
+ *   - metric 2 (PFC %) and metric 4 (high-fat day) use MACRO-derived kcal
+ *     (P*4 + F*9 + C*4), because "what share of energy is fat" is the fatty-liver
+ *     signal and should come from the macros, not a possibly-divergent calorie field.
+ */
+import { extractJstDate } from './localDate';
+import {
+  dailyWeightSeries,
+  movingAverageSeries,
+  type MealRow,
+  type WeightRow,
+} from './mcpAggregate';
+
+export interface WeeklyMealTargets {
+  windowDays: number;
+  dailyCalorieLimit: number;
+  proteinPct: number;
+  fatPct: number;
+  carbsPct: number;
+  proteinFloorPerDay: number;
+  highFatDaysLimit: number;
+  weightMaWindow: number;
+}
+
+export interface WeeklyMealSummaryResult {
+  startDate: string;
+  endDate: string;
+  windowDays: number;
+  recordedMealDays: number;
+  recordedWeightDays: number;
+  avgCalories: number;
+  proteinPct: number;
+  fatPct: number;
+  carbsPct: number;
+  proteinFloorDays: number;
+  highFatDays: number;
+  weightDirection: 'down' | 'flat' | 'up' | 'none';
+  weightDeltaKg: number;
+  targets: {
+    dailyCalorieLimit: number;
+    proteinPct: number;
+    fatPct: number;
+    carbsPct: number;
+    proteinFloorPerDay: number;
+    highFatDaysLimit: number;
+  };
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/** Macro-derived kcal for a day/period: protein & carbs at 4, fat at 9 kcal/g. */
+const macroKcal = (p: number, f: number, c: number) => p * 4 + f * 9 + c * 4;
+
+/**
+ * @param meals   meals within [startDate, endDate] (the route filters to the window)
+ * @param weights weights over a WIDER range ([startDate - weightMaWindow .. endDate])
+ *                so the moving average at startDate is properly smoothed
+ */
+export function computeWeeklyMealSummary(
+  meals: MealRow[],
+  weights: WeightRow[],
+  opts: { startDate: string; endDate: string; targets: WeeklyMealTargets }
+): WeeklyMealSummaryResult {
+  const { startDate, endDate, targets } = opts;
+
+  // ---- per-day nutrition (one bucket per JST calendar day in the window) ----
+  const dayMap = new Map<string, { calories: number; protein: number; fat: number; carbs: number }>();
+  for (const m of meals) {
+    const date = extractJstDate(m.recordedAt);
+    if (date < startDate || date > endDate) continue; // guard against out-of-window rows
+    const d = dayMap.get(date) ?? { calories: 0, protein: 0, fat: 0, carbs: 0 };
+    d.calories += m.calories ?? 0;
+    d.protein += m.totalProtein ?? 0;
+    d.fat += m.totalFat ?? 0;
+    d.carbs += m.totalCarbs ?? 0;
+    dayMap.set(date, d);
+  }
+  const days = [...dayMap.values()];
+  const recordedMealDays = days.length;
+
+  // metric 1: average daily calories over the days that HAVE a meal record.
+  const totalCalories = days.reduce((s, d) => s + d.calories, 0);
+  const avgCalories = recordedMealDays > 0 ? round1(totalCalories / recordedMealDays) : 0;
+
+  // metric 2: PFC balance as % of macro-derived kcal over the whole window.
+  const totalP = days.reduce((s, d) => s + d.protein, 0);
+  const totalF = days.reduce((s, d) => s + d.fat, 0);
+  const totalC = days.reduce((s, d) => s + d.carbs, 0);
+  const weekMacro = macroKcal(totalP, totalF, totalC);
+  const proteinPct = weekMacro > 0 ? round1(((totalP * 4) / weekMacro) * 100) : 0;
+  const fatPct = weekMacro > 0 ? round1(((totalF * 9) / weekMacro) * 100) : 0;
+  const carbsPct = weekMacro > 0 ? round1(((totalC * 4) / weekMacro) * 100) : 0;
+
+  // metric 3: days whose total protein reached the floor.
+  const proteinFloorDays = days.filter((d) => d.protein >= targets.proteinFloorPerDay).length;
+
+  // metric 4: days whose fat share (of that day's macro-kcal) exceeded the band.
+  const highFatDays = days.filter((d) => {
+    const dm = macroKcal(d.protein, d.fat, d.carbs);
+    return dm > 0 && ((d.fat * 9) / dm) * 100 > targets.fatPct;
+  }).length;
+
+  // ---- weight (metrics 5 & 6) ----
+  const wDaily = dailyWeightSeries(weights); // ascending, one weight per JST day
+  const recordedWeightDays = wDaily.filter((p) => p.date >= startDate && p.date <= endDate).length;
+
+  // Moving average over the wider series, then restrict to the window for the
+  // direction: MA at the last in-window day minus MA at the first in-window day.
+  const maInWindow = movingAverageSeries(wDaily, targets.weightMaWindow).filter(
+    (p) => p.date >= startDate && p.date <= endDate
+  );
+  let weightDirection: WeeklyMealSummaryResult['weightDirection'] = 'none';
+  let weightDeltaKg = 0;
+  if (maInWindow.length >= 2) {
+    weightDeltaKg = round1(maInWindow[maInWindow.length - 1]!.movingAvg - maInWindow[0]!.movingAvg);
+    weightDirection = Math.abs(weightDeltaKg) < 0.1 ? 'flat' : weightDeltaKg < 0 ? 'down' : 'up';
+  }
+
+  return {
+    startDate,
+    endDate,
+    windowDays: targets.windowDays,
+    recordedMealDays,
+    recordedWeightDays,
+    avgCalories,
+    proteinPct,
+    fatPct,
+    carbsPct,
+    proteinFloorDays,
+    highFatDays,
+    weightDirection,
+    weightDeltaKg,
+    targets: {
+      dailyCalorieLimit: targets.dailyCalorieLimit,
+      proteinPct: targets.proteinPct,
+      fatPct: targets.fatPct,
+      carbsPct: targets.carbsPct,
+      proteinFloorPerDay: targets.proteinFloorPerDay,
+      highFatDaysLimit: targets.highFatDaysLimit,
+    },
+  };
+}

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -1,9 +1,20 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
+import { WEEKLY_MEAL_TARGETS, weeklyMealSummaryQuerySchema } from '@lifestyle-app/shared';
 import { DashboardService } from '../services/dashboard';
+import { MealService } from '../services/meal';
+import { WeightService } from '../services/weight';
+import { computeWeeklyMealSummary } from '../lib/weeklyMealSummary';
 import { authMiddleware } from '../middleware/auth';
 import type { Bindings, Variables } from '../types';
+
+/** Shift a YYYY-MM-DD date by whole days (UTC date math is safe on date-only strings). */
+function shiftDate(dateStr: string, deltaDays: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().slice(0, 10);
+}
 
 // Period presets
 const PERIOD_DAYS = {
@@ -96,4 +107,33 @@ export const dashboard = new Hono<{ Bindings: Bindings; Variables: Variables }>(
     const activity = await service.getDailyActivity(user.id, days);
 
     return c.json(activity);
-  });
+  })
+  .get(
+    '/weekly-meal-summary',
+    zValidator('query', weeklyMealSummaryQuerySchema),
+    async (c) => {
+      const user = c.get('user');
+      const { today } = c.req.valid('query');
+      const db = c.get('db');
+
+      // The 7-day window ends on the client's local "today".
+      const endDate = today;
+      const startDate = shiftDate(today, -(WEEKLY_MEAL_TARGETS.windowDays - 1));
+      // Widen the weight fetch so the moving average at startDate is smoothed by
+      // the preceding week rather than starting cold.
+      const weightStart = shiftDate(startDate, -WEEKLY_MEAL_TARGETS.weightMaWindow);
+
+      const [meals, weights] = await Promise.all([
+        new MealService(db).findByUserId(user.id, { startDate, endDate }),
+        new WeightService(db).findByUserId(user.id, { startDate: weightStart, endDate }),
+      ]);
+
+      const summary = computeWeeklyMealSummary(meals, weights, {
+        startDate,
+        endDate,
+        targets: WEEKLY_MEAL_TARGETS,
+      });
+
+      return c.json(summary);
+    }
+  );

--- a/packages/frontend/src/components/meal/WeeklyMealSummaryCard.tsx
+++ b/packages/frontend/src/components/meal/WeeklyMealSummaryCard.tsx
@@ -1,0 +1,189 @@
+import type { WeeklyMealSummary } from '@lifestyle-app/shared';
+
+interface WeeklyMealSummaryCardProps {
+  summary: WeeklyMealSummary;
+}
+
+type Status = 'good' | 'warn' | 'bad' | 'none';
+
+const dotClass: Record<Status, string> = {
+  good: 'bg-emerald-400',
+  warn: 'bg-amber-400',
+  bad: 'bg-red-400',
+  none: 'bg-gray-300',
+};
+
+const leverClass: Record<Status, string> = {
+  good: 'text-emerald-600',
+  warn: 'text-amber-600',
+  bad: 'text-red-500',
+  none: 'text-gray-400',
+};
+
+/** One evaluation tile: value + target band + status dot + a single "明日のレバー". */
+function Metric({
+  label,
+  value,
+  unit,
+  band,
+  status,
+  lever,
+  valueClass,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  band: string;
+  status: Status;
+  lever: string;
+  valueClass?: string;
+}) {
+  return (
+    <div className="rounded-lg bg-gray-50 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-gray-400">{label}</p>
+        <span className={`h-2 w-2 shrink-0 rounded-full ${dotClass[status]}`} />
+      </div>
+      <p className={`mt-1 text-lg font-bold tabular-nums ${valueClass ?? 'text-gray-900'}`}>
+        {value}
+        {unit && <span className="text-xs font-normal text-gray-400"> {unit}</span>}
+      </p>
+      <p className="mt-0.5 text-[10px] text-gray-400">{band}</p>
+      <p className={`mt-1 text-[11px] ${leverClass[status]}`}>{lever}</p>
+    </div>
+  );
+}
+
+/**
+ * "この1週間" card: answers "傾向は正しいか?" over the trailing 7 days — kept
+ * separate from the today card (which answers "予算内に収めたか?"). Each of the
+ * six metrics carries a target band and one actionable lever. For this user's
+ * fatty-liver plan the PFC balance (fat share) is the primary signal, not total
+ * calories. Bands/targets come from the API (WEEKLY_MEAL_TARGETS) so this
+ * component holds no magic thresholds of its own.
+ */
+export function WeeklyMealSummaryCard({ summary }: WeeklyMealSummaryCardProps) {
+  const { targets, windowDays } = summary;
+  const noData = summary.recordedMealDays === 0;
+
+  // metric 1 — 7-day average calories (over recorded days)
+  const calOver = summary.avgCalories - targets.dailyCalorieLimit;
+  const calStatus: Status = noData ? 'none' : calOver <= 0 ? 'good' : 'bad';
+  const calLever = noData
+    ? '記録がありません'
+    : calOver > 0
+      ? `1日あたり −${Math.round(calOver)}kcal で帯内`
+      : '帯内をキープできています';
+
+  // metric 2 — PFC balance % (primary signal; fat share drives it)
+  const fatOver = summary.fatPct > targets.fatPct;
+  const proteinLow = summary.proteinPct < targets.proteinPct;
+  const pfcStatus: Status = noData ? 'none' : fatOver || proteinLow ? 'bad' : 'good';
+  const pfcLever = noData
+    ? '記録がありません'
+    : fatOver
+      ? `脂質を約${Math.round(summary.fatPct - targets.fatPct)}pt下げる（脂の多い一品を置換）`
+      : proteinLow
+        ? 'たんぱく質の比率を上げる'
+        : 'バランス良好';
+
+  // metric 3 — protein floor achievement days (user's biggest lever)
+  const floorStatus: Status = noData
+    ? 'none'
+    : summary.proteinFloorDays >= 5
+      ? 'good'
+      : summary.proteinFloorDays >= 2
+        ? 'warn'
+        : 'bad';
+  const floorLever =
+    summary.proteinFloorDays >= windowDays
+      ? '全日クリア'
+      : `1日${targets.proteinFloorPerDay}g（≒各食30g）を1日でも増やす`;
+
+  // metric 4 — high-fat days
+  const fatDaysStatus: Status = noData ? 'none' : summary.highFatDays <= targets.highFatDaysLimit ? 'good' : 'bad';
+  const fatDaysLever =
+    summary.highFatDays > targets.highFatDaysLimit
+      ? `${summary.highFatDays - targets.highFatDaysLimit}日分、脂質の高い食事を置換`
+      : `目安 ≤${targets.highFatDaysLimit}日/週 の範囲内`;
+
+  // metric 5 — weight moving-average direction (the diet's answer-check)
+  const dir = summary.weightDirection;
+  const weightStatus: Status = dir === 'none' ? 'none' : dir === 'up' ? 'bad' : 'good';
+  const weightArrow = dir === 'down' ? '↓' : dir === 'up' ? '↑' : dir === 'flat' ? '→' : '—';
+  const weightValue =
+    dir === 'none'
+      ? 'データ不足'
+      : `${weightArrow} ${summary.weightDeltaKg > 0 ? '+' : ''}${summary.weightDeltaKg.toFixed(1)}kg`;
+  const weightValueClass = dir === 'down' ? 'text-emerald-600' : dir === 'up' ? 'text-red-500' : undefined;
+
+  // metric 6 — completeness (analysis only bites once records are filled in)
+  const completeStatus: Status =
+    summary.recordedMealDays >= windowDays ? 'good' : summary.recordedMealDays >= 4 ? 'warn' : 'bad';
+  const missingDays = windowDays - summary.recordedMealDays;
+  const completeLever = missingDays <= 0 ? `${windowDays}日すべて記録済み` : `${missingDays}日分 未記録`;
+
+  const rangeLabel = `${summary.startDate.slice(5)}〜${summary.endDate.slice(5)}`;
+
+  return (
+    <div className="card p-4 sm:p-5">
+      <div className="flex items-baseline justify-between gap-2">
+        <h2 className="text-sm font-semibold text-gray-900">この1週間</h2>
+        <span className="text-[11px] text-gray-400">傾向は正しいか（{rangeLabel}）</span>
+      </div>
+      <div className="mt-3 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+        <Metric
+          label="7日平均カロリー"
+          value={summary.avgCalories.toLocaleString()}
+          unit="kcal/日"
+          band={`目標 ≤${targets.dailyCalorieLimit.toLocaleString()}・記録${summary.recordedMealDays}日平均`}
+          status={calStatus}
+          lever={calLever}
+          valueClass={calStatus === 'bad' ? 'text-red-500' : undefined}
+        />
+        <Metric
+          label="PFCバランス（主指標）"
+          value={`P${summary.proteinPct} F${summary.fatPct} C${summary.carbsPct}`}
+          unit="%"
+          band={`P≥${targets.proteinPct} F≤${targets.fatPct} C≈${targets.carbsPct}`}
+          status={pfcStatus}
+          lever={pfcLever}
+          valueClass={fatOver ? 'text-red-500' : undefined}
+        />
+        <Metric
+          label="たんぱく質 下限達成"
+          value={`${summary.proteinFloorDays}/${windowDays}`}
+          unit="日"
+          band={`1日${targets.proteinFloorPerDay}g 到達`}
+          status={floorStatus}
+          lever={floorLever}
+        />
+        <Metric
+          label="脂質過多だった日"
+          value={`${summary.highFatDays}/${windowDays}`}
+          unit="日"
+          band={`目安 ≤${targets.highFatDaysLimit}日/週`}
+          status={fatDaysStatus}
+          lever={fatDaysLever}
+          valueClass={fatDaysStatus === 'bad' ? 'text-red-500' : undefined}
+        />
+        <Metric
+          label="体重(7日平均)の向き"
+          value={weightValue}
+          band="減少で緑・食事の答え合わせ"
+          status={weightStatus}
+          lever={dir === 'none' ? '体重を数日記録すると出ます' : '7日移動平均の推移'}
+          valueClass={weightValueClass}
+        />
+        <Metric
+          label="記録できた日数"
+          value={`${summary.recordedMealDays}/${windowDays}`}
+          unit="日"
+          band={`体重 ${summary.recordedWeightDays}/${windowDays}日`}
+          status={completeStatus}
+          lever={completeLever}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useWeeklyMealSummary.ts
+++ b/packages/frontend/src/hooks/useWeeklyMealSummary.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/client';
+
+/**
+ * Fetch the meal tab's "この1週間" evaluation for the 7 days ending on `today`
+ * (client-local YYYY-MM-DD). The backend computes the six coaching metrics; this
+ * hook just wires the RPC call + cache key.
+ */
+export function useWeeklyMealSummary(today: string) {
+  return useQuery({
+    queryKey: ['weekly-meal-summary', today],
+    queryFn: async () => {
+      const res = await api.dashboard['weekly-meal-summary'].$get({ query: { today } });
+      if (!res.ok) {
+        throw new Error('Failed to fetch weekly meal summary');
+      }
+      return res.json();
+    },
+  });
+}

--- a/packages/frontend/src/pages/Meal.tsx
+++ b/packages/frontend/src/pages/Meal.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { useMeals } from '../hooks/useMeals';
+import { useWeeklyMealSummary } from '../hooks/useWeeklyMealSummary';
 import { MealList } from '../components/meal/MealList';
 import { CalorieSummary } from '../components/meal/CalorieSummary';
+import { WeeklyMealSummaryCard } from '../components/meal/WeeklyMealSummaryCard';
 import { SmartMealInput } from '../components/meal/SmartMealInput';
 import { AIUsageBanner } from '../components/meal/AIUsageBanner';
 import { useAIDailyUsage } from '../hooks/useAIDailyUsage';
@@ -47,6 +49,9 @@ export function Meal() {
     isDeleting,
   } = useMeals(mealsOptions);
 
+  // Weekly ("この1週間") evaluation for the 7 days ending today.
+  const { data: weeklySummary } = useWeeklyMealSummary(todayDate);
+
   // Save meal from SmartMealInput
   const handleSmartSave = useCallback(async (mealId: string, mealType: MealType, recordedAt?: string) => {
     await mealAnalysisApi.saveMealAnalysis(mealId, mealType, recordedAt);
@@ -85,6 +90,9 @@ export function Meal() {
           totalCarbs={todaySummary.totalCarbs ?? 0}
         />
       )}
+
+      {/* Weekly trend evaluation (separate question from the today card) */}
+      {weeklySummary && <WeeklyMealSummaryCard summary={weeklySummary} />}
 
       {/* Smart Meal Input */}
       <div>

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -122,6 +122,21 @@ export const DASHBOARD_PERIOD_LABELS: Record<(typeof DASHBOARD_PERIODS)[number],
   month: '月間',
 };
 
+// Targets for the meal tab's "この1週間" weekly evaluation card. Tuned for the
+// user's fatty-liver plan where fat SHARE (not total calories) is the lever, so
+// the PFC band is the primary signal. Adjust here — the values are echoed to the
+// client via the weekly-summary API so the card renders bands without its own copy.
+export const WEEKLY_MEAL_TARGETS = {
+  windowDays: 7,
+  dailyCalorieLimit: 1750, // metric 1: green if avg daily calories ≤ this
+  proteinPct: 20, // metric 2: protein should be ≥ this share of macro-kcal
+  fatPct: 30, // metric 2/4: fat should be ≤ this share; a day above it is "high-fat"
+  carbsPct: 50, // metric 2: reference band (~50%), not pass/fail
+  proteinFloorPerDay: 90, // metric 3: a day "achieves" when total protein ≥ this (g)
+  highFatDaysLimit: 2, // metric 4: at most this many high-fat days per week
+  weightMaWindow: 7, // metric 5: window for the weight moving average
+} as const;
+
 // Date formats
 export const DATE_FORMATS = {
   display: 'YYYY/MM/DD',

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -217,6 +217,47 @@ export const mealDatesResponseSchema = z.object({
 export type MealDatesQuery = z.infer<typeof mealDatesQuerySchema>;
 export type MealDatesResponse = z.infer<typeof mealDatesResponseSchema>;
 
+// Weekly meal summary schema (食事タブ「この1週間」評価カード)
+// Answers "is the weekly trend right?" (as opposed to the today card's "did I
+// stay in budget?"). Evaluated over the 7 days ending on `today`.
+export const weeklyMealSummaryQuerySchema = z.object({
+  today: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export const weeklyMealSummarySchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  windowDays: z.number().int(),
+  // metric 6: completeness — distinct days in the window with a record
+  recordedMealDays: z.number().int(),
+  recordedWeightDays: z.number().int(),
+  // metric 1: average daily calories over the days that HAVE a meal record
+  avgCalories: z.number(),
+  // metric 2: PFC balance as % of macro-derived kcal (P*4 + F*9 + C*4)
+  proteinPct: z.number(),
+  fatPct: z.number(),
+  carbsPct: z.number(),
+  // metric 3: days whose total protein reached the floor
+  proteinFloorDays: z.number().int(),
+  // metric 4: days whose fat share exceeded the fat band
+  highFatDays: z.number().int(),
+  // metric 5: 7-day weight moving-average direction over the window
+  weightDirection: z.enum(['down', 'flat', 'up', 'none']),
+  weightDeltaKg: z.number(),
+  // Targets echoed so the client renders bands/levers without duplicating them.
+  targets: z.object({
+    dailyCalorieLimit: z.number(),
+    proteinPct: z.number(),
+    fatPct: z.number(),
+    carbsPct: z.number(),
+    proteinFloorPerDay: z.number(),
+    highFatDaysLimit: z.number(),
+  }),
+});
+
+export type WeeklyMealSummaryQuery = z.infer<typeof weeklyMealSummaryQuerySchema>;
+export type WeeklyMealSummary = z.infer<typeof weeklyMealSummarySchema>;
+
 // Meal analysis schemas
 export * from './meal-analysis';
 

--- a/tests/unit/weeklyMealSummary.test.ts
+++ b/tests/unit/weeklyMealSummary.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { WEEKLY_MEAL_TARGETS } from '../../packages/shared/src';
+import { computeWeeklyMealSummary } from '../../packages/backend/src/lib/weeklyMealSummary';
+import type { MealRow, WeightRow } from '../../packages/backend/src/lib/mcpAggregate';
+
+const meal = (over: Partial<MealRow>): MealRow => ({
+  mealType: 'lunch',
+  recordedAt: '2026-07-17T12:00:00+09:00',
+  calories: 500,
+  totalProtein: 20,
+  totalFat: 15,
+  totalCarbs: 60,
+  ...over,
+});
+
+const opts = {
+  startDate: '2026-07-13',
+  endDate: '2026-07-19',
+  targets: WEEKLY_MEAL_TARGETS,
+};
+
+describe('computeWeeklyMealSummary', () => {
+  it('computes the six metrics over the window', () => {
+    const meals: MealRow[] = [
+      // 07-17: P48 F37 C140 → macro 1085, fat% 30.7 (>30 high-fat), protein 48 (<90)
+      meal({ recordedAt: '2026-07-17T12:30:00+09:00', calories: 613, totalProtein: 30, totalFat: 12, totalCarbs: 80 }),
+      meal({ recordedAt: '2026-07-17T19:00:00+09:00', calories: 615, totalProtein: 18, totalFat: 25, totalCarbs: 60 }),
+      // 07-18: P97 F43 C175 → fat% 26.2 (ok), protein 97 (≥90 floor day)
+      meal({ recordedAt: '2026-07-18T08:00:00+09:00', calories: 400, totalProtein: 22, totalFat: 10, totalCarbs: 45 }),
+      meal({ recordedAt: '2026-07-18T12:00:00+09:00', calories: 700, totalProtein: 40, totalFat: 15, totalCarbs: 70 }),
+      meal({ recordedAt: '2026-07-18T19:00:00+09:00', calories: 650, totalProtein: 35, totalFat: 18, totalCarbs: 60 }),
+      // 07-19: P25 F30 C40 → fat% 50.9 (>30 high-fat), protein 25 (<90)
+      meal({ recordedAt: '2026-07-19T12:00:00+09:00', calories: 500, totalProtein: 25, totalFat: 30, totalCarbs: 40 }),
+    ];
+    const weights: WeightRow[] = [
+      { weight: 71.5, recordedAt: '2026-07-10T07:00:00+09:00' }, // before window (smooths MA)
+      { weight: 71.2, recordedAt: '2026-07-12T07:00:00+09:00' },
+      { weight: 71.0, recordedAt: '2026-07-13T07:00:00+09:00' },
+      { weight: 70.6, recordedAt: '2026-07-15T07:00:00+09:00' },
+      { weight: 70.4, recordedAt: '2026-07-17T07:00:00+09:00' },
+      { weight: 70.0, recordedAt: '2026-07-19T07:00:00+09:00' },
+    ];
+
+    const r = computeWeeklyMealSummary(meals, weights, opts);
+
+    // metric 6: completeness
+    expect(r.recordedMealDays).toBe(3);
+    expect(r.recordedWeightDays).toBe(4); // 07-13,15,17,19 within window
+
+    // metric 1: avg over recorded days = (1228 + 1750 + 500) / 3
+    expect(r.avgCalories).toBe(1159.3);
+
+    // metric 2: PFC on macro-kcal basis (P170 F110 C355 → macro 3090)
+    expect(r.proteinPct).toBe(22.0);
+    expect(r.fatPct).toBe(32.0);
+    expect(r.carbsPct).toBe(46.0);
+
+    // metric 3 & 4
+    expect(r.proteinFloorDays).toBe(1); // only 07-18
+    expect(r.highFatDays).toBe(2); // 07-17 and 07-19
+
+    // metric 5: MA(07-19) < MA(07-13) → downward
+    expect(r.weightDirection).toBe('down');
+    expect(r.weightDeltaKg).toBeLessThan(0);
+
+    // targets echoed for the client
+    expect(r.targets.dailyCalorieLimit).toBe(1750);
+    expect(r.windowDays).toBe(7);
+  });
+
+  it('handles an empty week', () => {
+    const r = computeWeeklyMealSummary([], [], opts);
+    expect(r.recordedMealDays).toBe(0);
+    expect(r.avgCalories).toBe(0);
+    expect(r.proteinPct).toBe(0);
+    expect(r.highFatDays).toBe(0);
+    expect(r.proteinFloorDays).toBe(0);
+    expect(r.weightDirection).toBe('none');
+    expect(r.weightDeltaKg).toBe(0);
+  });
+
+  it('buckets a bare-UTC "Z" meal onto its JST day inside the window', () => {
+    // 20:00Z on 07-18 → 05:00 JST on 07-19 (still inside the window)
+    const r = computeWeeklyMealSummary(
+      [meal({ recordedAt: '2026-07-18T20:00:00Z', totalProtein: 95, totalFat: 5, totalCarbs: 10, calories: 500 })],
+      [],
+      opts
+    );
+    expect(r.recordedMealDays).toBe(1);
+    expect(r.proteinFloorDays).toBe(1); // 95g ≥ 90 on 07-19
+  });
+
+  it('excludes days outside the window', () => {
+    const r = computeWeeklyMealSummary(
+      [meal({ recordedAt: '2026-07-12T12:00:00+09:00' })], // one day before startDate
+      [],
+      opts
+    );
+    expect(r.recordedMealDays).toBe(0);
+  });
+});


### PR DESCRIPTION
## 背景

食事タブの評価が総カロリーだけだと、脂肪肝で一番効く**脂質比率**が緑バーの裏に隠れる（例: 総1737kcalで目標内=緑に見えるが脂質が全体の45%）。「週の傾向」と「PFCの質」を評価するカードを新設する。

## 置き場所

今日カード（`今日のカロリー/残りカロリー`）は**今日ビュー（予算内に収めたか）**として残し、その直下に独立した**「この1週間」カード（傾向は正しいか）**を追加。答える質問が違うので混ぜない。`Meal.tsx` の `<CalorieSummary/>` 直後に条件付きで挿入。

## 評価6項目（各項目に目標帯＋明日直せるレバー1つ）

| # | 指標 | 目標帯 | 実装 |
|---|---|---|---|
| 1 | 7日平均カロリー | ≤1750/日で緑 | **記録のある日数**で割る平均（欠け日で薄まらない） |
| 2 | **PFCバランス%（主指標）** | P≥20 / F≤30 / C≈50 | マクロ由来kcal(P4/F9/C4)比。脂質%超過で赤 |
| 3 | たんぱく質下限 達成日数 | 7日中◯日 | **1日合計≥90g**の日数 |
| 4 | 脂質過多だった日数 | ≤2日/週 | その日の脂質%>30 の日数 |
| 5 | 体重7日移動平均の向き | 減少で緑 | 既存 `dailyWeightSeries`+`movingAverageSeries` 再利用 |
| 6 | 記録できた日数 | 7/7で緑 | 抜けの可視化（食事・体重） |

①③の曖昧点（平均の分母／達成日の定義）は依頼者に確認し、**記録日数で割る／1日合計≥90g**で確定。

## 設計

- **フロントはMCPを直接叩けない**ため、既存サービス層＋純関数集計を再利用した**新API `GET /api/dashboard/weekly-meal-summary?today=YYYY-MM-DD`** を新設（RPC型は `AppType` に自動反映）。MCPツール(`get_nutrition_trend`等)と同じ集計基盤なので数値整合。**スキーマ変更なし**。
- 集計は副作用なしの純関数 `lib/weeklyMealSummary.ts` に分離 → **root `tests/unit/`** で単体テスト4件（PFC%・高脂質日・移動平均の向き・Z境界・窓外除外）。
- 目標帯は `shared` の `WEEKLY_MEAL_TARGETS` に定数化し**APIでechoする**ので、カード側は閾値を一切持たない（調整は定数1箇所）。
- カードは今日カードの `.card` / タイル配色を踏襲し、6タイル（各: 値・目標帯・状態ドット・レバー）を1枚のカードに配置。

## 検証

- `pnpm typecheck`（全3パッケージ、フロントのRPC型が新ルートを解決）/ `pnpm lint`（0 error）通過
- `vitest` 単体テスト4件 pass（`avgCalories=1159.3`, PFC `22/32/46%`, 高脂質2日, 下限1日, 体重down, Z境界を手計算と照合）
- **UI/エンドポイントの実データ確認はPR preview + cdp-e2e で実施予定**（この後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)