### PR TITLE
feat: 食事カードにPFCの目標プログレスバーを追加

### DIFF
--- a/packages/frontend/src/components/meal/CalorieSummary.tsx
+++ b/packages/frontend/src/components/meal/CalorieSummary.tsx
@@ -7,8 +7,55 @@ interface CalorieSummaryProps {
   totalProtein: number;
   totalFat: number;
   totalCarbs: number;
+  /** PFCのグラム目標（resolvePfcGramTargetsで算出）。未指定なら目標線なし。 */
+  proteinTarget?: number | null;
+  fatTarget?: number | null;
+  carbsTarget?: number | null;
   /** 履歴画面用のラベル表示 */
   isHistory?: boolean;
+}
+
+/** 目標に対する意味づけ。floor=下限(満たす), cap=上限(超で赤), reference=目安(中立) */
+type MacroTone = 'floor' | 'cap' | 'reference';
+
+function MacroBar({
+  label,
+  current,
+  target,
+  tone,
+}: {
+  label: string;
+  current: number;
+  target: number | null | undefined;
+  tone: MacroTone;
+}) {
+  const hasTarget = target != null && target > 0;
+  const progress = hasTarget ? Math.min((current / target) * 100, 100) : 0;
+
+  let barColor = 'bg-sky-400'; // reference（炭水化物の目安）
+  if (hasTarget && tone === 'floor') {
+    barColor = current >= target ? 'bg-emerald-400' : 'bg-amber-400';
+  } else if (hasTarget && tone === 'cap') {
+    barColor = current > target ? 'bg-red-400' : 'bg-emerald-400';
+  }
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between text-[10px] text-gray-400">
+        <span>{label}</span>
+        <span className="tabular-nums">
+          {current.toFixed(1)}
+          {hasTarget ? ` / ${Math.round(target)}` : ''}g
+        </span>
+      </div>
+      <div className="mt-0.5 h-1 overflow-hidden rounded-full bg-gray-100">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
 }
 
 export function CalorieSummary({
@@ -20,6 +67,9 @@ export function CalorieSummary({
   totalProtein,
   totalFat,
   totalCarbs,
+  proteinTarget,
+  fatTarget,
+  carbsTarget,
   isHistory = false,
 }: CalorieSummaryProps) {
   const progress = Math.min((totalCalories / targetCalories) * 100, 100);
@@ -34,9 +84,6 @@ export function CalorieSummary({
         <p className="mt-1 text-xl font-bold text-gray-900 tabular-nums sm:text-2xl">
           {totalCalories.toLocaleString()} <span className="text-xs font-normal text-gray-400">kcal</span>
         </p>
-        <p className="mt-1 text-xs text-gray-400">
-          P: {totalProtein.toFixed(1)}g  F: {totalFat.toFixed(1)}g  C: {totalCarbs.toFixed(1)}g
-        </p>
         <div className="mt-2">
           <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
             <div
@@ -49,6 +96,11 @@ export function CalorieSummary({
           <p className="mt-1 text-[10px] text-gray-400">
             目標: {targetCalories.toLocaleString()} kcal
           </p>
+        </div>
+        <div className="mt-2.5 space-y-1.5">
+          <MacroBar label="P たんぱく質" current={totalProtein} target={proteinTarget} tone="floor" />
+          <MacroBar label="F 脂質" current={totalFat} target={fatTarget} tone="cap" />
+          <MacroBar label="C 炭水化物" current={totalCarbs} target={carbsTarget} tone="reference" />
         </div>
       </div>
 

--- a/packages/frontend/src/pages/Meal.tsx
+++ b/packages/frontend/src/pages/Meal.tsx
@@ -13,7 +13,7 @@ import { mealAnalysisApi } from '../lib/api';
 import { api } from '../lib/client';
 import { getTodayDateString } from '../lib/dateValidation';
 import type { MealType, MealRecord } from '@lifestyle-app/shared';
-import { MEAL_TYPE_LABELS } from '@lifestyle-app/shared';
+import { MEAL_TYPE_LABELS, resolvePfcGramTargets } from '@lifestyle-app/shared';
 
 export function Meal() {
   const [filterType, setFilterType] = useState<MealType | ''>('');
@@ -57,6 +57,12 @@ export function Meal() {
     await mealAnalysisApi.saveMealAnalysis(mealId, mealType, recordedAt);
   }, []);
 
+  // Per-day PFC gram targets derived from the calorie goal + weekly band settings.
+  const pfcTargets = resolvePfcGramTargets(profile?.goalCalories, {
+    fatPct: profile?.targetFatPct,
+    proteinFloorPerDay: profile?.targetProteinFloorPerDay,
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16">
@@ -88,6 +94,9 @@ export function Meal() {
           totalProtein={todaySummary.totalProtein ?? 0}
           totalFat={todaySummary.totalFat ?? 0}
           totalCarbs={todaySummary.totalCarbs ?? 0}
+          proteinTarget={pfcTargets.protein}
+          fatTarget={pfcTargets.fat}
+          carbsTarget={pfcTargets.carbs}
         />
       )}
 

--- a/packages/frontend/src/pages/MealHistory.tsx
+++ b/packages/frontend/src/pages/MealHistory.tsx
@@ -8,6 +8,7 @@ import { MealCalendar } from '../components/meal/MealCalendar';
 import { CalorieSummary } from '../components/meal/CalorieSummary';
 import { api } from '../lib/client';
 import { getTodayDateString, formatDateString } from '../lib/dateValidation';
+import { resolvePfcGramTargets } from '@lifestyle-app/shared';
 import type { MealRecord } from '@lifestyle-app/shared';
 
 function MealHistory() {
@@ -59,6 +60,12 @@ function MealHistory() {
       totalCarbs,
     };
   }, [meals]);
+
+  // Per-day PFC gram targets derived from the calorie goal + weekly band settings.
+  const pfcTargets = resolvePfcGramTargets(profile?.goalCalories, {
+    fatPct: profile?.targetFatPct,
+    proteinFloorPerDay: profile?.targetProteinFloorPerDay,
+  });
 
   // Format the selected date for display
   const formattedDate = useMemo(() => {
@@ -117,6 +124,9 @@ function MealHistory() {
           totalProtein={daySummary.totalProtein}
           totalFat={daySummary.totalFat}
           totalCarbs={daySummary.totalCarbs}
+          proteinTarget={pfcTargets.protein}
+          fatTarget={pfcTargets.fat}
+          carbsTarget={pfcTargets.carbs}
           isHistory
         />
       )}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -169,6 +169,47 @@ export function resolveWeeklyMealTargets(overrides?: WeeklyMealTargetOverrides) 
   };
 }
 
+// Energy density per gram of each macronutrient (kcal/g). Protein and carbs
+// yield ~4 kcal/g, fat ~9 kcal/g. Used to translate a %-of-calories target band
+// into an absolute gram target for the meal tab's PFC bars.
+export const KCAL_PER_GRAM = { protein: 4, fat: 9, carbs: 4 } as const;
+
+/**
+ * Per-day PFC gram targets used as the baseline for the meal card's macro bars.
+ * - `protein` is a floor (aim to meet or exceed).
+ * - `fat` is an upper cap (stay at or under); null when no calorie goal is set.
+ * - `carbs` is a ~carbsPct reference; null when no calorie goal is set.
+ */
+export interface PfcGramTargets {
+  protein: number;
+  fat: number | null;
+  carbs: number | null;
+}
+
+/**
+ * Derive per-day PFC gram targets from the calorie goal and the user's weekly
+ * band settings (#170 overrides layered over WEEKLY_MEAL_TARGETS). Protein is a
+ * floor in g/day, so it is always available. Fat and carbs are defined as a
+ * share of calories, so translating them to grams needs `goalCalories`; when it
+ * is absent they are returned as null (bar renders without a target line).
+ */
+export function resolvePfcGramTargets(
+  goalCalories: number | null | undefined,
+  overrides?: Pick<WeeklyMealTargetOverrides, 'proteinFloorPerDay' | 'fatPct'>,
+): PfcGramTargets {
+  const targets = resolveWeeklyMealTargets(overrides);
+  const protein = targets.proteinFloorPerDay;
+
+  // Fat/carbs are defined as a % share of calories, so convert
+  // "share of kcal ÷ kcal-per-gram" once a calorie goal exists.
+  const fat: number | null =
+    goalCalories == null ? null : (goalCalories * targets.fatPct) / 100 / KCAL_PER_GRAM.fat;
+  const carbs: number | null =
+    goalCalories == null ? null : (goalCalories * targets.carbsPct) / 100 / KCAL_PER_GRAM.carbs;
+
+  return { protein, fat, carbs };
+}
+
 // Date formats
 export const DATE_FORMATS = {
   display: 'YYYY/MM/DD',

--- a/tests/unit/resolvePfcGramTargets.test.ts
+++ b/tests/unit/resolvePfcGramTargets.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  KCAL_PER_GRAM,
+  WEEKLY_MEAL_TARGETS,
+  resolvePfcGramTargets,
+} from '../../packages/shared/src';
+
+describe('resolvePfcGramTargets', () => {
+  it('returns fat/carbs = null when no calorie goal is set, protein still floors', () => {
+    for (const noGoal of [null, undefined]) {
+      const r = resolvePfcGramTargets(noGoal);
+      expect(r.fat).toBeNull();
+      expect(r.carbs).toBeNull();
+      // protein is a g/day floor, so it is always available
+      expect(r.protein).toBe(WEEKLY_MEAL_TARGETS.proteinFloorPerDay);
+    }
+  });
+
+  it('converts fat/carbs %-share into grams from the calorie goal (defaults)', () => {
+    const r = resolvePfcGramTargets(1750);
+    // fat: 1750 * 30% / 9kcal-per-g = 58.33...
+    expect(r.fat).toBeCloseTo((1750 * WEEKLY_MEAL_TARGETS.fatPct) / 100 / KCAL_PER_GRAM.fat, 5);
+    expect(r.fat).toBeCloseTo(58.33, 2);
+    // carbs: 1750 * 50% / 4kcal-per-g = 218.75 (exact)
+    expect(r.carbs).toBe(218.75);
+    expect(r.protein).toBe(WEEKLY_MEAL_TARGETS.proteinFloorPerDay);
+  });
+
+  it('honors per-user overrides for fatPct and proteinFloorPerDay', () => {
+    const r = resolvePfcGramTargets(2000, { fatPct: 25, proteinFloorPerDay: 110 });
+    expect(r.fat).toBeCloseTo((2000 * 25) / 100 / KCAL_PER_GRAM.fat, 5); // 55.55...
+    expect(r.protein).toBe(110);
+    // carbsPct is reference-only (not overridable), so it tracks the constant
+    expect(r.carbs).toBe((2000 * WEEKLY_MEAL_TARGETS.carbsPct) / 100 / KCAL_PER_GRAM.carbs);
+  });
+
+  it('treats null/undefined overrides as unset and falls back to defaults', () => {
+    const r = resolvePfcGramTargets(1750, { fatPct: null, proteinFloorPerDay: undefined });
+    expect(r.fat).toBeCloseTo((1750 * WEEKLY_MEAL_TARGETS.fatPct) / 100 / KCAL_PER_GRAM.fat, 5);
+    expect(r.protein).toBe(WEEKLY_MEAL_TARGETS.proteinFloorPerDay);
+  });
+});


### PR DESCRIPTION
## 概要

食事記録カードの「今日のカロリー」で、カロリーと同じように **PFC（たんぱく質・脂質・炭水化物）も目標に対する進捗バー**で表示するようにしました。

スクショの要望（カロリーだけでなくPFCも同じように出したい）に対応。

## 表示仕様（栄養素で色の意味が変わる）

目標はカロリー目標＋週次バンド設定から自動算出（`resolvePfcGramTargets`）。

- **P たんぱく質** — 下限（例 90g/日）。達成で緑 / 未達はアンバー（多いほど良い）
- **F 脂質** — 上限（目標kcal×30%÷9）。超過で赤 / 以内は緑（脂肪肝対策で少ないほど良い）
- **C 炭水化物** — 目安（目標kcal×50%÷4）。中立の青

カロリー目標未設定時は F/C は目標線なし（現在gのみ）、P は下限で常に表示。

## 変更

| ファイル | 変更 |
|---|---|
| `packages/shared/src/constants.ts` | `KCAL_PER_GRAM` / `PfcGramTargets` / `resolvePfcGramTargets()` を追加 |
| `components/meal/CalorieSummary.tsx` | PFCテキスト行を `MacroBar` 3本に置き換え |
| `pages/Meal.tsx` / `pages/MealHistory.tsx` | 目標を算出してカードに受け渡し（今日／過去日で共有） |
| `tests/unit/resolvePfcGramTargets.test.ts` | 純関数の単体テスト（4件）を追加 |

## テスト

- `pnpm typecheck` ✅（shared/backend/frontend）
- `pnpm test:unit` ✅ 274 passed（新規4件含む）

DBスキーマ変更なし（read-onlyの算出追加のみ、マイグレーション不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)