### PR TITLE
feat: インターバルタイマーに使い方ヒントを表示

### DIFF
--- a/packages/frontend/src/components/exercise/RestTimer.tsx
+++ b/packages/frontend/src/components/exercise/RestTimer.tsx
@@ -71,6 +71,18 @@ export function RestTimer({ timer }: RestTimerProps) {
         >
           {formattedTime}
         </span>
+
+        {/* 使い方ヒント: 左寄せタイマーの右側の余白を操作説明で埋める。
+            タップの動作は状態で変わるので文言も連動させる。 */}
+        <div className="ml-1 flex flex-col text-[10px] leading-tight text-gray-400">
+          <span>
+            タップで
+            <span className={`font-medium ${isRunning ? 'text-orange-600' : 'text-gray-500'}`}>
+              {isRunning ? 'リセット' : seconds === 0 ? '再スタート' : 'スタート'}
+            </span>
+          </span>
+          <span>スワイプで ±1分</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## やったこと

左寄せインターバルタイマー（#167で左寄せ化）の右側に生まれていた余白に、操作説明を追加。

- タップで **開始 / リセット**（実行中→リセット、停止中→スタート、0→再スタート。文言は状態連動）
- スワイプで **±1分**

フロントのみ・`RestTimer.tsx` 12行追加、DB/APIスキーマ変更なし・マイグレーション不要。

## テスト
- `pnpm typecheck` frontend Done ／ `pnpm lint` 0 errors
- 描画はPR previewで確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nfBBYaBA3TTVkwhUjDYfz