### PR TITLE
fix: タイマーを左寄せにし「前回と同じ」でメモを引き継ぐ

### DIFF
--- a/packages/frontend/src/components/exercise/StrengthInput.tsx
+++ b/packages/frontend/src/components/exercise/StrengthInput.tsx
@@ -124,6 +124,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
         reps: record.reps,
         weight: record.weight,
         variation: record.variation || undefined,
+        memo: record.memo || undefined,
       }));
       setSets(newSets);
       setActiveSetIndex(null);
@@ -134,6 +135,8 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
         newSets[0] = {
           reps: lastRecord.reps,
           weight: lastRecord.weight,
+          variation: lastRecord.variation || undefined,
+          memo: lastRecord.memo || undefined,
         };
         setSets(newSets);
       }
@@ -431,7 +434,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
         <div className="bg-gray-50 rounded-lg p-2">
           {/* 実行中のセットが無いときの定位置 */}
           {activeSetIndex === null && (
-            <div className="flex justify-center border-b border-gray-100 pb-2 mb-1">
+            <div className="flex border-b border-gray-100 pb-2 mb-1 pl-1">
               <RestTimer timer={timer} />
             </div>
           )}
@@ -453,7 +456,7 @@ export function StrengthInput({ onSubmit, isLoading, error, onFetchLastRecord, o
               />
               {/* 実行中のセットの直下にタイマーを追従させる */}
               {activeSetIndex === index && (
-                <div className="flex justify-center border-l-4 border-l-orange-500 bg-orange-50 rounded-br-md py-2">
+                <div className="flex border-l-4 border-l-orange-500 bg-orange-50 rounded-br-md py-2 pl-1">
                   <RestTimer timer={timer} />
                 </div>
               )}


### PR DESCRIPTION
## 変更内容

### 1. インターバルタイマーを左寄せに

`justify-center` で中央寄せだったため行構造から浮いて見えた。セット番号の列に揃えて左寄せにする。`border-l-4` が既に左インセットを作っているので `pl-1` で番号ボタンの左端とほぼ一致する。実行中セット直下・未選択時の定位置の両方に適用。

### 2. 「前回と同じ」でメモを引き継ぐ

`ExerciseRecord` は `memo` を持ちバックエンドも返しているが、`handleCopyLastRecord` の `map` が `reps` / `weight` / `variation` しか拾っていなかった。`SetInput.memo` が optional なため型チェックでは検出できない。

`lastSession` が空で `lastRecord` のみの fallback 経路で落ちていた `variation` も併せて補った。

## 既知の残課題（本PRでは未対応）

「過去のトレーニングから取り込む」(`handleSessionSelect`) も同様にメモを捨てている。こちらは `StrengthInput.tsx` 内のローカル型 `SessionExercise` を使っており shared の `ExerciseRecord` ではないため、API が memo を返しているかの確認から必要。

## 確認

- `pnpm typecheck` 3パッケージ通過
- UI/フロントのみ、スキーマ変更・マイグレーションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nfBBYaBA3TTVkwhUjDYfz