### PR TITLE
fix: D1の100バインド上限で食事取得が落ちる問題を修正

### DIFF
--- a/packages/backend/src/lib/d1.ts
+++ b/packages/backend/src/lib/d1.ts
@@ -1,0 +1,32 @@
+/**
+ * D1 statement limits.
+ *
+ * D1 rejects any statement carrying more than 100 bound parameters with
+ * "D1_ERROR: too many SQL variables" — see
+ * https://developers.cloudflare.com/d1/platform/limits/
+ *
+ * This bites specifically on `inArray(col, ids)`, which spends ONE binding per
+ * id. Those id lists grow with the user's data (a month of meals, a date
+ * range), so the query works in development and starts failing once the user
+ * has recorded enough. Any inArray whose length is not a fixed small constant
+ * must go through chunkBindings.
+ */
+export const D1_MAX_BOUND_PARAMS = 100;
+
+/**
+ * Split `values` into chunks small enough that one statement per chunk stays
+ * within D1's binding limit, so the caller can run the query per chunk and
+ * concatenate the rows.
+ *
+ * `reserved` is the number of bindings the REST of the statement already uses
+ * (userId, date bounds, …) — those share the same budget as the inArray list.
+ * An empty input yields no chunks, which conveniently skips the query entirely.
+ */
+export function chunkBindings<T>(values: readonly T[], reserved = 0): T[][] {
+  const perChunk = Math.max(1, D1_MAX_BOUND_PARAMS - reserved);
+  const chunks: T[][] = [];
+  for (let i = 0; i < values.length; i += perChunk) {
+    chunks.push(values.slice(i, i + perChunk));
+  }
+  return chunks;
+}

--- a/packages/backend/src/services/exercise.ts
+++ b/packages/backend/src/services/exercise.ts
@@ -4,6 +4,7 @@ import type { Database } from '../db';
 import { schema } from '../db';
 import { AppError } from '../middleware/error';
 import { extractLocalDate, getWeekDateRange, nextLocalDate } from '../lib/localDate';
