### PR TITLE
feat: PWAの縦向き固定を解除しタブレットの横向き表示を許可する

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
         theme_color: '#ef4444',
         background_color: '#ffffff',
         display: 'standalone',
-        orientation: 'portrait',
         start_url: '/',
         icons: [
           {


### PR DESCRIPTION
## 概要

PWAマニフェストの `orientation: 'portrait'` を削除し、タブレットで横向き表示を許可する。

## 変更内容

- `packages/frontend/vite.config.ts`: manifestから `orientation: 'portrait'` を削除

## 背景

タブレットでPWA起動時に縦向きが強制される問題の修正。iOSのインストール済みPWAはmanifestをキャッシュするため再追加が必要になる場合がある。