### PR TITLE
fix: 食事削除時にR2の写真が残る問題を修正し、画像をWebP化する

### DIFF
--- a/packages/backend/src/cron/cleanup.ts
+++ b/packages/backend/src/cron/cleanup.ts
@@ -27,6 +27,10 @@ const TOKEN_CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const EMAIL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (operational logs, recipient PII)
 const AI_USAGE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days (detail; total kept in rollup)
 const TEMP_PHOTO_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours (analysis review flow is minutes)
+// Grace period before an unreferenced photo object is considered orphaned. An
+// object is written to R2 before its meal_photos row exists, so anything recent
+// may simply be mid-save.
+const ORPHANED_PHOTO_GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const R2_DELETE_BATCH_SIZE = 1000; // R2 bucket.delete() accepts up to 1000 keys per call
 
 interface CleanupResult {
@@ -39,6 +43,59 @@ interface CleanupResult {
   deletedAiUsageRecords: number;
   deletedRateLimits: number;
   deletedTempPhotos: number;
+  deletedOrphanedPhotos: number;
+}
+
+/**
+ * Delete R2 photo objects that no meal_photos row references any more.
+ *
+ * Deleting a meal removes its meal_photos rows through ON DELETE CASCADE, but
+ * CASCADE only reaches rows in this database — the R2 objects survive. The
+ * delete route now removes them directly, and per-photo deletion has always
+ * tried to; both, however, swallow storage failures on purpose (the DB is the
+ * source of truth). This sweep is the backstop that makes those cases
+ * eventually consistent, and it also collects objects orphaned before the
+ * delete route was fixed, including the legacy `meals/<id>/photo.jpg` layout.
+ *
+ * The grace window matters: a photo is written to R2 before its meal_photos row
+ * exists, so a freshly uploaded object is briefly unreferenced. Only objects
+ * older than the window are eligible, which keeps an in-flight save safe.
+ *
+ * temp/ is excluded — cleanupTempPhotos owns that prefix and uses its own rule.
+ *
+ * Exported for unit testing.
+ */
+export async function cleanupOrphanedPhotos(
+  bucket: R2Bucket,
+  db: D1Database,
+  now: number
+): Promise<number> {
+  const cutoff = now - ORPHANED_PHOTO_GRACE_MS;
+
+  const referenced = new Set<string>();
+  const rows = await db.prepare('SELECT photo_key FROM meal_photos').all<{ photo_key: string }>();
+  for (const row of rows.results ?? []) {
+    referenced.add(row.photo_key);
+  }
+
+  const orphanedKeys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const listed = await bucket.list({ cursor });
+    for (const object of listed.objects) {
+      if (object.key.startsWith('temp/')) continue;
+      if (object.uploaded.getTime() >= cutoff) continue;
+      if (referenced.has(object.key)) continue;
+      orphanedKeys.push(object.key);
+    }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  for (let i = 0; i < orphanedKeys.length; i += R2_DELETE_BATCH_SIZE) {
+    await bucket.delete(orphanedKeys.slice(i, i + R2_DELETE_BATCH_SIZE));
+  }
+
+  return orphanedKeys.length;
 }
 
 /**
@@ -293,6 +350,22 @@ export async function executeScheduledCleanup(
     console.error('[Cleanup] Error deleting orphaned temp photos:', error);
   }
 
+  // 10. Delete photo objects no meal_photos row references any more. Deleting a
+  //     meal used to leave its R2 objects behind (CASCADE does not reach R2),
+  //     and both delete paths swallow storage errors by design, so this sweep is
+  //     what makes the bucket eventually consistent with the database.
+  let deletedOrphanedPhotos = 0;
+  try {
+    deletedOrphanedPhotos = await cleanupOrphanedPhotos(photosBucket, db, now);
+    console.log(
+      deletedOrphanedPhotos > 0
+        ? `[Cleanup] Deleted ${deletedOrphanedPhotos} orphaned photos from R2`
+        : '[Cleanup] No orphaned photos to delete'
+    );
+  } catch (error) {
+    console.error('[Cleanup] Error deleting orphaned photos:', error);
+  }
+
   const result = {
     deletedUsers,
     deletedPasswordResetTokens,
@@ -303,6 +376,7 @@ export async function executeScheduledCleanup(
     deletedAiUsageRecords,
     deletedRateLimits,
     deletedTempPhotos,
+    deletedOrphanedPhotos,
   };
 
   console.log('[Cleanup] Cleanup tasks completed:', result);

--- a/packages/backend/src/routes/meal-chat.ts
+++ b/packages/backend/src/routes/meal-chat.ts
@@ -11,7 +11,7 @@ import { AIUsageService } from '../services/ai-usage';
 import { aiUsageLimitCheck } from '../middleware/ai-usage-limit';
 import { AIAnalysisService } from '../services/ai-analysis';
 import { MealPhotoService } from '../services/meal-photo.service';
-import { PhotoStorageService } from '../services/photo-storage';
+import { PhotoStorageService, photoExtensionFor } from '../services/photo-storage';
 import { getAIConfigFromEnv } from '../lib/ai-provider';
 import type { Database } from '../db';
 import {
@@ -417,7 +417,7 @@ mealChat.post('/:mealId/chat/add-photo', async (c) => {
   try {
     // Upload to R2
     const photoId = nanoid();
-    const photoKey = `photos/${user.id}/${mealId}/${photoId}.jpg`;
+    const photoKey = `photos/${user.id}/${mealId}/${photoId}${photoExtensionFor(photoFile.type)}`;
     await photoStorage.uploadPhoto(photoKey, photoFile);
 
     // Create DB record

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -336,7 +336,6 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     // (they accounted for the bulk of the orphaned objects in the bucket).
     const photoService = new MealPhotoService(db);
     const photos = await photoService.getMealPhotos(id);
-    console.log(`[Meal Delete] meal=${id} photos=${photos.length}`);
 
     await mealService.delete(id, user.id);
 
@@ -344,7 +343,6 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     for (const photo of photos) {
       try {
         await photoStorage.deletePhoto(photo.photoKey);
-        console.log(`[Meal Delete] removed from R2: ${photo.photoKey}`);
       } catch (error) {
         // The row is already gone, so the object is now unreferenced; the
         // scheduled orphan sweep will pick it up. Don't fail the request.

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -94,7 +94,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       // Validate each photo
       for (const photo of photos) {
         if (!photo.type.startsWith('image/')) {
-          return c.json({ message: '画像ファイルのみアップロードできます' }, 400);
+          return c.json({ message: 'Only image files are supported' }, 400);
         }
         if (photo.size > 10 * 1024 * 1024) {
           return c.json({ message: 'File size exceeds 10MB limit' }, 400);

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -336,6 +336,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     // (they accounted for the bulk of the orphaned objects in the bucket).
     const photoService = new MealPhotoService(db);
     const photos = await photoService.getMealPhotos(id);
+    console.log(`[Meal Delete] meal=${id} photos=${photos.length}`);
 
     await mealService.delete(id, user.id);
 
@@ -343,6 +344,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     for (const photo of photos) {
       try {
         await photoStorage.deletePhoto(photo.photoKey);
+        console.log(`[Meal Delete] removed from R2: ${photo.photoKey}`);
       } catch (error) {
         // The row is already gone, so the object is now unreferenced; the
         // scheduled orphan sweep will pick it up. Don't fail the request.

--- a/packages/backend/src/routes/meals.ts
+++ b/packages/backend/src/routes/meals.ts
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid';
 import { createMealSchema, updateMealSchema, dateRangeSchema, mealTypeSchema, mealDatesQuerySchema, ANALYSIS_SOURCE, MEAL_CONTENT_DELIMITER } from '@lifestyle-app/shared';
 import { MealService } from '../services/meal';
 import { MealPhotoService, deletePhotosWithFoodItems } from '../services/meal-photo.service';
-import { PhotoStorageService } from '../services/photo-storage';
+import { PhotoStorageService, photoExtensionFor } from '../services/photo-storage';
 import { AIAnalysisService } from '../services/ai-analysis';
 import { AIUsageService } from '../services/ai-usage';
 import { aiUsageLimitCheck } from '../middleware/ai-usage-limit';
@@ -94,7 +94,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       // Validate each photo
       for (const photo of photos) {
         if (!photo.type.startsWith('image/')) {
-          return c.json({ message: 'Only JPEG and PNG images are supported' }, 400);
+          return c.json({ message: '画像ファイルのみアップロードできます' }, 400);
         }
         if (photo.size > 10 * 1024 * 1024) {
           return c.json({ message: 'File size exceeds 10MB limit' }, 400);
@@ -137,8 +137,11 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
         // Upload to R2 - generate permanent key
         const photoId = nanoid();
-        const photoKey = `photos/${user.id}/${meal.id}/${photoId}.jpg`;
-        await photoStorage.uploadPhoto(photoKey, photoData);
+        const photoKey = `photos/${user.id}/${meal.id}/${photoId}${photoExtensionFor(photo.type)}`;
+        // Pass the File (not the ArrayBuffer) so the stored contentType comes
+        // from the upload instead of defaulting to image/jpeg — the client now
+        // sends WebP. photoData is still used for the AI analysis below.
+        await photoStorage.uploadPhoto(photoKey, photo);
 
         // Create meal_photo record
         const mealPhoto = await photoService.addPhoto({
@@ -322,7 +325,30 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     const user = c.get('user');
 
     const mealService = new MealService(db);
+
+    // Verify ownership BEFORE reading anything about the meal, so a request for
+    // someone else's meal never reaches its photo keys.
+    await mealService.findById(id, user.id);
+
+    // Collect the R2 keys before the row goes away. meal_photos is removed by
+    // ON DELETE CASCADE when meal_records is deleted, but CASCADE only reaches
+    // rows in this database — the objects in R2 would be left behind forever
+    // (they accounted for the bulk of the orphaned objects in the bucket).
+    const photoService = new MealPhotoService(db);
+    const photos = await photoService.getMealPhotos(id);
+
     await mealService.delete(id, user.id);
+
+    const photoStorage = new PhotoStorageService(c.env.PHOTOS);
+    for (const photo of photos) {
+      try {
+        await photoStorage.deletePhoto(photo.photoKey);
+      } catch (error) {
+        // The row is already gone, so the object is now unreferenced; the
+        // scheduled orphan sweep will pick it up. Don't fail the request.
+        console.error('Failed to delete photo from storage:', error);
+      }
+    }
 
     return c.json({ message: 'Deleted' });
   })
@@ -405,7 +431,7 @@ export const meals = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     try {
       // Upload to R2
       const photoId = nanoid();
-      const photoKey = `photos/${user.id}/${mealId}/${photoId}.jpg`;
+      const photoKey = `photos/${user.id}/${mealId}/${photoId}${photoExtensionFor(photoFile.type)}`;
       await photoStorage.uploadPhoto(photoKey, photoFile);
 
       // Create DB record

--- a/packages/backend/src/services/photo-storage.ts
+++ b/packages/backend/src/services/photo-storage.ts
@@ -1,6 +1,26 @@
 import { v4 as uuidv4 } from 'uuid';
 import { nanoid } from 'nanoid';
 
+/**
+ * File extension matching a photo's MIME type.
+ *
+ * The R2 key used to end in a hard-coded `.jpg`. Since the client re-encodes
+ * uploads to WebP, that would label WebP bytes as JPEG — harmless to serving
+ * (the stored contentType is what browsers honour) but actively misleading
+ * when reading keys during an investigation. Unknown types keep `.jpg`, which
+ * is what every object predating WebP already uses.
+ */
+export function photoExtensionFor(mimeType: string | undefined): string {
+  switch (mimeType) {
+    case 'image/webp':
+      return '.webp';
+    case 'image/png':
+      return '.png';
+    default:
+      return '.jpg';
+  }
+}
+
 export class PhotoStorageService {
   constructor(private r2: R2Bucket) {}
 
@@ -44,7 +64,7 @@ export class PhotoStorageService {
     const data = await tempObject.arrayBuffer();
     const mimeType = tempObject.httpMetadata?.contentType || 'image/jpeg';
     const photoId = nanoid();
-    const permanentKey = `photos/${userId}/${mealId}/${photoId}.jpg`;
+    const permanentKey = `photos/${userId}/${mealId}/${photoId}${photoExtensionFor(mimeType)}`;
 
     await this.r2.put(permanentKey, data, {
       httpMetadata: {

--- a/packages/frontend/src/components/meal/PhotoUploadButton.tsx
+++ b/packages/frontend/src/components/meal/PhotoUploadButton.tsx
@@ -28,7 +28,7 @@ export function PhotoUploadButton({
       event.target.value = '';
 
       // T076: Validate file type (JPEG/PNG only)
-      const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png'];
+      const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
       if (!ALLOWED_TYPES.includes(file.type.toLowerCase())) {
         setError('JPEG または PNG 形式の画像を選択してください');
         return;
@@ -73,7 +73,7 @@ export function PhotoUploadButton({
       <input
         ref={cameraInputRef}
         type="file"
-        accept="image/jpeg,image/jpg,image/png"
+        accept="image/jpeg,image/jpg,image/png,image/webp"
         capture="environment"
         onChange={handleFileSelect}
         className="hidden"
@@ -82,7 +82,7 @@ export function PhotoUploadButton({
       <input
         ref={libraryInputRef}
         type="file"
-        accept="image/jpeg,image/jpg,image/png"
+        accept="image/jpeg,image/jpg,image/png,image/webp"
         onChange={handleFileSelect}
         className="hidden"
       />

--- a/packages/frontend/src/hooks/usePhotoMealFlow.ts
+++ b/packages/frontend/src/hooks/usePhotoMealFlow.ts
@@ -59,7 +59,7 @@ export interface UsePhotoMealFlowReturn {
   reset: () => void;
 }
 
-const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png'];
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const MAX_PHOTOS = 10;
 

--- a/packages/frontend/src/lib/imageResize.ts
+++ b/packages/frontend/src/lib/imageResize.ts
@@ -1,32 +1,63 @@
 /**
- * Resize image to maximum dimensions while preserving aspect ratio
- * Converts to JPEG with quality compression
+ * Downscale a photo and re-encode it as WebP before upload.
+ *
+ * Meal photos dominate R2 storage (the bucket averaged ~609KB per object while
+ * still on 1920px JPEG). Two levers apply: the long edge, and the codec. WebP
+ * is typically 25-35% smaller than JPEG at comparable quality, and 1280px still
+ * leaves headroom for Gemini — whose effective image input is well below that —
+ * while display never needs more than a phone-width card.
+ *
+ * Falls back to the original file whenever anything goes wrong, so a browser
+ * without WebP encoding (or a decode failure) never blocks an upload.
  */
+
+/** Long-edge cap. Above Gemini's effective input size, below the old 1920px. */
+export const MAX_IMAGE_DIMENSION = 1280;
+
+/** WebP quality. 0.80 keeps food detail while undercutting JPEG q0.85 markedly. */
+export const IMAGE_QUALITY = 0.8;
+
+const WEBP_MIME = 'image/webp';
+
+/**
+ * Whether canvas can actually encode WebP. Safari only gained this in 14, and
+ * toBlob silently falls back to PNG for an unsupported type — which would make
+ * files *larger*, so this is checked rather than assumed.
+ */
+function canEncodeWebP(): boolean {
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    return canvas.toDataURL(WEBP_MIME).startsWith(`data:${WEBP_MIME}`);
+  } catch {
+    return false;
+  }
+}
+
 export async function resizeImage(
   file: File,
-  maxWidth: number = 1920,
-  maxHeight: number = 1920,
-  quality: number = 0.85
+  maxWidth: number = MAX_IMAGE_DIMENSION,
+  maxHeight: number = MAX_IMAGE_DIMENSION,
+  quality: number = IMAGE_QUALITY
 ): Promise<File> {
-  // If already small enough, return as-is
-  if (file.size < 500 * 1024) {
-    // Less than 500KB, no need to resize
-    return file;
-  }
-
+  // NOTE: deliberately no "small files pass through" shortcut. A 400KB JPEG is
+  // still worth re-encoding, and skipping by size alone would leave the stored
+  // format inconsistent for no benefit.
   try {
-    // Create image bitmap from file
     const img = await createImageBitmap(file);
+    const sourceWidth = img.width;
+    const sourceHeight = img.height;
 
-    // Calculate new dimensions preserving aspect ratio
-    let { width, height } = img;
+    // Preserve aspect ratio; never upscale.
+    let width = sourceWidth;
+    let height = sourceHeight;
     if (width > maxWidth || height > maxHeight) {
       const ratio = Math.min(maxWidth / width, maxHeight / height);
       width = Math.floor(width * ratio);
       height = Math.floor(height * ratio);
     }
 
-    // Create canvas and draw resized image
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
@@ -37,8 +68,12 @@ export async function resizeImage(
     }
 
     ctx.drawImage(img, 0, 0, width, height);
+    img.close();
 
-    // Convert to blob
+    const useWebP = canEncodeWebP();
+    const mimeType = useWebP ? WEBP_MIME : 'image/jpeg';
+    const extension = useWebP ? '.webp' : '.jpg';
+
     const blob = await new Promise<Blob>((resolve, reject) => {
       canvas.toBlob(
         (result) => {
@@ -48,14 +83,20 @@ export async function resizeImage(
             reject(new Error('Failed to create blob'));
           }
         },
-        'image/jpeg',
+        mimeType,
         quality
       );
     });
 
-    // Convert blob to File
-    return new File([blob], file.name.replace(/\.\w+$/, '.jpg'), {
-      type: 'image/jpeg',
+    // Re-encoding can lose to the original on an already-optimised image that
+    // needed no downscaling. Keeping the smaller of the two means this never
+    // makes an upload heavier than it was.
+    if (blob.size >= file.size && width === sourceWidth && height === sourceHeight) {
+      return file;
+    }
+
+    return new File([blob], file.name.replace(/\.\w+$/, extension), {
+      type: mimeType,
       lastModified: Date.now(),
     });
   } catch (error) {

--- a/tests/integration/meals.test.ts
+++ b/tests/integration/meals.test.ts
@@ -159,7 +159,9 @@ describe('Meal API Integration Tests', () => {
       expect(error.message).toContain('10MB');
     });
 
-    it('should reject invalid photo formats (not JPEG/PNG)', async () => {
+    // The route accepts any image/* type (WebP included since the client
+    // re-encodes uploads); what it rejects is a non-image upload.
+    it('should reject a non-image upload', async () => {
       // T053: File type validation
       const invalidImage = new Blob([new Uint8Array([0x00, 0x01, 0x02])], { type: 'text/plain' });
 

--- a/tests/unit/cleanup-orphaned-photos.test.ts
+++ b/tests/unit/cleanup-orphaned-photos.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanupOrphanedPhotos } from '../../packages/backend/src/cron/cleanup';
+
+const NOW = Date.parse('2026-07-31T02:00:00.000Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+const object = (key: string, ageMs: number) => ({ key, uploaded: new Date(NOW - ageMs) });
+
+const createMockR2Bucket = () => ({
+  list: vi.fn(),
+  delete: vi.fn().mockResolvedValue(undefined),
+});
+
+/** Minimal D1 stub: only `prepare(...).all()` is used, to read photo_key rows. */
+const createMockDb = (keys: string[]) => ({
+  prepare: vi.fn().mockReturnValue({
+    all: vi.fn().mockResolvedValue({ results: keys.map((photo_key) => ({ photo_key })) }),
+  }),
+});
+
+describe('cleanupOrphanedPhotos', () => {
+  let mockR2: ReturnType<typeof createMockR2Bucket>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockR2 = createMockR2Bucket();
+  });
+
+  const run = (referenced: string[]) =>
+    cleanupOrphanedPhotos(
+      mockR2 as unknown as R2Bucket,
+      createMockDb(referenced) as unknown as D1Database,
+      NOW
+    );
+
+  it('deletes photo objects no meal_photos row references', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [
+        object('photos/u1/m1/kept.webp', 48 * HOUR_MS),
+        object('photos/u1/m2/orphan.jpg', 48 * HOUR_MS),
+      ],
+      truncated: false,
+    });
+
+    const deleted = await run(['photos/u1/m1/kept.webp']);
+
+    expect(deleted).toBe(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['photos/u1/m2/orphan.jpg']);
+  });
+
+  it('never deletes an object a row still points at', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [object('photos/u1/m1/live.webp', 90 * 24 * HOUR_MS)],
+      truncated: false,
+    });
+
+    const deleted = await run(['photos/u1/m1/live.webp']);
+
+    expect(deleted).toBe(0);
+    expect(mockR2.delete).not.toHaveBeenCalled();
+  });
+
+  it('spares recent objects — a photo is written to R2 before its row exists', async () => {
+    // Mid-save: the object is unreferenced right now but must survive.
+    mockR2.list.mockResolvedValueOnce({
+      objects: [
+        object('photos/u1/m1/just-uploaded.webp', 2 * HOUR_MS),
+        object('photos/u1/m1/yesterday.webp', 23 * HOUR_MS),
+        object('photos/u1/m1/stale.webp', 25 * HOUR_MS),
+      ],
+      truncated: false,
+    });
+
+    const deleted = await run([]);
+
+    expect(deleted).toBe(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['photos/u1/m1/stale.webp']);
+  });
+
+  it('leaves temp/ alone — cleanupTempPhotos owns that prefix', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [
+        object('temp/abandoned-uuid', 48 * HOUR_MS),
+        object('photos/u1/m1/orphan.webp', 48 * HOUR_MS),
+      ],
+      truncated: false,
+    });
+
+    const deleted = await run([]);
+
+    expect(deleted).toBe(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['photos/u1/m1/orphan.webp']);
+  });
+
+  it('collects the legacy meals/<id>/photo.jpg layout too', async () => {
+    mockR2.list.mockResolvedValueOnce({
+      objects: [object('meals/m-old/photo.jpg', 200 * 24 * HOUR_MS)],
+      truncated: false,
+    });
+
+    const deleted = await run([]);
+
+    expect(deleted).toBe(1);
+    expect(mockR2.delete).toHaveBeenCalledWith(['meals/m-old/photo.jpg']);
+  });
+
+  it('follows the cursor across pages', async () => {
+    mockR2.list
+      .mockResolvedValueOnce({
+        objects: [object('photos/u1/m1/a.webp', 48 * HOUR_MS)],
+        truncated: true,
+        cursor: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        objects: [object('photos/u1/m2/b.webp', 48 * HOUR_MS)],
+        truncated: false,
+      });
+
+    const deleted = await run([]);
+
+    expect(deleted).toBe(2);
+    expect(mockR2.list).toHaveBeenNthCalledWith(2, { cursor: 'page-2' });
+  });
+
+  it('does not call delete when nothing is orphaned', async () => {
+    mockR2.list.mockResolvedValueOnce({ objects: [], truncated: false });
+
+    expect(await run([])).toBe(0);
+    expect(mockR2.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 発端

本番R2バケット（`lifestyle-app-photos`）を調査したところ、**514オブジェクト / 298.8MB のうち188件（37%、約100MB）がD1の `meal_photos` から参照されない孤児**だった。

| プレフィックス | 件数 | 容量 | 平均 |
|---|---|---|---|
| `photos/` | 496 | 294.9 MB | 609 KB |
| `meals/`（初期実装の旧形式） | 18 | 3.9 MB | 223 KB |
| `temp/` | 0 | — | — |

`temp/` が0件だったので既存のcronは正常。原因は別にあった。

## 1. 孤児の原因と修正

`DELETE /api/meals/:id` が `meal_records` の行を消すだけだった。`meal_photos` は `ON DELETE CASCADE` で消えるが、**CASCADEはR2には届かない**ため、写真付きの食事を削除するたびにオブジェクトが残り続けていた。

- **削除経路でR2も消す**。所有権の検証（`findById`）を写真キーの取得より**前**に行い、他人の食事への削除要求がキーに到達しないようにした
- **cronに孤児の掃除を追加**。個別の写真削除は元々R2削除を試みているが、失敗を意図的に握り潰している（DBを正とする設計）。そのぶんを回収する受け皿がなかった

**24時間の猶予**を置いている点が要。写真は `meal_photos` の行より先にR2へ書かれるため、保存中の一瞬は必ず未参照になる。猶予なしで消すと保存中の写真を消しかねない。旧形式の `meals/<id>/photo.jpg` 18件もこの掃除で回収される。

## 2. 画像サイズの削減

長辺1920px・JPEG q0.85（平均609KB）→ **長辺1280px・WebP q0.80**。

Geminiの画像入力は実質これより小さい解像度で足り、表示もスマホ幅の食事カードが主なので、分析精度と表示品質に余裕を残したまま削減できる。

実装上の判断:

- **「500KB未満はリサイズせず返す」早期returnを削除**。サイズで分岐すると400KBのJPEGだけ変換されずに残り、保存形式が不統一になる。代わりに「再エンコード後のほうが大きい かつ 縮小も不要だった」場合は元ファイルを返すので、アップロードが重くなることはない
- **WebPエンコード可否を `canvas.toDataURL` で実際に確認**する。`toBlob` は未対応の形式を渡すと黙ってPNGにフォールバックし、かえって肥大化する（Safari 14未満が該当）
- **R2キーの拡張子をMIMEから導出**（`photoExtensionFor`）。`.jpg` 固定のままだとWebPのバイト列をJPEGと名乗ることになり、キーを読んだ人を誤らせる
- **複数写真アップロード時に `ArrayBuffer` ではなく `File` を渡すよう修正**。`ArrayBuffer` 経路では `contentType` が `image/jpeg` 固定になっていた

## テスト

`tests/unit/cleanup-orphaned-photos.test.ts` を新規追加（7ケース）。参照済みオブジェクトを消さないこと、猶予期間内の新しいオブジェクトを守ること、`temp/` に手を出さないこと、ページングを固定した。

- `pnpm exec vitest run tests/unit` — 293 passed / 0 failed
- `pnpm typecheck` — 3パッケージとも通過
- `pnpm lint` — エラー0

## 適用後の見込み

- 既存の孤児188件（約100MB）は次回のcron実行（毎日2:00 UTC）で回収される
- 以降の写真は1枚あたり **609KB → 150〜200KB程度**（体感1/3〜1/4）になる見込み。既存の画像は再エンコードされないため縮まない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7c4K6LBpXLMx1PgqdmSxg