### PR TITLE
feat: インターバルタイマーを実行中のセットに追従させる

### DIFF
--- a/packages/frontend/src/components/exercise/RestTimer.tsx
+++ b/packages/frontend/src/components/exercise/RestTimer.tsx
@@ -1,136 +1,23 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import type { RestTimerController } from '../../hooks/useRestTimer';
 
 interface RestTimerProps {
-  defaultSeconds?: number;
-  incrementSeconds?: number;
+  timer: RestTimerController;
 }
 
-export function RestTimer({ defaultSeconds = 60, incrementSeconds = 60 }: RestTimerProps) {
-  const [seconds, setSeconds] = useState(defaultSeconds);
-  const [isRunning, setIsRunning] = useState(false);
-  const [totalSeconds, setTotalSeconds] = useState(defaultSeconds);
-  const touchStartX = useRef<number | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-
-  // Play alarm sound using Web Audio API
-  const playAlarm = useCallback(() => {
-    try {
-      if (!audioContextRef.current) {
-        audioContextRef.current = new AudioContext();
-      }
-      const ctx = audioContextRef.current;
-      const oscillator = ctx.createOscillator();
-      const gainNode = ctx.createGain();
-
-      oscillator.connect(gainNode);
-      gainNode.connect(ctx.destination);
-
-      oscillator.frequency.value = 800;
-      oscillator.type = 'sine';
-      gainNode.gain.value = 0.3;
-
-      // Beep pattern: 3 short beeps
-      const now = ctx.currentTime;
-      oscillator.start(now);
-
-      gainNode.gain.setValueAtTime(0.3, now);
-      gainNode.gain.setValueAtTime(0, now + 0.15);
-      gainNode.gain.setValueAtTime(0.3, now + 0.25);
-      gainNode.gain.setValueAtTime(0, now + 0.4);
-      gainNode.gain.setValueAtTime(0.3, now + 0.5);
-      gainNode.gain.setValueAtTime(0, now + 0.65);
-
-      oscillator.stop(now + 0.7);
-    } catch {
-      // Audio not supported or blocked
-    }
-  }, []);
-
-  // Timer countdown logic
-  useEffect(() => {
-    if (!isRunning) return;
-
-    const interval = setInterval(() => {
-      setSeconds((prev) => {
-        if (prev <= 1) {
-          setIsRunning(false);
-          playAlarm();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [isRunning, playAlarm]);
-
-  // Handle tap: start or reset
-  const handleTap = () => {
-    if (isRunning) {
-      // Reset when tapped during countdown
-      setIsRunning(false);
-      setSeconds(totalSeconds);
-    } else {
-      // Start countdown
-      if (seconds === 0) {
-        setSeconds(totalSeconds);
-      }
-      setIsRunning(true);
-    }
-  };
-
-  // Handle swipe start
-  const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0]?.clientX ?? null;
-  };
-
-  // Handle swipe end - right swipe adds time
-  const handleTouchEnd = (e: React.TouchEvent) => {
-    if (touchStartX.current === null) return;
-
-    const touchEndX = e.changedTouches[0]?.clientX ?? 0;
-    const diff = touchEndX - touchStartX.current;
-
-    // Right swipe (threshold: 50px)
-    if (diff > 50) {
-      const newTotal = totalSeconds + incrementSeconds;
-      setTotalSeconds(newTotal);
-      if (!isRunning) {
-        setSeconds(newTotal);
-      } else {
-        setSeconds((prev) => prev + incrementSeconds);
-      }
-    }
-    // Left swipe - decrease time (minimum 60 seconds)
-    else if (diff < -50 && totalSeconds > incrementSeconds) {
-      const newTotal = totalSeconds - incrementSeconds;
-      setTotalSeconds(newTotal);
-      if (!isRunning) {
-        setSeconds(newTotal);
-      } else {
-        setSeconds((prev) => Math.max(1, prev - incrementSeconds));
-      }
-    }
-
-    touchStartX.current = null;
-  };
-
-  // Format seconds as MM:SS
-  const formatTime = (secs: number) => {
-    const mins = Math.floor(secs / 60);
-    const remainingSecs = secs % 60;
-    return `${mins}:${remainingSecs.toString().padStart(2, '0')}`;
-  };
-
-  // Calculate progress percentage
-  const progress = totalSeconds > 0 ? (seconds / totalSeconds) * 100 : 0;
+/**
+ * インターバルタイマーの表示専用コンポーネント。
+ * 状態は useRestTimer が持つので、アクティブなセット行に追従して
+ * JSX上の位置が変わっても（＝remountされても）カウントダウンは継続する。
+ */
+export function RestTimer({ timer }: RestTimerProps) {
+  const { seconds, isRunning, progress, formattedTime, onTap, onTouchStart, onTouchEnd } = timer;
 
   return (
     <div
       className="select-none cursor-pointer"
-      onClick={handleTap}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
+      onClick={onTap}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
     >
       <div className="flex items-center gap-2">
         {/* Circular progress indicator */}
@@ -182,7 +69,7 @@ export function RestTimer({ defaultSeconds = 60, incrementSeconds = 60 }: RestTi
             isRunning ? 'text-orange-600' : seconds === 0 ? 'text-green-600' : 'text-gray-700'
           }`}
         >
-          {formatTime(seconds)}
+          {formattedTime}
         </span>
       </div>
     </div>

--- a/packages/frontend/src/components/exercise/StrengthInput.tsx
+++ b/packages/frontend/src/components/exercise/StrengthInput.tsx
@@ -1,6 +1,8 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Fragment, useState, useCallback, useMemo, useEffect } from 'react';
 import { EXERCISE_PRESETS, MUSCLE_GROUPS, MUSCLE_GROUP_LABELS, type MuscleGroup, type ExerciseRecord } from '@lifestyle-app/shared';
 import { SetRow } from './SetRow';
+import { RestTimer } from './RestTimer';
+import { useRestTimer } from '../../hooks/useRestTimer';
 import { LastRecordBadge } from './LastRecordBadge';
 import { SessionListModal } from './SessionListModal';
 import { logValidationError } from '../../lib/errorLogger';
@@ -67,6 +69,10 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
   const [validationError, setValidationError] = useState<string | null>(null);
   // Index of the set currently being performed. null = 実行中のセットなし
   const [activeSetIndex, setActiveSetIndex] = useState<number | null>(null);
+
+  // インターバルタイマー。状態はここに置き、表示はアクティブなセット行の
+  // 直下へ移動する（未選択時はセット枠の先頭）。
+  const timer = useRestTimer({ defaultSeconds: 60, incrementSeconds: 60 });
 
   const actualExerciseType = showCustomInput ? customExerciseName : exerciseType;
 
@@ -151,6 +157,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
     }
   };
 
+  // タイマーとは意図的に連動させない（開始・リセットは常にユーザーのタップ）
   const handleActivateSet = (index: number) => {
     setActiveSetIndex((prev) => (prev === index ? null : index));
   };
@@ -422,22 +429,35 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
 
         {/* Set Rows */}
         <div className="bg-gray-50 rounded-lg p-2">
+          {/* 実行中のセットが無いときの定位置 */}
+          {activeSetIndex === null && (
+            <div className="flex justify-center border-b border-gray-100 pb-2 mb-1">
+              <RestTimer timer={timer} />
+            </div>
+          )}
           {sets.map((set, index) => (
-            <SetRow
-              key={index}
-              setNumber={index + 1}
-              reps={set.reps}
-              weight={set.weight}
-              variation={set.variation}
-              memo={set.memo}
-              onRepsChange={(reps) => updateSet(index, 'reps', reps)}
-              onWeightChange={(weight) => updateSet(index, 'weight', weight)}
-              onMemoChange={(memo) => updateSet(index, 'memo', memo)}
-              onRemove={() => removeSet(index)}
-              isRemovable={sets.length > 1}
-              isActive={activeSetIndex === index}
-              onActivate={() => handleActivateSet(index)}
-            />
+            <Fragment key={index}>
+              <SetRow
+                setNumber={index + 1}
+                reps={set.reps}
+                weight={set.weight}
+                variation={set.variation}
+                memo={set.memo}
+                onRepsChange={(reps) => updateSet(index, 'reps', reps)}
+                onWeightChange={(weight) => updateSet(index, 'weight', weight)}
+                onMemoChange={(memo) => updateSet(index, 'memo', memo)}
+                onRemove={() => removeSet(index)}
+                isRemovable={sets.length > 1}
+                isActive={activeSetIndex === index}
+                onActivate={() => handleActivateSet(index)}
+              />
+              {/* 実行中のセットの直下にタイマーを追従させる */}
+              {activeSetIndex === index && (
+                <div className="flex justify-center border-l-4 border-l-orange-500 bg-orange-50 rounded-br-md py-2">
+                  <RestTimer timer={timer} />
+                </div>
+              )}
+            </Fragment>
           ))}
         </div>
       </div>

--- a/packages/frontend/src/hooks/useRestTimer.ts
+++ b/packages/frontend/src/hooks/useRestTimer.ts
@@ -1,0 +1,167 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { TouchEvent } from 'react';
+
+interface UseRestTimerOptions {
+  defaultSeconds?: number;
+  incrementSeconds?: number;
+}
+
+export interface RestTimerController {
+  seconds: number;
+  isRunning: boolean;
+  /** 残り時間の割合 (0-100)。円形プログレスの描画に使う */
+  progress: number;
+  /** M:SS 形式の表示用文字列 */
+  formattedTime: string;
+  /** タップ: 停止中なら開始、カウントダウン中ならリセット */
+  onTap: () => void;
+  onTouchStart: (e: TouchEvent) => void;
+  onTouchEnd: (e: TouchEvent) => void;
+}
+
+/**
+ * インターバルタイマーの状態とロジック。
+ *
+ * 表示コンポーネント (RestTimer) から状態を分離しているのは、タイマーを
+ * アクティブなセット行の直下へ移動させるため。JSX上の位置が変わると
+ * 表示コンポーネントは unmount/remount されるが、状態はこのフックを呼ぶ
+ * 側 (StrengthInput) に留まるのでカウントダウンが途切れない。
+ */
+export function useRestTimer({
+  defaultSeconds = 60,
+  incrementSeconds = 60,
+}: UseRestTimerOptions = {}): RestTimerController {
+  const [seconds, setSeconds] = useState(defaultSeconds);
+  const [isRunning, setIsRunning] = useState(false);
+  const [totalSeconds, setTotalSeconds] = useState(defaultSeconds);
+  const touchStartX = useRef<number | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+
+  // Play alarm sound using Web Audio API
+  const playAlarm = useCallback(() => {
+    try {
+      if (!audioContextRef.current) {
+        audioContextRef.current = new AudioContext();
+      }
+      const ctx = audioContextRef.current;
+      const oscillator = ctx.createOscillator();
+      const gainNode = ctx.createGain();
+
+      oscillator.connect(gainNode);
+      gainNode.connect(ctx.destination);
+
+      oscillator.frequency.value = 800;
+      oscillator.type = 'sine';
+      gainNode.gain.value = 0.3;
+
+      // Beep pattern: 3 short beeps
+      const now = ctx.currentTime;
+      oscillator.start(now);
+
+      gainNode.gain.setValueAtTime(0.3, now);
+      gainNode.gain.setValueAtTime(0, now + 0.15);
+      gainNode.gain.setValueAtTime(0.3, now + 0.25);
+      gainNode.gain.setValueAtTime(0, now + 0.4);
+      gainNode.gain.setValueAtTime(0.3, now + 0.5);
+      gainNode.gain.setValueAtTime(0, now + 0.65);
+
+      oscillator.stop(now + 0.7);
+    } catch {
+      // Audio not supported or blocked
+    }
+  }, []);
+
+  // Timer countdown logic
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const interval = setInterval(() => {
+      setSeconds((prev) => {
+        if (prev <= 1) {
+          setIsRunning(false);
+          playAlarm();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRunning, playAlarm]);
+
+  const reset = useCallback(() => {
+    setIsRunning(false);
+    setSeconds(totalSeconds);
+  }, [totalSeconds]);
+
+  // Handle tap: start or reset
+  const onTap = useCallback(() => {
+    if (isRunning) {
+      // Reset when tapped during countdown
+      reset();
+    } else {
+      // Start countdown
+      if (seconds === 0) {
+        setSeconds(totalSeconds);
+      }
+      setIsRunning(true);
+    }
+  }, [isRunning, seconds, totalSeconds, reset]);
+
+  // Handle swipe start
+  const onTouchStart = useCallback((e: TouchEvent) => {
+    touchStartX.current = e.touches[0]?.clientX ?? null;
+  }, []);
+
+  // Handle swipe end - right swipe adds time
+  const onTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      if (touchStartX.current === null) return;
+
+      const touchEndX = e.changedTouches[0]?.clientX ?? 0;
+      const diff = touchEndX - touchStartX.current;
+
+      // Right swipe (threshold: 50px)
+      if (diff > 50) {
+        const newTotal = totalSeconds + incrementSeconds;
+        setTotalSeconds(newTotal);
+        if (!isRunning) {
+          setSeconds(newTotal);
+        } else {
+          setSeconds((prev) => prev + incrementSeconds);
+        }
+      }
+      // Left swipe - decrease time (minimum 60 seconds)
+      else if (diff < -50 && totalSeconds > incrementSeconds) {
+        const newTotal = totalSeconds - incrementSeconds;
+        setTotalSeconds(newTotal);
+        if (!isRunning) {
+          setSeconds(newTotal);
+        } else {
+          setSeconds((prev) => Math.max(1, prev - incrementSeconds));
+        }
+      }
+
+      touchStartX.current = null;
+    },
+    [isRunning, totalSeconds, incrementSeconds]
+  );
+
+  // Format seconds as MM:SS
+  const mins = Math.floor(seconds / 60);
+  const remainingSecs = seconds % 60;
+  const formattedTime = `${mins}:${remainingSecs.toString().padStart(2, '0')}`;
+
+  // Calculate progress percentage
+  const progress = totalSeconds > 0 ? (seconds / totalSeconds) * 100 : 0;
+
+  return {
+    seconds,
+    isRunning,
+    progress,
+    formattedTime,
+    onTap,
+    onTouchStart,
+    onTouchEnd,
+  };
+}

--- a/packages/frontend/src/pages/Exercise.tsx
+++ b/packages/frontend/src/pages/Exercise.tsx
@@ -3,7 +3,6 @@ import { useExercises } from '../hooks/useExercises';
 import { StrengthInput } from '../components/exercise/StrengthInput';
 import { ExerciseList } from '../components/exercise/ExerciseList';
 import { ExerciseSummary } from '../components/exercise/ExerciseSummary';
-import { RestTimer } from '../components/exercise/RestTimer';
 import { getTodayDateString } from '../lib/dateValidation';
 
 export function Exercise() {
@@ -61,10 +60,7 @@ export function Exercise() {
 
       {/* Input Form */}
       <div className="card p-5">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-semibold text-gray-900">筋トレを記録</h2>
-          <RestTimer defaultSeconds={60} incrementSeconds={60} />
-        </div>
+        <h2 className="text-sm font-semibold text-gray-900 mb-3">筋トレを記録</h2>
         <StrengthInput
           onSubmit={create}
           isLoading={isCreating}


### PR DESCRIPTION
## 背景

セット数が増えると下方向にスクロールが必要になり、カード上部に固定されていたインターバルタイマーが画面外に出て操作しづらくなっていた。

## 変更内容

- タイマーをアクティブなセット行の直下に表示し、フォーカス移動に追従させる
- 実行中のセットが無いときはセット枠の先頭が定位置
- 状態を `useRestTimer` フックへ切り出し、`RestTimer` は表示専用に

### なぜ状態を切り出したか

表示位置が変わると `RestTimer` は unmount/remount される。状態を表示コンポーネント内に持ったままだと、フォーカスを移すたびにカウントダウンがリセットされてしまう。フックは `activeSetIndex` を持つ `StrengthInput` 側に置いているため、位置が変わっても `setInterval` と残り秒数は維持される。

### 意図的にやっていないこと

タイマーの開始・リセットはユーザーのタップのみ。セットフォーカスの操作とは連動させていない（タイマーを使うかどうかは自由なため）。

## 確認

- `pnpm typecheck` 3パッケージ通過
- `pnpm lint` 新規の警告なし
- read-onlyのUI変更のみ、スキーマ変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nfBBYaBA3TTVkwhUjDYfz