### PR TITLE
feat: レポートに週ごとのPFC推移を追加

### DIFF
--- a/packages/backend/src/lib/mcpAggregate.ts
+++ b/packages/backend/src/lib/mcpAggregate.ts
@@ -243,8 +243,7 @@ export function weeklyWeightAverages(daily: DailyWeight[]): WeeklyWeightAverage[
 
 export type NutritionGrouping = 'week' | 'month';
 
-export interface NutritionBucket {
-  label: string;
+export interface NutritionTotals {
   days: number;
   meals: number;
   totalCalories: number;
@@ -253,46 +252,71 @@ export interface NutritionBucket {
   totalCarbs: number;
   avgCalories: number;
   avgProtein: number;
+  avgFat: number;
+  avgCarbs: number;
+}
+
+export interface NutritionBucket extends NutritionTotals {
+  label: string;
+}
+
+/**
+ * Sum calories/PFC over an already-selected set of meals.
+ *
+ * `days` counts distinct JST dates that carry a meal, so the per-day averages
+ * divide by LOGGED days rather than the calendar length of the period — a week
+ * with 3 logged days reports the average of those 3 days instead of a figure
+ * diluted across 7. Nulls count as 0: an un-analyzed meal contributes nothing
+ * but still marks the day as logged.
+ *
+ * Split out of nutritionTrend so callers that bucket meals themselves — the
+ * dashboard's rolling 7-day weeks, which do not line up with calendar weeks —
+ * reuse this arithmetic instead of re-summing PFC on their own.
+ */
+export function sumNutrition(meals: MealRow[]): NutritionTotals {
+  const dates = new Set<string>();
+  let cal = 0;
+  let p = 0;
+  let f = 0;
+  let c = 0;
+  for (const m of meals) {
+    dates.add(extractJstDate(m.recordedAt));
+    cal += m.calories ?? 0;
+    p += m.totalProtein ?? 0;
+    f += m.totalFat ?? 0;
+    c += m.totalCarbs ?? 0;
+  }
+  const days = dates.size;
+  const perDay = (total: number): number => (days > 0 ? total / days : 0);
+  return {
+    days,
+    meals: meals.length,
+    totalCalories: cal,
+    totalProtein: p,
+    totalFat: f,
+    totalCarbs: c,
+    avgCalories: perDay(cal),
+    avgProtein: perDay(p),
+    avgFat: perDay(f),
+    avgCarbs: perDay(c),
+  };
 }
 
 /**
  * Bucket meals into weeks (Sun–Sat start date as label) or calendar months
- * (YYYY-MM) and sum calories/PFC. `days` counts distinct JST dates with a meal
- * in the bucket, so the per-day averages reflect actual logged days rather than
- * calendar length.
+ * (YYYY-MM) and sum calories/PFC per bucket via sumNutrition.
  */
 export function nutritionTrend(meals: MealRow[], groupBy: NutritionGrouping): NutritionBucket[] {
-  const buckets = new Map<
-    string,
-    { label: string; dates: Set<string>; meals: number; cal: number; p: number; f: number; c: number }
-  >();
+  const buckets = new Map<string, MealRow[]>();
   for (const m of meals) {
     const date = extractJstDate(m.recordedAt);
     const label = groupBy === 'week' ? getWeekDateRange(date).startDate : date.slice(0, 7);
-    const b = buckets.get(label) ?? { label, dates: new Set<string>(), meals: 0, cal: 0, p: 0, f: 0, c: 0 };
-    b.dates.add(date);
-    b.meals += 1;
-    b.cal += m.calories ?? 0;
-    b.p += m.totalProtein ?? 0;
-    b.f += m.totalFat ?? 0;
-    b.c += m.totalCarbs ?? 0;
-    buckets.set(label, b);
+    const group = buckets.get(label);
+    if (group) group.push(m);
+    else buckets.set(label, [m]);
   }
-  return [...buckets.values()]
-    .map((b) => {
-      const days = b.dates.size;
-      return {
-        label: b.label,
-        days,
-        meals: b.meals,
-        totalCalories: b.cal,
-        totalProtein: b.p,
-        totalFat: b.f,
-        totalCarbs: b.c,
-        avgCalories: days > 0 ? b.cal / days : 0,
-        avgProtein: days > 0 ? b.p / days : 0,
-      };
-    })
+  return [...buckets.entries()]
+    .map(([label, group]) => ({ label, ...sumNutrition(group) }))
     .sort((a, b) => a.label.localeCompare(b.label));
 }
 

--- a/packages/backend/src/services/dashboard.ts
+++ b/packages/backend/src/services/dashboard.ts
@@ -1,7 +1,9 @@
 import { eq, desc, and, gte, lt } from 'drizzle-orm';
+import { KCAL_PER_GRAM, macroKcal } from '@lifestyle-app/shared';
 import { weights, meals, exercises } from '../db/schema';
 import type { Database } from '../db';
 import { extractLocalDate, nextLocalDate } from '../lib/localDate';
+import { sumNutrition } from '../lib/mcpAggregate';
 
 interface DateRange {
   startDate: Date;
@@ -70,6 +72,23 @@ interface WeeklyTrendItem {
   weight: number | null;
   totalCalories: number;
   exerciseSets: number;
+  /** Days in the week that carry at least one meal — the divisor for the avg* fields. */
+  mealDays: number;
+  mealCount: number;
+  totalProtein: number;
+  totalFat: number;
+  totalCarbs: number;
+  /** Per LOGGED day (mealDays), not per calendar day. */
+  avgCalories: number;
+  avgProtein: number;
+  avgFat: number;
+  avgCarbs: number;
+  /**
+   * Fat's share of macro-derived kcal, 0–100, UNROUNDED. null when the week has
+   * no analyzed macros. Rounding is left to the caller so a display value is
+   * never mistaken for a comparison value (the trap fixed in #178).
+   */
+  fatPct: number | null;
 }
 
 interface GoalProgress {
@@ -357,9 +376,13 @@ export class DashboardService {
       const weekMeals = allMeals.filter((m) => inWeek(m.recordedAt));
       const weekExercises = allExercises.filter((e) => inWeek(e.recordedAt));
 
-      const totalCalories = weekMeals
-        .filter((m) => m.calories != null)
-        .reduce((sum, m) => sum + (m.calories || 0), 0);
+      // Same arithmetic the MCP nutrition trend uses, applied to this rolling
+      // 7-day bucket instead of a calendar week (#181). sumNutrition buckets
+      // `days` by extractJstDate while week membership above uses the
+      // extractLocalDate prefix; the two only diverge for legacy bare-"Z" rows
+      // (pre-#159), which no longer occur inside a trailing few-week window.
+      const nutrition = sumNutrition(weekMeals);
+      const macro = macroKcal(nutrition.totalProtein, nutrition.totalFat, nutrition.totalCarbs);
 
       // Each record is 1 set
       const exerciseSets = weekExercises.length;
@@ -368,8 +391,18 @@ export class DashboardService {
         weekStart: weekStartLocal,
         weekEnd: weekEndLocal,
         weight: latestWeekWeight?.weight ?? null,
-        totalCalories,
+        totalCalories: nutrition.totalCalories,
         exerciseSets,
+        mealDays: nutrition.days,
+        mealCount: nutrition.meals,
+        totalProtein: nutrition.totalProtein,
+        totalFat: nutrition.totalFat,
+        totalCarbs: nutrition.totalCarbs,
+        avgCalories: nutrition.avgCalories,
+        avgProtein: nutrition.avgProtein,
+        avgFat: nutrition.avgFat,
+        avgCarbs: nutrition.avgCarbs,
+        fatPct: macro > 0 ? ((nutrition.totalFat * KCAL_PER_GRAM.fat) / macro) * 100 : null,
       });
     }
 

--- a/packages/frontend/src/components/dashboard/WeeklyPfcTrendCard.tsx
+++ b/packages/frontend/src/components/dashboard/WeeklyPfcTrendCard.tsx
@@ -101,7 +101,11 @@ export function WeeklyPfcTrendCard({ weeks, fatPctTarget }: WeeklyPfcTrendCardPr
     };
   });
 
-  const hasAnyData = rows.some((r) => r.shares !== null);
+  // PFCは写真のAI解析（またはfood item）経由でしか入らないので、「食事はあるが
+  // マクロが1件も無い」状態が普通に起きる。行を4本とも「PFC未分析」で埋めるより、
+  // 何をすれば出るのかを1行で言うほうが親切。
+  const hasAnyShares = rows.some((r) => r.shares !== null);
+  const hasAnyMeals = rows.some((r) => r.week.mealDays > 0);
 
   return (
     <div className="card p-4 sm:p-5" data-testid="weekly-pfc-trend-card">
@@ -110,9 +114,11 @@ export function WeeklyPfcTrendCard({ weeks, fatPctTarget }: WeeklyPfcTrendCardPr
         <span className="text-[11px] text-gray-400">脂質シェアの推移（{weeks.length}週）</span>
       </div>
 
-      {!hasAnyData ? (
+      {!hasAnyShares ? (
         <p className="mt-4 text-center text-sm text-gray-400">
-          食事を記録すると週ごとの推移が出ます
+          {hasAnyMeals
+            ? '食事の写真をAI解析するとPFCの推移が出ます'
+            : '食事を記録すると週ごとの推移が出ます'}
         </p>
       ) : (
         <>
@@ -134,7 +140,11 @@ export function WeeklyPfcTrendCard({ weeks, fatPctTarget }: WeeklyPfcTrendCardPr
                         脂質 {week.fatPct.toFixed(1)}%
                       </span>
                     ) : (
-                      <span className="text-gray-300">記録なし</span>
+                      // 食事はあるがマクロが未分析の週を「記録なし」と書くと嘘になる
+                      // （手入力の食事や、写真解析前の食事はカロリーだけを持つ）。
+                      <span className="text-gray-300">
+                        {week.mealDays > 0 ? 'PFC未分析' : '記録なし'}
+                      </span>
                     )}
                     {delta.text && (
                       <span className={`text-[10px] ${deltaClass[delta.tone]}`}>{delta.text}</span>
@@ -153,11 +163,17 @@ export function WeeklyPfcTrendCard({ weeks, fatPctTarget }: WeeklyPfcTrendCardPr
                     <div className="h-2 w-full rounded-full bg-gray-100" />
                   )}
                 </div>
-                {shares && (
+                {week.mealDays > 0 && (
                   <p className="mt-1 text-[10px] text-gray-400 tabular-nums">
-                    1日 {Math.round(week.avgCalories).toLocaleString()}kcal・P
-                    {Math.round(week.avgProtein)}g F{Math.round(week.avgFat)}g C
-                    {Math.round(week.avgCarbs)}g（記録{week.mealDays}日）
+                    1日 {Math.round(week.avgCalories).toLocaleString()}kcal
+                    {/* マクロ未分析の週はカロリーだけ分かっているので、そこまでは出す。 */}
+                    {shares && (
+                      <>
+                        ・P{Math.round(week.avgProtein)}g F{Math.round(week.avgFat)}g C
+                        {Math.round(week.avgCarbs)}g
+                      </>
+                    )}
+                    （記録{week.mealDays}日）
                   </p>
                 )}
               </div>

--- a/packages/frontend/src/components/dashboard/WeeklyPfcTrendCard.tsx
+++ b/packages/frontend/src/components/dashboard/WeeklyPfcTrendCard.tsx
@@ -1,0 +1,192 @@
+import { KCAL_PER_GRAM, macroKcal } from '@lifestyle-app/shared';
+import { describeFatShareDelta, type FatShareDeltaTone } from '../../lib/fatShareDelta';
+
+/**
+ * One rolling 7-day bucket from GET /api/dashboard/trends. Declared structurally
+ * (rather than importing the RPC type) so the card only depends on the fields it
+ * actually renders.
+ */
+interface WeeklyPfcPoint {
+  weekStart: string;
+  weekEnd: string;
+  mealDays: number;
+  totalProtein: number;
+  totalFat: number;
+  totalCarbs: number;
+  avgCalories: number;
+  avgProtein: number;
+  avgFat: number;
+  avgCarbs: number;
+  /** 脂質のエネルギーシェア(0-100, 未丸め)。マクロ未分析の週は null。 */
+  fatPct: number | null;
+}
+
+interface WeeklyPfcTrendCardProps {
+  /** 古い週 → 新しい週 の順（APIの並びのまま）。 */
+  weeks: WeeklyPfcPoint[];
+  /** 脂質シェアの上限(%)。resolveWeeklyMealTargets().fatPct を渡す。 */
+  fatPctTarget: number;
+}
+
+const deltaClass: Record<FatShareDeltaTone, string> = {
+  better: 'text-emerald-600',
+  worse: 'text-amber-600',
+  flat: 'text-gray-400',
+  none: 'text-gray-300',
+};
+
+/**
+ * 積み上げPFCバー。色と並び（P=緑 → C=琥珀 → F=赤）は WeeklyMealSummaryCard の
+ * PfcBar と同一にしてある。脂質が最後＝右端に積まれるので、「脂質シェアが目標以下」は
+ * 「赤い帯の左端が (100 - 目標)% より右」と読める。参照線はその位置に1本引くだけでよく、
+ * 合否の色分け（今回スコープ外）を持ち込まずに目標の位置だけ示せる。
+ */
+function StackedPfcBar({
+  proteinPct,
+  carbsPct,
+  fatPct,
+  fatPctTarget,
+}: {
+  proteinPct: number;
+  carbsPct: number;
+  fatPct: number;
+  fatPctTarget: number;
+}) {
+  return (
+    <div className="relative h-2 w-full overflow-hidden rounded-full bg-gray-100">
+      <div className="flex h-full w-full">
+        <span className="bg-emerald-400" style={{ width: `${proteinPct}%` }} />
+        <span className="bg-amber-300" style={{ width: `${carbsPct}%` }} />
+        <span className="bg-red-400" style={{ width: `${fatPct}%` }} />
+      </div>
+      {/* 線は赤帯(bg-red-400)の上に来ることが多いので、薄いグレーだと沈んで見えない。 */}
+      <span
+        aria-hidden
+        className="absolute inset-y-0 w-0.5 -translate-x-1/2 bg-gray-800/70"
+        style={{ left: `${100 - fatPctTarget}%` }}
+      />
+    </div>
+  );
+}
+
+/** "01-04" → "1/4" */
+function shortDate(isoDate: string): string {
+  const [, month, day] = isoDate.split('-');
+  return `${Number(month)}/${Number(day)}`;
+}
+
+/**
+ * 週次のPFC推移カード。1日単位のブレに振り回されずに脂質シェアの傾向を見るための
+ * ビュー（体重を移動平均で見るのと同じ発想）。週の区切りは /trends のローリング窓
+ * （今日から7日ずつ遡る）で、暦週ではない。
+ */
+export function WeeklyPfcTrendCard({ weeks, fatPctTarget }: WeeklyPfcTrendCardProps) {
+  const rows = weeks.map((week, i) => {
+    const macro = macroKcal(week.totalProtein, week.totalFat, week.totalCarbs);
+    // シェアは3つとも同じ分母（PFC由来kcal）で出す。摂取カロリーを分母にすると
+    // 未計上分（アルコール等）でシェアが歪み、カレンダーのドットと食い違う。
+    const shares =
+      macro > 0
+        ? {
+            protein: ((week.totalProtein * KCAL_PER_GRAM.protein) / macro) * 100,
+            carbs: ((week.totalCarbs * KCAL_PER_GRAM.carbs) / macro) * 100,
+            fat: ((week.totalFat * KCAL_PER_GRAM.fat) / macro) * 100,
+          }
+        : null;
+    return {
+      week,
+      shares,
+      delta: describeFatShareDelta(week.fatPct, weeks[i - 1]?.fatPct),
+      isLatest: i === weeks.length - 1,
+    };
+  });
+
+  const hasAnyData = rows.some((r) => r.shares !== null);
+
+  return (
+    <div className="card p-4 sm:p-5" data-testid="weekly-pfc-trend-card">
+      <div className="flex items-baseline justify-between gap-2">
+        <h2 className="text-sm font-semibold text-gray-900">週ごとのPFC</h2>
+        <span className="text-[11px] text-gray-400">脂質シェアの推移（{weeks.length}週）</span>
+      </div>
+
+      {!hasAnyData ? (
+        <p className="mt-4 text-center text-sm text-gray-400">
+          食事を記録すると週ごとの推移が出ます
+        </p>
+      ) : (
+        <>
+          <div className="mt-3 space-y-3">
+            {rows.map(({ week, shares, delta, isLatest }) => (
+              <div key={week.weekStart}>
+                <div className="flex items-baseline justify-between gap-2 text-[11px]">
+                  <span className="text-gray-500 tabular-nums">
+                    {shortDate(week.weekStart)}〜{shortDate(week.weekEnd)}
+                    {isLatest && (
+                      <span className="ml-1.5 rounded bg-gray-100 px-1 py-px text-[10px] text-gray-500">
+                        今週
+                      </span>
+                    )}
+                  </span>
+                  <span className="flex items-baseline gap-1.5 tabular-nums">
+                    {week.fatPct != null ? (
+                      <span className="font-semibold text-gray-900">
+                        脂質 {week.fatPct.toFixed(1)}%
+                      </span>
+                    ) : (
+                      <span className="text-gray-300">記録なし</span>
+                    )}
+                    {delta.text && (
+                      <span className={`text-[10px] ${deltaClass[delta.tone]}`}>{delta.text}</span>
+                    )}
+                  </span>
+                </div>
+                <div className="mt-1">
+                  {shares ? (
+                    <StackedPfcBar
+                      proteinPct={shares.protein}
+                      carbsPct={shares.carbs}
+                      fatPct={shares.fat}
+                      fatPctTarget={fatPctTarget}
+                    />
+                  ) : (
+                    <div className="h-2 w-full rounded-full bg-gray-100" />
+                  )}
+                </div>
+                {shares && (
+                  <p className="mt-1 text-[10px] text-gray-400 tabular-nums">
+                    1日 {Math.round(week.avgCalories).toLocaleString()}kcal・P
+                    {Math.round(week.avgProtein)}g F{Math.round(week.avgFat)}g C
+                    {Math.round(week.avgCarbs)}g（記録{week.mealDays}日）
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-3 border-t border-gray-100 pt-2.5 text-[10px] text-gray-400">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span className="flex items-center gap-1">
+                <span className="h-2 w-2 rounded-sm bg-emerald-400" />
+                たんぱく質
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="h-2 w-2 rounded-sm bg-amber-300" />
+                炭水化物
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="h-2 w-2 rounded-sm bg-red-400" />
+                脂質
+              </span>
+            </div>
+            {/* 脂質は右端に積まれるので、線を「越える／越えない」で読める。 */}
+            <p className="mt-1 flex items-center gap-1">
+              <span className="h-2.5 w-0.5 shrink-0 bg-gray-800/70" />
+              縦線は脂質{fatPctTarget}%の位置。赤がここを越えると多めです
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/fatShareDelta.ts
+++ b/packages/frontend/src/lib/fatShareDelta.ts
@@ -1,0 +1,50 @@
+/**
+ * 週次PFCカードの「前週比」。脂質シェアの差を短いラベルに変換する純関数。
+ *
+ * カード本体（WeeklyPfcTrendCard）から切り出してあるのは、下の「横ばい」幅が
+ * 見た目ではなく判断の閾値だから。ここだけ単体テストで固定しておきたい。
+ */
+
+/** tone はテキストの色分けに使う。脂質は下がるほうが良い指標なので減少=better。 */
+export type FatShareDeltaTone = 'better' | 'worse' | 'flat' | 'none';
+
+export interface FatShareDelta {
+  text: string;
+  tone: FatShareDeltaTone;
+}
+
+/**
+ * 前週比を「横ばい」と見なす幅（%ポイント）。
+ *
+ * 1750 kcal/日の計画で 1pt は脂質約1.9g/日 — ドレッシング大さじ半分程度で、
+ * 献立が変わったとは言えない量。このカード自体が「1日のブレに振り回されずに
+ * 週の傾向を見る」ために作られているので、差の読み方も同じ基準に揃え、
+ * これ未満は傾向ではなくノイズとして扱う。
+ */
+export const FAT_SHARE_NOISE_PT = 1;
+
+/**
+ * 脂質シェアの前週比を短いラベルにする。
+ *
+ * `previous` は配列の先頭（最も古い週）で undefined、記録のない週で null になる。
+ * どちらも「比較できない」なので tone='none' と空文字を返し、呼び出し側は
+ * 何も描画しない — 0pt と表示すると「変化なし」に見えてしまう。
+ */
+export function describeFatShareDelta(
+  current: number | null,
+  previous: number | null | undefined
+): FatShareDelta {
+  // == null で undefined と null の両方を弾く。
+  if (current == null || previous == null) return { text: '', tone: 'none' };
+
+  const delta = current - previous;
+  if (Math.abs(delta) < FAT_SHARE_NOISE_PT) return { text: '横ばい', tone: 'flat' };
+
+  // 矢印+絶対値の書式は WeeklyMealSummaryCard の体重表記（"7日平均 ↓0.3kg"）に合わせる。
+  // 単位は % ではなく pt — 比べているのは割合そのものではなく割合の差。
+  const improving = delta < 0;
+  return {
+    text: `${improving ? '↓' : '↑'}${Math.abs(delta).toFixed(1)}pt`,
+    tone: improving ? 'better' : 'worse',
+  };
+}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,13 +1,28 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { resolveWeeklyMealTargets } from '@lifestyle-app/shared';
 import { useDashboard, type Period } from '../hooks/useDashboard';
+import { api } from '../lib/client';
 import { PeriodSelector } from '../components/dashboard/PeriodSelector';
 import { WeightSummaryCard } from '../components/dashboard/WeightSummaryCard';
 import { MealSummaryCard } from '../components/dashboard/MealSummaryCard';
 import { ExerciseSummaryCard } from '../components/dashboard/ExerciseSummaryCard';
+import { WeeklyPfcTrendCard } from '../components/dashboard/WeeklyPfcTrendCard';
 
 export function Dashboard() {
   const [period, setPeriod] = useState<Period>('week');
-  const { summary, isLoading, refetch } = useDashboard({ period });
+  const { summary, trends, isLoading, refetch } = useDashboard({ period });
+
+  // 脂質シェアの参照線はユーザー個別の目標に追従させる（#170で users に保存済み）。
+  const { data: profile } = useQuery({
+    queryKey: ['user', 'profile'],
+    queryFn: async () => {
+      const res = await api.user.profile.$get();
+      if (!res.ok) throw new Error('Failed to fetch profile');
+      return res.json();
+    },
+  });
+  const fatPctTarget = resolveWeeklyMealTargets({ fatPct: profile?.targetFatPct }).fatPct;
 
   if (isLoading) {
     return (
@@ -93,6 +108,11 @@ export function Dashboard() {
               byType={summary?.exercises.byType ?? {}}
             />
           </div>
+
+          {/* 週次のPFC推移。/trends のローリング窓なので period セレクタとは独立。 */}
+          {trends && trends.length > 0 && (
+            <WeeklyPfcTrendCard weeks={trends} fatPctTarget={fatPctTarget} />
+          )}
 
           {/* Period Info */}
           {summary?.period && (

--- a/tests/unit/dashboard.service.test.ts
+++ b/tests/unit/dashboard.service.test.ts
@@ -203,6 +203,83 @@ describe('DashboardService', () => {
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
     });
+
+    // #181: the trend now carries weekly PFC so the dashboard can show the fat
+    // share as a rolling-7-day trend instead of a single noisy day.
+    describe('weekly PFC', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        // 2026-01-17T05:00:00Z = 2026-01-17 14:00 JST. weeks=2 =>
+        // [2026-01-04 .. 2026-01-10] and [2026-01-11 .. 2026-01-17].
+        vi.setSystemTime(new Date('2026-01-17T05:00:00Z'));
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('sums PFC per rolling week and derives the fat energy share', async () => {
+        mockDb.all.mockResolvedValueOnce([]); // allWeights
+        mockDb.all.mockResolvedValueOnce([
+          // Older week: macros never analyzed.
+          { calories: 600, recordedAt: '2026-01-08T12:00:00+09:00', totalProtein: null, totalFat: null, totalCarbs: null },
+          // Recent week: two meals on 01-12, one on 01-15 => 2 logged days.
+          { calories: 800, recordedAt: '2026-01-12T08:00:00+09:00', totalProtein: 30, totalFat: 25, totalCarbs: 80 },
+          { calories: 700, recordedAt: '2026-01-12T19:00:00+09:00', totalProtein: 20, totalFat: 10, totalCarbs: 40 },
+          { calories: 500, recordedAt: '2026-01-15T12:00:00+09:00', totalProtein: 10, totalFat: 5, totalCarbs: 30 },
+          // Before the oldest weekStart — must be excluded from both weeks.
+          { calories: 9999, recordedAt: '2026-01-03T12:00:00+09:00', totalProtein: 99, totalFat: 99, totalCarbs: 99 },
+        ]); // allMeals
+        mockDb.all.mockResolvedValueOnce([]); // allExercises
+
+        const result = await service.getWeeklyTrend('user-pfc', 2);
+
+        expect(result).toHaveLength(2);
+        // result is unshifted, so [0] is the older week.
+        expect(result[0]).toMatchObject({
+          weekStart: '2026-01-04',
+          weekEnd: '2026-01-10',
+          totalCalories: 600,
+          mealDays: 1,
+          mealCount: 1,
+          totalProtein: 0,
+          totalFat: 0,
+          // No analyzed macros => no denominator => share is unknown, not 0%.
+          fatPct: null,
+        });
+        expect(result[1]).toMatchObject({
+          weekStart: '2026-01-11',
+          weekEnd: '2026-01-17',
+          totalCalories: 2000,
+          mealDays: 2,
+          mealCount: 3,
+          totalProtein: 60,
+          totalFat: 40,
+          totalCarbs: 150,
+          // Per LOGGED day (2), not per calendar day (7).
+          avgCalories: 1000,
+          avgProtein: 30,
+          avgFat: 20,
+          avgCarbs: 75,
+        });
+        // macro kcal = 60*4 + 40*9 + 150*4 = 1200; fat contributes 360 => 30%.
+        expect(result[1]!.fatPct).toBeCloseTo(30, 10);
+      });
+
+      it('reports zeros and a null fat share for a week with no meals', async () => {
+        mockDb.all.mockResolvedValue([]);
+
+        const result = await service.getWeeklyTrend('user-empty', 1);
+
+        expect(result[0]).toMatchObject({
+          totalCalories: 0,
+          mealDays: 0,
+          mealCount: 0,
+          totalFat: 0,
+          avgFat: 0,
+          fatPct: null,
+        });
+      });
+    });
   });
 
   describe('getGoalProgress', () => {

--- a/tests/unit/fatShareDelta.test.ts
+++ b/tests/unit/fatShareDelta.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import {
+  describeFatShareDelta,
+  FAT_SHARE_NOISE_PT,
+} from '../../packages/frontend/src/lib/fatShareDelta';
+
+describe('describeFatShareDelta', () => {
+  it('calls a drop an improvement (fat share is a lower-is-better metric)', () => {
+    expect(describeFatShareDelta(30.2, 34.5)).toEqual({ text: '↓4.3pt', tone: 'better' });
+  });
+
+  it('calls a rise a regression', () => {
+    expect(describeFatShareDelta(38.0, 34.5)).toEqual({ text: '↑3.5pt', tone: 'worse' });
+  });
+
+  it(`treats a swing under ${FAT_SHARE_NOISE_PT}pt as noise, not a trend`, () => {
+    // ~1.9g of fat a day on a 1750 kcal plan — the menu did not really change.
+    expect(describeFatShareDelta(30.4, 30.0)).toEqual({ text: '横ばい', tone: 'flat' });
+    expect(describeFatShareDelta(30.0, 30.4)).toEqual({ text: '横ばい', tone: 'flat' });
+  });
+
+  it('puts the boundary itself outside the noise band', () => {
+    // Exactly the threshold reads as a real move; just under it does not.
+    expect(describeFatShareDelta(31, 30).tone).toBe('worse');
+    expect(describeFatShareDelta(30.99, 30).tone).toBe('flat');
+  });
+
+  it('stays silent when there is nothing to compare against', () => {
+    // Oldest week in the series (no predecessor).
+    expect(describeFatShareDelta(30.0, undefined)).toEqual({ text: '', tone: 'none' });
+    // Either side unlogged: "0pt" would read as "unchanged", which is a lie.
+    expect(describeFatShareDelta(30.0, null)).toEqual({ text: '', tone: 'none' });
+    expect(describeFatShareDelta(null, 30.0)).toEqual({ text: '', tone: 'none' });
+  });
+
+  it('rounds only for display, never for the comparison', () => {
+    // Rounds to "↑1.0pt" but is genuinely above the band, so it is not flat.
+    expect(describeFatShareDelta(31.04, 30.0)).toEqual({ text: '↑1.0pt', tone: 'worse' });
+  });
+});

--- a/tests/unit/mcpAggregate.test.ts
+++ b/tests/unit/mcpAggregate.test.ts
@@ -5,6 +5,7 @@ import {
   dailyWeightSeries,
   movingAverageSeries,
   weeklyWeightAverages,
+  sumNutrition,
   nutritionTrend,
   exerciseBreakdown,
   type FoodItemRow,
@@ -146,6 +147,49 @@ describe('weeklyWeightAverages', () => {
     const weekly = weeklyWeightAverages(daily);
     expect(weekly).toHaveLength(1);
     expect(weekly[0]).toMatchObject({ weekStart: '2026-07-12', avg: 71, count: 2 });
+  });
+});
+
+describe('sumNutrition', () => {
+  it('sums PFC, counts distinct JST days, and averages per LOGGED day', () => {
+    const totals = sumNutrition([
+      meal({ recordedAt: '2026-07-17T08:00:00+09:00', calories: 400, totalProtein: 30, totalFat: 10, totalCarbs: 40 }),
+      meal({ recordedAt: '2026-07-17T19:00:00+09:00', calories: 600, totalProtein: 30, totalFat: 20, totalCarbs: 60 }),
+      meal({ recordedAt: '2026-07-19T12:00:00+09:00', calories: 500, totalProtein: 20, totalFat: 15, totalCarbs: 50 }),
+    ]);
+    expect(totals).toMatchObject({
+      days: 2, // 07-17 and 07-19; 07-18 was skipped and is NOT a divisor
+      meals: 3,
+      totalCalories: 1500,
+      totalProtein: 80,
+      totalFat: 45,
+      totalCarbs: 150,
+      avgCalories: 750,
+      avgProtein: 40,
+      avgFat: 22.5,
+      avgCarbs: 75,
+    });
+  });
+
+  it('treats null macros as zero but still counts the day as logged', () => {
+    const totals = sumNutrition([
+      meal({ recordedAt: '2026-07-17T12:00:00+09:00', calories: null, totalProtein: null, totalFat: null, totalCarbs: null }),
+    ]);
+    expect(totals).toMatchObject({ days: 1, meals: 1, totalCalories: 0, totalFat: 0, avgFat: 0 });
+  });
+
+  it('returns zeros (not NaN) for an empty period', () => {
+    expect(sumNutrition([])).toMatchObject({ days: 0, meals: 0, avgCalories: 0, avgFat: 0 });
+  });
+
+  it('buckets a legacy bare-UTC row onto its JST day, not its UTC prefix', () => {
+    // 2026-07-17T22:00:00Z is 2026-07-18 07:00 JST (pre-#159 rows). A naive
+    // slice(0,10) would read "2026-07-17" and split these into two days.
+    const totals = sumNutrition([
+      meal({ recordedAt: '2026-07-17T22:00:00Z' }),
+      meal({ recordedAt: '2026-07-18T12:00:00+09:00' }),
+    ]);
+    expect(totals.days).toBe(1);
   });
 });
 


### PR DESCRIPTION
## 背景

脂質は1日単位だとブレが大きい。焼肉ランチ1食（脂質108g）で日次評価が振り切れてしまうが、それは「その日の食事が悪かった」以上のことを意味しない。体重を移動平均で見るのと同じように、脂質も週トレンドで追えるようにする。

`mcpAggregate.ts` には `nutritionTrend()` という週次PFC集計が既にあったが、MCPツールからしか使われていなかった。一方フロントの `trendsQuery` は `/api/dashboard/trends` を取得だけして**どこにも描画していなかった**。この2つを繋ぐ。

## 変更

### バックエンド

- **`mcpAggregate.ts`** — `nutritionTrend()` は「バケット分け（暦週ラベル）」と「合計の算術」が同居していた。後者を `sumNutrition()` として分離し、バケットの決め方は呼び出し側の責務に。併せて `avgFat` / `avgCarbs` を追加（従来は `avgCalories` / `avgProtein` のみ）
- **`services/dashboard.ts`** — `getWeeklyTrend()` が `sumNutrition()` でローリング7日窓のPFCを集計。`WeeklyTrendItem` に `totalProtein/Fat/Carbs`・`mealDays`・`mealCount`・1日平均・`fatPct` を追加

週の区切りは既存 `getWeeklyTrend` の**ローリング窓**（今日から7日ずつ遡る）に統一した。`nutritionTrend()` の暦週（日〜土）とは別だが、集計の算術は共有している。

**追加クエリはない** — 既に週分の meals を取得済みなので、同じ配列を畳むだけ。

### フロントエンド

- **`WeeklyPfcTrendCard.tsx`**（新規）— 積み上げPFCバー + 脂質シェア + 前週比
- **`lib/fatShareDelta.ts`**（新規）— 前週比の判定（純関数）
- **`Dashboard.tsx`** — 未描画だった `trendsQuery` をここで初めて使用

色と積み上げ順（P緑 → C琥珀 → F赤）は既存 `WeeklyMealSummaryCard` の `PfcBar` に合わせた。副産物として**脂質が右端に積まれる**ので、「脂質シェア30%以下」＝「赤い帯の左端が70%より右」となり、目標が固定位置の縦線1本で表せる。合否判定ロジックを持ち込まずに目標の位置だけ示せる。

参照線はユーザー個別の目標（`users.target_fat_pct`, #170）に追従する。

## 設計判断

| 判断 | 内容 | 理由 |
|---|---|---|
| `fatPct` を未丸めで返す | 丸めは表示直前の `.toFixed(1)` 一箇所だけ | #178 で「丸めてから比較したせいで週次カードとカレンダーのドットがズレる」事故を踏んでいる |
| シェアの分母は PFC由来kcal | 摂取カロリーではない | 未計上分（アルコール等）でシェアが歪み、カレンダーのドットと食い違うのを防ぐ |
| 「横ばい」の幅 = 1.0pt | これ未満はノイズ扱い | 1750kcal/日の計画で1pt ≒ 脂質1.9g/日 ＝ ドレッシング大さじ半分。献立が変わったとは言えない |
| period セレクタと独立 | `/trends` は常に直近4週 | ローリング4週は「傾向を見る固定の窓」で、期間切替に連動させると意味が壊れる |

## スコープ外

脂質の**目標対比の評価（合否色）**は入れていない。縦線は位置を示すだけで、赤/緑の判定色は使っていない。DBスキーマ変更もなし（マイグレーション不要）。

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm typecheck` | 3パッケージすべて Done |
| `pnpm lint` | 0 errors（残る1 warningは `PhotoAnalysisReview.tsx` の既存分） |
| `pnpm exec vitest run tests/unit` | 305 passed（新規19件） |
| `pnpm build` | 成功 |
| `pnpm find-deadcode` | 新規の未使用エクスポートなし（既存2件のみ） |
| レイアウト | ビルド済みCSSで実描画し 320/390/768px で横スクロールなしを確認 |

追加テスト:
- `sumNutrition` — 記録日で割る平均 / null を0扱い / 空でNaNにならない / レガシーな bare-UTC 行をJST日にまとめる
- `getWeeklyTrend` — ローリング窓ごとのPFC合計と脂質シェア30%の算出、窓外レコードの除外、マクロ未分析週の `fatPct: null`
- `describeFatShareDelta` — 増減の向き / ノイズ帯の境界 / 比較対象がない場合 / **表示は丸めても比較は生値**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7c4K6LBpXLMx1PgqdmSxg

---

## プレビュー環境での検証（追記）

https://lifestyle-tracker-pr-181.abe00makoto.workers.dev

PFCはAPIから投入できない（`createMealSchema` は `mealType/content/calories/recordedAt` のみ）ため、preview D1 に `[seed181]` タグ付きの食事40件を直接INSERTし、脂質シェアが **36% → 31% → 30.5% → 38%** と動くデータで確認した。検証後に40件とも削除済み（既存データは無傷）。

### API (`/api/dashboard/trends?weeks=4`)

| 週 | 記録日 | 食事数 | fatPct |
|---|---|---|---|
| 07-05〜07-11 | 5 | 10 | 36.0 |
| 07-12〜07-18 | 5 | 10 | 31.0 |
| 07-19〜07-25 | **6** | **13** | 30.5 |
| 07-26〜08-01 | 5 | 10 | 38.0 |

07-19〜07-25 の週にはマクロ未分析の既存3件が含まれるため `mealCount` が13になるが、**脂質シェアは30.5%のまま**変わらない。null を0として扱う設計（分母がPFC由来kcal）が実データで確認できた。

前週比は ↓5.0pt（改善）/ 横ばい / ↑7.5pt（悪化）の3状態がすべて出た。

### 実データで見つけた不具合（2コミット目で修正）

マクロ未分析の週が「記録なし」と表示されていた。PFCは写真のAI解析経由でしか入らないので、**食事は記録されているがマクロが無い週は普通に存在する**（preview の直近3件がまさにこれ）。

- 行の見出しを `mealDays > 0` なら「PFC未分析」、0のときだけ「記録なし」に
- 補足行はマクロが無くてもカロリーと記録日数を出す（`1日 1,565kcal（記録5日）`）
- カード全体の空表示も、食事はあるがマクロが1件も無い場合は「食事の写真をAI解析するとPFCの推移が出ます」に

修正後、W2のマクロをNULLにした状態で再検証し、意図通りの表示になることを確認。**未分析の週を挟むと前週比は出ない**（比較対象が測れていないため）ことも確認した。

### その他

- 320 / 390 / 768px で横スクロールなし
- 最下部までスクロールした状態で、凡例が下部ナビに隠れないことを実測（凡例下端708px < ナビ上端786px）
- コンソールエラーは main preview 側でも同数出る `ERR_ABORTED`（ページ遷移によるリクエストキャンセル）で、本PRによる新規発生はなし