+import { chunkBindings } from '../lib/d1';
 import type {
   CreateExerciseInput,
   UpdateExerciseInput,
@@ -353,24 +354,43 @@ export class ExerciseService {
     // per-record computation stays in JS — but only the relevant rows are
     // fetched now. Empty/undefined exerciseTypes keeps the "all types"
     // behavior (inArray with [] would match nothing, so it's guarded).
-    const conditions = [
+    const baseConditions = [
       eq(schema.exerciseRecords.userId, userId),
       isNotNull(schema.exerciseRecords.weight),
     ];
-    if (exerciseTypes && exerciseTypes.length > 0) {
-      conditions.push(inArray(schema.exerciseRecords.exerciseType, exerciseTypes));
-    }
 
-    const filtered = await this.db
-      .select({
-        exerciseType: schema.exerciseRecords.exerciseType,
-        weight: schema.exerciseRecords.weight,
-        reps: schema.exerciseRecords.reps,
-        recordedAt: schema.exerciseRecords.recordedAt,
-      })
-      .from(schema.exerciseRecords)
-      .where(and(...conditions))
-      .all();
+    // A fresh builder per query — drizzle builders can't be reused after .where().
+    const selectRows = () =>
+      this.db
+        .select({
+          exerciseType: schema.exerciseRecords.exerciseType,
+          weight: schema.exerciseRecords.weight,
+          reps: schema.exerciseRecords.reps,
+          recordedAt: schema.exerciseRecords.recordedAt,
+        })
+        .from(schema.exerciseRecords);
+
+    // exerciseTypes comes straight from `?exerciseTypes=a,b,c`, so its length is
+    // client-controlled and unbounded. inArray spends one binding per entry and
+    // D1 caps a statement at 100 (see lib/d1.ts), so chunk it. One binding is
+    // reserved for userId (isNotNull binds nothing). The max-by-type reduction
+    // below is order-independent, so concatenating the chunks is equivalent.
+    const filtered =
+      exerciseTypes && exerciseTypes.length > 0
+        ? (
+            await Promise.all(
+              chunkBindings(exerciseTypes, 1).map((chunk) =>
+                selectRows()
+                  .where(
+                    and(...baseConditions, inArray(schema.exerciseRecords.exerciseType, chunk))
+                  )
+                  .all()
+              )
+            )
+          ).flat()
+        : await selectRows()
+            .where(and(...baseConditions))
+            .all();
 
     // Group by exercise type and find max 1RM for each
     const maxByType = new Map<string, { maxRM: number; achievedAt: string }>();

--- a/packages/backend/src/services/meal.ts
+++ b/packages/backend/src/services/meal.ts
@@ -10,6 +10,7 @@ import type {
   MealDaySummary,
 } from '@lifestyle-app/shared';
 import { extractLocalDate, nextLocalDate } from '../lib/localDate';
+import { chunkBindings } from '../lib/d1';
 
 export class MealService {
   constructor(private db: Database) {}
@@ -101,13 +102,27 @@ export class MealService {
       // Fetch only this user's meal photos, filtered and ordered in the DB so
       // the idx_meal_photos_meal (meal_id, display_order) index is used —
       // instead of scanning every user's photos and filtering/sorting in JS
-      // (#102). mealIds is guaranteed non-empty here, so inArray is safe.
-      const photoRecords = await this.db
-        .select()
-        .from(schema.mealPhotos)
-        .where(inArray(schema.mealPhotos.mealId, mealIds))
-        .orderBy(schema.mealPhotos.mealId, schema.mealPhotos.displayOrder)
-        .all();
+      // (#102).
+      //
+      // Chunked because inArray spends one bound parameter per id and D1 caps a
+      // statement at 100 (see lib/d1.ts). mealIds is as long as the requested
+      // range has meals, so a month of records blew the limit outright and made
+      // the monthly calendar and the MCP period tools fail with
+      // "too many SQL variables". Splitting is safe for the grouping below: we
+      // chunk BY mealId, so one meal's photos never straddle two chunks and the
+      // per-meal displayOrder ordering survives the concatenation.
+      const photoRecords = (
+        await Promise.all(
+          chunkBindings(mealIds).map((chunk) =>
+            this.db
+              .select()
+              .from(schema.mealPhotos)
+              .where(inArray(schema.mealPhotos.mealId, chunk))
+              .orderBy(schema.mealPhotos.mealId, schema.mealPhotos.displayOrder)
+              .all()
+          )
+        )
+      ).flat();
 
       // Group photos by mealId (rows are already restricted to these meals and
       // ordered by displayOrder within each meal).

--- a/tests/unit/d1-bind-limit.test.ts
+++ b/tests/unit/d1-bind-limit.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { chunkBindings, D1_MAX_BOUND_PARAMS } from '../../packages/backend/src/lib/d1';
+
+describe('chunkBindings', () => {
+  it('keeps every chunk within D1 bound-parameter limit', () => {
+    const chunks = chunkBindings(Array.from({ length: 250 }, (_, i) => i));
+    expect(chunks.map((c) => c.length)).toEqual([100, 100, 50]);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    }
+  });
+
+  it('preserves order and loses nothing', () => {
+    const values = Array.from({ length: 205 }, (_, i) => `id-${i}`);
+    expect(chunkBindings(values).flat()).toEqual(values);
+  });
+
+  it('leaves room for the bindings the rest of the statement uses', () => {
+    // e.g. userId + two date bounds already spent 3 of the 100.
+    const chunks = chunkBindings(Array.from({ length: 200 }, (_, i) => i), 3);
+    expect(chunks[0]!.length).toBe(97);
+    for (const chunk of chunks) {
+      expect(chunk.length + 3).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    }
+  });
+
+  it('returns no chunks for an empty list so the caller skips the query', () => {
+    expect(chunkBindings([])).toEqual([]);
+  });
+
+  it('never emits a zero-length chunk, even if reserved exceeds the limit', () => {
+    // A zero-length chunk would loop forever; degrade to one value per query.
+    const chunks = chunkBindings([1, 2, 3], D1_MAX_BOUND_PARAMS + 10);
+    expect(chunks).toEqual([[1], [2], [3]]);
+  });
+
+  it('does not split a list that already fits', () => {
+    const values = Array.from({ length: D1_MAX_BOUND_PARAMS }, (_, i) => i);
+    expect(chunkBindings(values)).toHaveLength(1);
+  });
+});

--- a/tests/unit/meal.service.test.ts
+++ b/tests/unit/meal.service.test.ts
@@ -83,6 +83,37 @@ describe('MealService', () => {
       // The photos were fetched with a WHERE clause (inArray), not a full scan.
       expect(mockDb.where).toHaveBeenCalled();
     });
+
+    it('splits the photo lookup so it stays under D1\'s 100 bound-parameter cap', async () => {
+      // Regression: inArray spends one binding per meal id, so a range with more
+      // than 100 meals produced "D1_ERROR: too many SQL variables". Production
+      // had 115 meals in 2026-01, which broke the monthly calendar outright.
+      const userId = 'user-123';
+      const now = '2026-01-15T12:00:00+09:00';
+      const meals = Array.from({ length: 115 }, (_, i) => ({
+        id: `m${i}`, userId, mealType: 'lunch', content: 'x', calories: 100,
+        recordedAt: now, createdAt: now, updatedAt: now,
+      }));
+
+      mockDb.all
+        .mockResolvedValueOnce(meals)
+        // One photo query per chunk: 115 ids => 100 + 15.
+        .mockResolvedValueOnce([{ id: 'p0', mealId: 'm0', photoKey: 'k0', displayOrder: 0 }])
+        .mockResolvedValueOnce([{ id: 'p114', mealId: 'm114', photoKey: 'k114', displayOrder: 0 }]);
+
+      const service = new MealService(mockDb as never);
+      const result = await service.findByUserId(userId, {
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+      });
+
+      // 1 meals query + 2 chunked photo queries.
+      expect(mockDb.all).toHaveBeenCalledTimes(3);
+      expect(result).toHaveLength(115);
+      // Photos from BOTH chunks land on their meals — the concatenation is not lossy.
+      expect(result.find((r) => r.id === 'm0')!.firstPhotoKey).toBe('k0');
+      expect(result.find((r) => r.id === 'm114')!.firstPhotoKey).toBe('k114');
+    });
   });
 
   describe('getCalorieSummary', () => {


### PR DESCRIPTION
## 症状

MCP の `get_nutrition_trend` を2ヶ月分で呼ぶと落ちる:

```
D1_ERROR: too many SQL variables at offset 492: SQLITE_ERROR
```

## 原因

`MealService.findByUserId` の写真取得:

```ts
.where(inArray(schema.mealPhotos.mealId, mealIds))
```

`inArray` は **meal 1件につきバインドパラメータを1つ**消費する。D1 は1文あたり **100バインドが上限**（[D1 limits](https://developers.cloudflare.com/d1/platform/limits/)）。`mealIds` の長さは「要求された期間に何食あるか」そのものなので、期間が広いと必ず超える。

**ユーザーがデータを貯めるほど壊れる**タイプで、開発時のデータ量では踏めない。#102 で N+1 を避けるため IN でまとめた際に、まとめる側の上限を見ていなかった。

## 影響範囲（MCPだけではない）

`findByUserId` の呼び出し元:

| 呼び出し元 | 期間 | 状態 |
|---|---|---|
| `MealService.getMonthlySummary`（**食事カレンダー**） | 1ヶ月 | **本番の 2026-01 は115件で既に超過** |
| `GET /api/meals?startDate&endDate` | 任意 | 広い範囲で落ちる |
| MCP `get_meals` / `get_nutrition_trend` / `get_protein_gap` | 任意 | 同上 |
| `/api/dashboard/weekly-meal-summary` | 7日 | 安全 |

本番DBの月別食事件数:

```
2026-01  115件   ← 上限超過
2026-02   90件
2026-07   76件
```

つまり**食事カレンダーで2026年1月を開くと現時点で落ちる**。v1.43.0 で日別PFCの3ドット表示を追加した、まさにその画面。

## 修正

- **`lib/d1.ts`**（新規）— `D1_MAX_BOUND_PARAMS = 100` と `chunkBindings(values, reserved)`。`reserved` は文の他の部分（userId・日付境界）が使うバインド数
- **`MealService.findByUserId`** — 写真取得をチャンク分割。**mealId で分割する**ので1つの食事の写真が2チャンクに割れることはなく、`displayOrder` 順は連結後も保たれる
- **`ExerciseService.getMaxRMs`** — `exerciseTypes` は `?exerciseTypes=a,b,c` のクライアント入力で件数に上限がないため同様に分割。max集約は順序非依存なので連結で等価

DBスキーマの変更なし（マイグレーション不要）。

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm typecheck` | 3パッケージすべて Done |
| `pnpm lint` | 0 errors |
| `pnpm exec vitest run tests/unit` | 312 passed（新規7件） |
| `pnpm find-deadcode` | 新規の未使用エクスポートなし |

追加テスト:
- `chunkBindings` — 上限を超えない / 順序と要素を失わない / `reserved` の考慮 / 空リスト / **`reserved` が上限以上でも長さ0のチャンクを出さない**（無限ループ防止）
- `findByUserId` — 115件の食事で写真クエリが 100+15 の2回に分かれ、**両チャンクの写真が正しく各食事に紐づく**こと。修正前は `all()` が2回（分割なし）なので落ちる回帰テスト

---

## プレビュー環境での実証（追記）

preview D1 に 2026-03 の食事を **120件**（>100）仕込み、**修正のない main preview** と **PR preview** に同じリクエストを投げて比較した。全preview が同一D1を共有するので、同じデータに対する新旧の直接比較になる。

| エンドポイント | main preview（修正なし） | PR #183（修正あり） |
|---|---|---|
| `GET /api/meals?startDate=2026-03-01&endDate=2026-03-31` | **HTTP 500** | **HTTP 200**（120件） |
| `GET /api/meals/dates?year=2026&month=3`（食事カレンダー） | **HTTP 500** | **HTTP 200** |

修正なし側のレスポンス:

```json
{"message":"サーバーエラーが発生しました","code":"INTERNAL_ERROR", ...}
```

### チャンクをまたいだ写真の紐づけ

120件は 100 + 20 の2チャンクに分かれる。**1チャンク目の先頭（03-01）と2チャンク目に入る末尾（03-30）**の食事にそれぞれ写真を付けて確認:

```
2026-03-01  seed183/first.webp  photoCount=1
2026-03-30  seed183/last.webp   photoCount=1
```

両チャンクの写真が正しく各食事に紐づいており、連結でロスがないことを実DBで確認した。

### カレンダーの日別集計

```json
{"date":"2026-03-01","calories":1600,"protein":80,"fat":40,"carbs":200,"mealCount":4}
{"date":"2026-03-02","calories":1600,"protein":80,"fat":40,"carbs":200,"mealCount":4}
```

検証用の 120件と写真2件は削除済み（残存0件を確認）。
