### PR TITLE
feat: 週次サマリーの目標値をユーザー単位で設定可能に (#170)

### DIFF
--- a/packages/backend/migrations/0041_add_user_weekly_targets.sql
+++ b/packages/backend/migrations/0041_add_user_weekly_targets.sql
@@ -1,0 +1,20 @@
+-- Migration 0041: per-user weekly evaluation targets (#170)
+--
+-- The "この1週間" card evaluates every user against a single hardcoded
+-- WEEKLY_MEAL_TARGETS (tuned for the owner's fatty-liver plan). Move the
+-- goal-like values to per-user columns, mirroring goal_weight / goal_calories.
+--
+-- Deliberately NULLABLE with NO default: NULL means "unset", and the backend
+-- coalesces it to WEEKLY_MEAL_TARGETS at read time (resolveWeeklyMealTargets).
+-- That keeps unset users tracking the global default even if it is retuned,
+-- and avoids baking today's numbers into every existing row.
+--
+-- windowDays / weightMaWindow (structural) and carbsPct (reference-only band)
+-- stay global and are intentionally NOT stored per user.
+
+ALTER TABLE users ADD COLUMN target_daily_calorie_limit INTEGER;
+ALTER TABLE users ADD COLUMN target_protein_pct INTEGER;
+ALTER TABLE users ADD COLUMN target_fat_pct INTEGER;
+ALTER TABLE users ADD COLUMN target_protein_floor_per_day INTEGER;
+ALTER TABLE users ADD COLUMN target_high_fat_days_limit INTEGER;
+ALTER TABLE users ADD COLUMN target_exercise_days INTEGER;

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -35,6 +35,14 @@ export const users = sqliteTable(
     emailVerified: integer('email_verified').notNull().default(0), // 0 = false, 1 = true
     goalWeight: real('goal_weight'),
     goalCalories: integer('goal_calories').default(2000),
+    // Per-user weekly evaluation targets (#170). Nullable with no default:
+    // NULL = unset → backend falls back to WEEKLY_MEAL_TARGETS.
+    targetDailyCalorieLimit: integer('target_daily_calorie_limit'),
+    targetProteinPct: integer('target_protein_pct'),
+    targetFatPct: integer('target_fat_pct'),
+    targetProteinFloorPerDay: integer('target_protein_floor_per_day'),
+    targetHighFatDaysLimit: integer('target_high_fat_days_limit'),
+    targetExerciseDays: integer('target_exercise_days'),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { WEEKLY_MEAL_TARGETS, weeklyMealSummaryQuerySchema } from '@lifestyle-app/shared';
+import { WEEKLY_MEAL_TARGETS, resolveWeeklyMealTargets, weeklyMealSummaryQuerySchema } from '@lifestyle-app/shared';
 import { DashboardService } from '../services/dashboard';
 import { MealService } from '../services/meal';
 import { WeightService } from '../services/weight';
 import { ExerciseService } from '../services/exercise';
+import { UserService } from '../services/user';
 import { computeWeeklyMealSummary } from '../lib/weeklyMealSummary';
 import { authMiddleware } from '../middleware/auth';
 import type { Bindings, Variables } from '../types';
@@ -124,16 +125,28 @@ export const dashboard = new Hono<{ Bindings: Bindings; Variables: Variables }>(
       // the preceding week rather than starting cold.
       const weightStart = shiftDate(startDate, -WEEKLY_MEAL_TARGETS.weightMaWindow);
 
-      const [meals, weights, exercises] = await Promise.all([
+      const [meals, weights, exercises, profile] = await Promise.all([
         new MealService(db).findByUserId(user.id, { startDate, endDate }),
         new WeightService(db).findByUserId(user.id, { startDate: weightStart, endDate }),
         new ExerciseService(db).findByUserId(user.id, { startDate, endDate }),
+        new UserService(db).getProfile(user.id),
       ]);
+
+      // Layer this user's saved overrides (#170) onto the global defaults; unset
+      // fields (NULL) fall back to WEEKLY_MEAL_TARGETS.
+      const targets = resolveWeeklyMealTargets({
+        dailyCalorieLimit: profile?.targetDailyCalorieLimit,
+        proteinPct: profile?.targetProteinPct,
+        fatPct: profile?.targetFatPct,
+        proteinFloorPerDay: profile?.targetProteinFloorPerDay,
+        highFatDaysLimit: profile?.targetHighFatDaysLimit,
+        exerciseDaysTarget: profile?.targetExerciseDays,
+      });
 
       const summary = computeWeeklyMealSummary(meals, weights, exercises, {
         startDate,
         endDate,
-        targets: WEEKLY_MEAL_TARGETS,
+        targets,
       });
 
       return c.json(summary);

--- a/packages/backend/src/services/user.ts
+++ b/packages/backend/src/services/user.ts
@@ -45,6 +45,12 @@ export class UserService {
         email: users.email,
         goalWeight: users.goalWeight,
         goalCalories: users.goalCalories,
+        targetDailyCalorieLimit: users.targetDailyCalorieLimit,
+        targetProteinPct: users.targetProteinPct,
+        targetFatPct: users.targetFatPct,
+        targetProteinFloorPerDay: users.targetProteinFloorPerDay,
+        targetHighFatDaysLimit: users.targetHighFatDaysLimit,
+        targetExerciseDays: users.targetExerciseDays,
         createdAt: users.createdAt,
       })
       .from(users)
@@ -54,7 +60,19 @@ export class UserService {
     return user;
   }
 
-  async updateGoals(userId: string, goals: { goalWeight?: number | null; goalCalories?: number | null }) {
+  async updateGoals(
+    userId: string,
+    goals: {
+      goalWeight?: number | null;
+      goalCalories?: number | null;
+      targetDailyCalorieLimit?: number | null;
+      targetProteinPct?: number | null;
+      targetFatPct?: number | null;
+      targetProteinFloorPerDay?: number | null;
+      targetHighFatDaysLimit?: number | null;
+      targetExerciseDays?: number | null;
+    }
+  ) {
     const now = new Date().toISOString();
 
     await this.db
@@ -62,6 +80,18 @@ export class UserService {
       .set({
         ...(goals.goalWeight !== undefined && { goalWeight: goals.goalWeight }),
         ...(goals.goalCalories !== undefined && { goalCalories: goals.goalCalories }),
+        ...(goals.targetDailyCalorieLimit !== undefined && {
+          targetDailyCalorieLimit: goals.targetDailyCalorieLimit,
+        }),
+        ...(goals.targetProteinPct !== undefined && { targetProteinPct: goals.targetProteinPct }),
+        ...(goals.targetFatPct !== undefined && { targetFatPct: goals.targetFatPct }),
+        ...(goals.targetProteinFloorPerDay !== undefined && {
+          targetProteinFloorPerDay: goals.targetProteinFloorPerDay,
+        }),
+        ...(goals.targetHighFatDaysLimit !== undefined && {
+          targetHighFatDaysLimit: goals.targetHighFatDaysLimit,
+        }),
+        ...(goals.targetExerciseDays !== undefined && { targetExerciseDays: goals.targetExerciseDays }),
         updatedAt: now,
       })
       .where(eq(users.id, userId));

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,10 +1,33 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { WEEKLY_MEAL_TARGETS } from '@lifestyle-app/shared';
 import { api } from '../lib/client';
 import { useAuthStore } from '../stores/authStore';
 import { PasskeyManagement } from '../components/auth/PasskeyManagement';
 import { McpTokenManagement } from '../components/mcp/McpTokenManagement';
+
+type GoalsPayload = {
+  goalWeight?: number | null;
+  goalCalories?: number | null;
+  targetDailyCalorieLimit?: number | null;
+  targetProteinPct?: number | null;
+  targetFatPct?: number | null;
+  targetProteinFloorPerDay?: number | null;
+  targetHighFatDaysLimit?: number | null;
+  targetExerciseDays?: number | null;
+};
+
+// The per-user weekly-evaluation targets (#170). `def` is the fallback shown as a
+// placeholder so an empty field visibly means "use the recommended default".
+const WEEKLY_TARGET_FIELDS = [
+  { key: 'targetDailyCalorieLimit', label: '週の平均カロリー上限 (kcal)', hint: '減量ペースの週平均ライン', def: WEEKLY_MEAL_TARGETS.dailyCalorieLimit, min: 500, max: 10000, step: 50 },
+  { key: 'targetProteinPct', label: 'たんぱく質の目標 (%)', hint: '摂取カロリーに占める割合の下限', def: WEEKLY_MEAL_TARGETS.proteinPct, min: 0, max: 100, step: 1 },
+  { key: 'targetFatPct', label: '脂質の上限 (%)', hint: 'これを超えた日が「脂質過多」', def: WEEKLY_MEAL_TARGETS.fatPct, min: 0, max: 100, step: 1 },
+  { key: 'targetProteinFloorPerDay', label: 'たんぱく質の下限 (g/日)', hint: '1日でこのgに届いた日を達成とみなす', def: WEEKLY_MEAL_TARGETS.proteinFloorPerDay, min: 0, max: 400, step: 5 },
+  { key: 'targetHighFatDaysLimit', label: '脂質過多の許容日数 (日/週)', hint: '週にこの日数までは許容', def: WEEKLY_MEAL_TARGETS.highFatDaysLimit, min: 0, max: 7, step: 1 },
+  { key: 'targetExerciseDays', label: '運動の目標 (日/週)', hint: '週にこの日数以上で達成', def: WEEKLY_MEAL_TARGETS.exerciseDaysTarget, min: 0, max: 7, step: 1 },
+] as const;
 
 export function Settings() {
   const navigate = useNavigate();
@@ -17,6 +40,9 @@ export function Settings() {
   // Goal settings state
   const [goalWeight, setGoalWeight] = useState<string>('');
   const [goalCalories, setGoalCalories] = useState<string>('');
+  // Weekly-evaluation targets (#170) — kept as strings keyed by field so an empty
+  // string round-trips to null ("unset → use default").
+  const [weeklyTargets, setWeeklyTargets] = useState<Record<string, string>>({});
   const [goalsSaved, setGoalsSaved] = useState(false);
 
   // Fetch user profile
@@ -60,12 +86,20 @@ export function Settings() {
     if (profile) {
       setGoalWeight(profile.goalWeight?.toString() ?? '');
       setGoalCalories(profile.goalCalories?.toString() ?? '');
+      setWeeklyTargets({
+        targetDailyCalorieLimit: profile.targetDailyCalorieLimit?.toString() ?? '',
+        targetProteinPct: profile.targetProteinPct?.toString() ?? '',
+        targetFatPct: profile.targetFatPct?.toString() ?? '',
+        targetProteinFloorPerDay: profile.targetProteinFloorPerDay?.toString() ?? '',
+        targetHighFatDaysLimit: profile.targetHighFatDaysLimit?.toString() ?? '',
+        targetExerciseDays: profile.targetExerciseDays?.toString() ?? '',
+      });
     }
   }, [profile]);
 
   // Update goals mutation
   const goalsMutation = useMutation({
-    mutationFn: async (goals: { goalWeight?: number | null; goalCalories?: number | null }) => {
+    mutationFn: async (goals: GoalsPayload) => {
       const res = await api.user.goals.$patch({ json: goals });
       if (!res.ok) {
         throw new Error('Failed to update goals');
@@ -133,7 +167,7 @@ export function Settings() {
   };
 
   const handleSaveGoals = () => {
-    const goals: { goalWeight?: number | null; goalCalories?: number | null } = {};
+    const goals: GoalsPayload = {};
 
     if (goalWeight.trim() === '') {
       goals.goalWeight = null;
@@ -150,6 +184,19 @@ export function Settings() {
       const calories = parseInt(goalCalories, 10);
       if (!isNaN(calories) && calories >= 500 && calories <= 10000) {
         goals.goalCalories = calories;
+      }
+    }
+
+    // Weekly targets: blank → null (clear); otherwise an in-range integer.
+    for (const f of WEEKLY_TARGET_FIELDS) {
+      const raw = (weeklyTargets[f.key] ?? '').trim();
+      if (raw === '') {
+        goals[f.key] = null;
+      } else {
+        const n = parseInt(raw, 10);
+        if (!isNaN(n) && n >= f.min && n <= f.max) {
+          goals[f.key] = n;
+        }
       }
     }
 
@@ -231,6 +278,38 @@ export function Settings() {
             />
             <p className="mt-1 text-[10px] text-gray-400">500〜10000kcalの範囲</p>
           </div>
+
+          {/* Weekly evaluation targets (#170) — the "この1週間" card thresholds */}
+          <div className="border-t border-gray-100 pt-4">
+            <h3 className="text-xs font-semibold text-gray-700">週次評価の目標（「この1週間」カード）</h3>
+            <p className="mt-0.5 text-[10px] text-gray-400">
+              空欄はおすすめ値（かっこ内）を使用します。あなたの計画に合わせて上書きできます。
+            </p>
+            <div className="mt-3 space-y-4">
+              {WEEKLY_TARGET_FIELDS.map((f) => (
+                <div key={f.key}>
+                  <label htmlFor={f.key} className="block text-xs font-medium text-gray-600">
+                    {f.label}
+                  </label>
+                  <input
+                    type="number"
+                    id={f.key}
+                    value={weeklyTargets[f.key] ?? ''}
+                    onChange={(e) => setWeeklyTargets((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                    placeholder={`おすすめ: ${f.def}`}
+                    min={f.min}
+                    max={f.max}
+                    step={f.step}
+                    className="mt-1 block w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 sm:w-48 transition-colors"
+                  />
+                  <p className="mt-1 text-[10px] text-gray-400">
+                    {f.hint}（{f.min}〜{f.max}）
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
           <div className="flex items-center gap-3">
             <button
               onClick={handleSaveGoals}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -138,6 +138,37 @@ export const WEEKLY_MEAL_TARGETS = {
   exerciseDaysTarget: 2, // metric 7: aim for at least this many exercise days per week
 } as const;
 
+/**
+ * Per-user overrides for the weekly targets (#170). Each field is optional and
+ * nullable: `null`/`undefined` means "not set — fall back to the global default".
+ * windowDays / weightMaWindow / carbsPct stay global (structural / reference-only).
+ */
+export interface WeeklyMealTargetOverrides {
+  dailyCalorieLimit?: number | null;
+  proteinPct?: number | null;
+  fatPct?: number | null;
+  proteinFloorPerDay?: number | null;
+  highFatDaysLimit?: number | null;
+  exerciseDaysTarget?: number | null;
+}
+
+/**
+ * Resolve the effective weekly targets by layering a user's overrides onto the
+ * global defaults. Coalescing against WEEKLY_MEAL_TARGETS (not a captured copy)
+ * means unset fields keep tracking the default if it is ever retuned.
+ */
+export function resolveWeeklyMealTargets(overrides?: WeeklyMealTargetOverrides) {
+  return {
+    ...WEEKLY_MEAL_TARGETS,
+    dailyCalorieLimit: overrides?.dailyCalorieLimit ?? WEEKLY_MEAL_TARGETS.dailyCalorieLimit,
+    proteinPct: overrides?.proteinPct ?? WEEKLY_MEAL_TARGETS.proteinPct,
+    fatPct: overrides?.fatPct ?? WEEKLY_MEAL_TARGETS.fatPct,
+    proteinFloorPerDay: overrides?.proteinFloorPerDay ?? WEEKLY_MEAL_TARGETS.proteinFloorPerDay,
+    highFatDaysLimit: overrides?.highFatDaysLimit ?? WEEKLY_MEAL_TARGETS.highFatDaysLimit,
+    exerciseDaysTarget: overrides?.exerciseDaysTarget ?? WEEKLY_MEAL_TARGETS.exerciseDaysTarget,
+  };
+}
+
 // Date formats
 export const DATE_FORMATS = {
   display: 'YYYY/MM/DD',

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -61,6 +61,13 @@ export const updateUserSchema = z.object({
 export const updateGoalsSchema = z.object({
   goalWeight: z.number().min(20).max(300).nullable().optional(),
   goalCalories: z.number().int().min(500).max(10000).nullable().optional(),
+  // Weekly evaluation targets (#170). null clears an override back to the default.
+  targetDailyCalorieLimit: z.number().int().min(500).max(10000).nullable().optional(),
+  targetProteinPct: z.number().int().min(0).max(100).nullable().optional(),
+  targetFatPct: z.number().int().min(0).max(100).nullable().optional(),
+  targetProteinFloorPerDay: z.number().int().min(0).max(400).nullable().optional(),
+  targetHighFatDaysLimit: z.number().int().min(0).max(7).nullable().optional(),
+  targetExerciseDays: z.number().int().min(0).max(7).nullable().optional(),
 });
 
 // Weight schemas

--- a/tests/unit/resolveWeeklyMealTargets.test.ts
+++ b/tests/unit/resolveWeeklyMealTargets.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { WEEKLY_MEAL_TARGETS, resolveWeeklyMealTargets } from '../../packages/shared/src';
+
+describe('resolveWeeklyMealTargets (#170)', () => {
+  it('returns the global defaults when no overrides are given', () => {
+    expect(resolveWeeklyMealTargets()).toEqual(WEEKLY_MEAL_TARGETS);
+    expect(resolveWeeklyMealTargets({})).toEqual(WEEKLY_MEAL_TARGETS);
+  });
+
+  it('applies a partial override and leaves the rest at default', () => {
+    const r = resolveWeeklyMealTargets({ proteinFloorPerDay: 75, exerciseDaysTarget: 4 });
+    expect(r.proteinFloorPerDay).toBe(75);
+    expect(r.exerciseDaysTarget).toBe(4);
+    // untouched fields keep the defaults
+    expect(r.fatPct).toBe(WEEKLY_MEAL_TARGETS.fatPct);
+    expect(r.dailyCalorieLimit).toBe(WEEKLY_MEAL_TARGETS.dailyCalorieLimit);
+  });
+
+  it('treats null / undefined as "unset" and falls back to the default', () => {
+    const r = resolveWeeklyMealTargets({
+      proteinPct: null,
+      fatPct: undefined,
+      dailyCalorieLimit: 1500,
+    });
+    expect(r.proteinPct).toBe(WEEKLY_MEAL_TARGETS.proteinPct); // null → default
+    expect(r.fatPct).toBe(WEEKLY_MEAL_TARGETS.fatPct); // undefined → default
+    expect(r.dailyCalorieLimit).toBe(1500); // real value wins
+  });
+
+  it('never lets structural/reference fields be overridden', () => {
+    // windowDays / weightMaWindow / carbsPct are not part of the override type,
+    // so they always come from the constant.
+    const r = resolveWeeklyMealTargets({ proteinFloorPerDay: 120 });
+    expect(r.windowDays).toBe(WEEKLY_MEAL_TARGETS.windowDays);
+    expect(r.weightMaWindow).toBe(WEEKLY_MEAL_TARGETS.weightMaWindow);
+    expect(r.carbsPct).toBe(WEEKLY_MEAL_TARGETS.carbsPct);
+  });
+
+  it('accepts 0 as a real override (not treated as unset)', () => {
+    const r = resolveWeeklyMealTargets({ highFatDaysLimit: 0, exerciseDaysTarget: 0 });
+    expect(r.highFatDaysLimit).toBe(0);
+    expect(r.exerciseDaysTarget).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #170

## やったこと

「この1週間」評価カードが使う `WEEKLY_MEAL_TARGETS` の目標値を、`goalWeight`/`goalCalories` と同様に**ユーザー単位でDB保持＋設定画面から編集**できるようにしました。未設定はデフォルト値へフォールバックします。

### per-user化した6値
| 項目 | カラム | デフォルト |
|---|---|---|
| 週の平均カロリー上限 | `target_daily_calorie_limit` | 1750 |
| たんぱく質の目標(%) | `target_protein_pct` | 20 |
| 脂質の上限(%) | `target_fat_pct` | 30 |
| たんぱく質の下限(g/日) | `target_protein_floor_per_day` | 90 |
| 脂質過多の許容日数(日/週) | `target_high_fat_days_limit` | 2 |
| 運動の目標(日/週) | `target_exercise_days` | 2 |

`windowDays`/`weightMaWindow`（構造）と `carbsPct`（参照帯）はグローバル据え置き。

### 設計の要点
- **NULL＝未設定→デフォルト**方式：カラムはnullable・DB default無し。バックエンドが `resolveWeeklyMealTargets()` で `userValue ?? WEEKLY_MEAL_TARGETS.x` と解決。これで「定数を後で再チューニングすると未設定ユーザー全員に伝播」する。
- 週次カロリー上限は今日カードの `goalCalories` とは**別フィールド**（減量の週平均ライン ≠ 1日の摂取目標）。

### 変更ファイル
- `packages/shared/src/constants.ts` — `resolveWeeklyMealTargets()` / `WeeklyMealTargetOverrides`
- `packages/shared/src/schemas/index.ts` — `updateGoalsSchema` に6値（範囲検証・null許可）
- `packages/backend/migrations/0041_add_user_weekly_targets.sql` — カラム追加
- `packages/backend/src/db/schema.ts` / `services/user.ts` / `routes/dashboard.ts`
- `packages/frontend/src/pages/Settings.tsx` — 「週次評価の目標」入力群

## ⚠ マイグレーション
**DBスキーマ変更あり（0041）**。PR previewは自動適用されないため、preview検証前に手動適用が必要：
```
pnpm --filter @lifestyle-app/backend exec wrangler d1 migrations apply DB --env preview --remote
```
本番は tag deploy 時に自動適用。ローカルは適用・動作確認済み。

## テスト
- `pnpm typecheck` 全3パッケージ Done ／ `pnpm lint` 0 errors
- `pnpm exec vitest run tests/unit` **326 passed / 0 failed**（`resolveWeeklyMealTargets` 5件追加：null/undefined/0/部分上書き/構造値の非上書き）
- migration 0041 をローカルD1へ適用成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nfBBYaBA3TTVkwhUjDYfz
